### PR TITLE
fix: Trino basic auth, Studio StarRocks poolSize, docs, and DB safety

### DIFF
--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -546,6 +546,7 @@ pub struct ClusterConfig {
 /// Authentication credentials for a backend cluster (Type 1 — service account).
 ///
 /// - `basic`: HTTP Basic auth (Trino, ClickHouse) or MySQL username+password (StarRocks).
+///   Password may be empty for backends that allow it (e.g. Trino with no auth).
 /// - `bearer`: HTTP Bearer token (Trino with JWT / OAuth2).
 /// - `keyPair`: RSA key-pair (Snowflake, Databricks — future adapters).
 /// - `accessKey`: AWS static access key (Athena and other AWS backends).

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -517,6 +517,9 @@ pub struct ClusterConfig {
     /// `maxRunningQueries` is used at runtime.
     #[serde(default)]
     pub max_running_queries: Option<u64>,
+    /// StarRocks MySQL connection pool size for QueryFlux (`poolSize` in JSON/YAML). Other engines ignore this.
+    #[serde(default)]
+    pub pool_size: Option<usize>,
     /// HTTP(S) endpoint for Trino / ClickHouse / StarRocks FE.
     pub endpoint: Option<String>,
     /// Local file path for DuckDB.

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -102,13 +102,16 @@ pub fn json_pool_size(config: &serde_json::Value) -> Option<usize> {
 
 fn json_positive_usize(v: &serde_json::Value) -> Option<usize> {
     if let Some(u) = v.as_u64() {
-        return (u >= 1).then_some(u as usize);
+        return (u >= 1).then(|| usize::try_from(u).ok()).flatten();
     }
     if let Some(i) = v.as_i64() {
-        return (i >= 1).then_some(i as usize);
+        return (i >= 1).then(|| usize::try_from(i).ok()).flatten();
     }
     let f = v.as_f64()?;
-    (f.fract() == 0.0 && f >= 1.0).then_some(f as usize)
+    if f.fract() != 0.0 || f < 1.0 || f > usize::MAX as f64 {
+        return None;
+    }
+    usize::try_from(f as u64).ok()
 }
 
 /// Build a [`ClusterConfig`] from a persisted `cluster_configs.config` JSON blob plus parsed auth.

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -82,13 +82,43 @@ pub fn json_bool(json: &serde_json::Value, key: &str) -> bool {
     json.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
 }
 
+/// Skip TLS certificate verification for HTTP clients (Trino, DuckDB HTTP, …).
+///
+/// Reads nested `tls.insecureSkipVerify` first (matches Studio / [`crate::config::TlsConfig`] JSON).
+/// If that key is absent under `tls`, falls back to legacy top-level `tlsInsecureSkipVerify`.
+pub fn json_tls_insecure_skip_verify(json: &serde_json::Value) -> bool {
+    if let Some(tls) = json.get("tls") {
+        if let Some(v) = tls.get("insecureSkipVerify") {
+            return v.as_bool().unwrap_or(false);
+        }
+    }
+    json_bool(json, "tlsInsecureSkipVerify")
+}
+
+/// Positive integer `poolSize` from JSON (Studio / persisted config), or `None` if missing/invalid.
+pub fn json_pool_size(config: &serde_json::Value) -> Option<usize> {
+    config.get("poolSize").and_then(json_positive_usize)
+}
+
+fn json_positive_usize(v: &serde_json::Value) -> Option<usize> {
+    if let Some(u) = v.as_u64() {
+        return (u >= 1).then_some(u as usize);
+    }
+    if let Some(i) = v.as_i64() {
+        return (i >= 1).then_some(i as usize);
+    }
+    let f = v.as_f64()?;
+    (f.fract() == 0.0 && f >= 1.0).then_some(f as usize)
+}
+
 /// Build a [`ClusterConfig`] from a persisted `cluster_configs.config` JSON blob plus parsed auth.
 ///
 /// Produces a minimal `ClusterConfig` containing only the fields consumed by:
 /// - Pass 2 group resolution in `main.rs` (`engine`, `enabled`, `max_running_queries`, `endpoint`)
 /// - [`BackendIdentityResolver`] (`auth`, `query_auth`)
+/// - StarRocks: `poolSize` → [`ClusterConfig::pool_size`] for YAML-compat / `from_cluster_config` builds
 ///
-/// Engine-specific fields (`databasePath`, `region`, `s3OutputLocation`, `workgroup`, `catalog`,
+/// Other engine-specific fields (`databasePath`, `region`, `s3OutputLocation`, `workgroup`, `catalog`,
 /// `tls`) are **not** extracted here — each adapter reads those directly from JSON via its own
 /// [`EngineConfigParseable::from_json`] implementation.
 pub fn cluster_config_from_persisted_json(
@@ -103,6 +133,7 @@ pub fn cluster_config_from_persisted_json(
         engine: Some(engine),
         enabled,
         max_running_queries,
+        pool_size: json_pool_size(config),
         endpoint: json_str(config, "endpoint"),
         database_path: None,
         region: None,
@@ -177,5 +208,34 @@ mod query_auth_parse_tests {
     fn parse_query_auth_invalid_is_err() {
         let blob = serde_json::json!({ "queryAuth": { "type": "notAConfiguredQueryAuth" } });
         assert!(parse_query_auth_from_config_json(&blob).is_err());
+    }
+}
+
+#[cfg(test)]
+mod tls_insecure_skip_verify_tests {
+    use super::*;
+
+    #[test]
+    fn nested_tls_wins_over_legacy() {
+        let json = serde_json::json!({
+            "tlsInsecureSkipVerify": true,
+            "tls": { "insecureSkipVerify": false }
+        });
+        assert!(!json_tls_insecure_skip_verify(&json));
+    }
+
+    #[test]
+    fn legacy_top_level_when_nested_absent() {
+        let json = serde_json::json!({ "tlsInsecureSkipVerify": true });
+        assert!(json_tls_insecure_skip_verify(&json));
+    }
+
+    #[test]
+    fn empty_tls_object_falls_back_to_legacy() {
+        let json = serde_json::json!({
+            "tls": {},
+            "tlsInsecureSkipVerify": true
+        });
+        assert!(json_tls_insecure_skip_verify(&json));
     }
 }

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -1,0 +1,181 @@
+//! JSON parsing helpers for cluster configuration JSONB blobs.
+//!
+//! These functions parse the flat-key format used by persistence:
+//! `authType`, `authUsername`, `authPassword`, `authToken` for Type 1 auth,
+//! and `queryAuth` (nested) for Type 2.
+//!
+//! Shared by all engine adapters and by `main.rs` for the `BackendIdentityResolver`.
+
+use crate::config::{ClusterAuth, ClusterConfig, EngineConfig, QueryAuthConfig};
+
+/// Extract a `ClusterAuth` from the flat DB JSON format used by persistence.
+///
+/// The JSON blob stores auth as flat keys: `authType`, `authUsername`,
+/// `authPassword`, `authToken`. This is the canonical format produced by
+/// `UpsertClusterConfig::from_core()` and stored in the `config` JSONB column.
+///
+/// - Missing / empty `authType` → `Ok(None)`.
+/// - Known `authType` with missing required fields → `Err` (so callers fail fast instead of
+///   building adapters with empty credentials).
+/// - `basic`: `authUsername` is required; `authPassword` may be empty (e.g. Trino with no password).
+pub fn parse_auth_from_config_json(
+    json: &serde_json::Value,
+) -> Result<Option<ClusterAuth>, String> {
+    let s =
+        |key: &str| -> Option<String> { json.get(key).and_then(|v| v.as_str()).map(String::from) };
+    let require = |key: &str| -> Result<String, String> {
+        s(key)
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| format!("missing or empty '{key}' for this authType"))
+    };
+    match s("authType").as_deref() {
+        None | Some("") => Ok(None),
+        Some("basic") => Ok(Some(ClusterAuth::Basic {
+            username: require("authUsername")?,
+            password: s("authPassword").unwrap_or_default(),
+        })),
+        Some("bearer") => Ok(Some(ClusterAuth::Bearer {
+            token: require("authToken")?,
+        })),
+        Some("keyPair") => Ok(Some(ClusterAuth::KeyPair {
+            username: require("authUsername")?,
+            private_key_pem: require("authPassword")?,
+            private_key_passphrase: s("authToken"),
+        })),
+        Some("accessKey") => Ok(Some(ClusterAuth::AccessKey {
+            access_key_id: require("authUsername")?,
+            secret_access_key: require("authPassword")?,
+            session_token: s("authToken"),
+        })),
+        Some("roleArn") => Ok(Some(ClusterAuth::RoleArn {
+            role_arn: require("authUsername")?,
+            external_id: s("authToken"),
+        })),
+        Some(other) => Err(format!("unsupported authType: '{other}'")),
+    }
+}
+
+/// Extract per-query auth (`queryAuth` / Type 2) from the cluster `config` JSONB blob.
+///
+/// Same JSON shape as YAML `queryAuth` on [`ClusterConfig`] (written on upsert from YAML
+/// and preserved in Postgres `cluster_configs.config`).
+///
+/// Returns [`Ok(None)`] when the field is omitted or null. A present but malformed payload
+/// yields [`Err`].
+pub fn parse_query_auth_from_config_json(
+    json: &serde_json::Value,
+) -> Result<Option<QueryAuthConfig>, serde_json::Error> {
+    match json.get("queryAuth") {
+        None => Ok(None),
+        Some(v) if v.is_null() => Ok(None),
+        Some(v) => Ok(Some(serde_json::from_value::<QueryAuthConfig>(v.clone())?)),
+    }
+}
+
+/// Extract an optional string field from a config JSON blob.
+pub fn json_str(json: &serde_json::Value, key: &str) -> Option<String> {
+    json.get(key).and_then(|v| v.as_str()).map(String::from)
+}
+
+/// Extract a boolean field from a config JSON blob (defaults to `false`).
+pub fn json_bool(json: &serde_json::Value, key: &str) -> bool {
+    json.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
+}
+
+/// Build a [`ClusterConfig`] from a persisted `cluster_configs.config` JSON blob plus parsed auth.
+///
+/// Produces a minimal `ClusterConfig` containing only the fields consumed by:
+/// - Pass 2 group resolution in `main.rs` (`engine`, `enabled`, `max_running_queries`, `endpoint`)
+/// - [`BackendIdentityResolver`] (`auth`, `query_auth`)
+///
+/// Engine-specific fields (`databasePath`, `region`, `s3OutputLocation`, `workgroup`, `catalog`,
+/// `tls`) are **not** extracted here — each adapter reads those directly from JSON via its own
+/// [`EngineConfigParseable::from_json`] implementation.
+pub fn cluster_config_from_persisted_json(
+    engine: EngineConfig,
+    enabled: bool,
+    max_running_queries: Option<u64>,
+    config: &serde_json::Value,
+    auth: Option<ClusterAuth>,
+    query_auth: Option<QueryAuthConfig>,
+) -> ClusterConfig {
+    ClusterConfig {
+        engine: Some(engine),
+        enabled,
+        max_running_queries,
+        endpoint: json_str(config, "endpoint"),
+        database_path: None,
+        region: None,
+        s3_output_location: None,
+        workgroup: None,
+        catalog: None,
+        tls: None,
+        auth,
+        query_auth,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod auth_parse_tests {
+    use super::*;
+    use crate::config::ClusterAuth;
+
+    #[test]
+    fn parse_auth_basic_allows_empty_password() {
+        let json = serde_json::json!({
+            "authType": "basic",
+            "authUsername": "admin",
+            "authPassword": "",
+        });
+        let auth = parse_auth_from_config_json(&json).unwrap().unwrap();
+        match auth {
+            ClusterAuth::Basic { username, password } => {
+                assert_eq!(username, "admin");
+                assert!(password.is_empty());
+            }
+            _ => panic!("expected Basic auth"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_basic_omitted_password_is_empty() {
+        let json = serde_json::json!({
+            "authType": "basic",
+            "authUsername": "u",
+        });
+        let auth = parse_auth_from_config_json(&json).unwrap().unwrap();
+        match auth {
+            ClusterAuth::Basic { password, .. } => assert!(password.is_empty()),
+            _ => panic!("expected Basic auth"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod query_auth_parse_tests {
+    use super::*;
+    use crate::config::QueryAuthConfig;
+
+    #[test]
+    fn parse_query_auth_impersonate() {
+        let blob = serde_json::json!({ "queryAuth": { "type": "impersonate" } });
+        let parsed = parse_query_auth_from_config_json(&blob).unwrap().unwrap();
+        assert!(matches!(parsed, QueryAuthConfig::Impersonate));
+    }
+
+    #[test]
+    fn parse_query_auth_omitted_is_none() {
+        let blob = serde_json::json!({ "endpoint": "http://t:8080" });
+        assert!(parse_query_auth_from_config_json(&blob).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_query_auth_invalid_is_err() {
+        let blob = serde_json::json!({ "queryAuth": { "type": "notAConfiguredQueryAuth" } });
+        assert!(parse_query_auth_from_config_json(&blob).is_err());
+    }
+}

--- a/crates/queryflux-core/src/engine_registry.rs
+++ b/crates/queryflux-core/src/engine_registry.rs
@@ -10,8 +10,14 @@
 
 use serde::Serialize;
 
-use crate::config::{ClusterAuth, ClusterConfig, EngineConfig, QueryAuthConfig, TlsConfig};
+use crate::config::{ClusterAuth, ClusterConfig, EngineConfig};
 use crate::query::EngineType;
+
+// Re-export JSON parsing helpers from config_json so existing call sites keep working.
+pub use crate::config_json::{
+    cluster_config_from_persisted_json, json_bool, json_str, parse_auth_from_config_json,
+    parse_query_auth_from_config_json,
+};
 
 // ---------------------------------------------------------------------------
 // Core types
@@ -240,116 +246,7 @@ pub fn validate_cluster_config(
 // ---------------------------------------------------------------------------
 // Config JSON helpers
 // ---------------------------------------------------------------------------
-
-/// Extract a `ClusterAuth` from the flat DB JSON format used by persistence.
-///
-/// The JSON blob stores auth as flat keys: `authType`, `authUsername`,
-/// `authPassword`, `authToken`. This is the canonical format produced by
-/// `UpsertClusterConfig::from_core()` and stored in the `config` JSONB column.
-///
-/// - Missing / empty `authType` → `Ok(None)`.
-/// - Known `authType` with missing required fields → `Err` (so callers fail fast instead of
-///   building adapters with empty credentials).
-pub fn parse_auth_from_config_json(
-    json: &serde_json::Value,
-) -> Result<Option<ClusterAuth>, String> {
-    let s =
-        |key: &str| -> Option<String> { json.get(key).and_then(|v| v.as_str()).map(String::from) };
-    let require = |key: &str| -> Result<String, String> {
-        s(key)
-            .filter(|v| !v.is_empty())
-            .ok_or_else(|| format!("missing or empty '{key}' for this authType"))
-    };
-    match s("authType").as_deref() {
-        None | Some("") => Ok(None),
-        Some("basic") => Ok(Some(ClusterAuth::Basic {
-            username: require("authUsername")?,
-            password: require("authPassword")?,
-        })),
-        Some("bearer") => Ok(Some(ClusterAuth::Bearer {
-            token: require("authToken")?,
-        })),
-        Some("keyPair") => Ok(Some(ClusterAuth::KeyPair {
-            username: require("authUsername")?,
-            private_key_pem: require("authPassword")?,
-            private_key_passphrase: s("authToken"),
-        })),
-        Some("accessKey") => Ok(Some(ClusterAuth::AccessKey {
-            access_key_id: require("authUsername")?,
-            secret_access_key: require("authPassword")?,
-            session_token: s("authToken"),
-        })),
-        Some("roleArn") => Ok(Some(ClusterAuth::RoleArn {
-            role_arn: require("authUsername")?,
-            external_id: s("authToken"),
-        })),
-        Some(other) => Err(format!("unsupported authType: '{other}'")),
-    }
-}
-
-/// Extract per-query auth (`queryAuth` / Type 2) from the cluster `config` JSONB blob.
-///
-/// Same JSON shape as YAML `queryAuth` on [`ClusterConfig`] (written on upsert from YAML
-/// and preserved in Postgres `cluster_configs.config`).
-///
-/// Returns [`Ok(None)`] when the field is omitted or null. A present but malformed payload
-/// yields [`Err`].
-pub fn parse_query_auth_from_config_json(
-    json: &serde_json::Value,
-) -> Result<Option<QueryAuthConfig>, serde_json::Error> {
-    match json.get("queryAuth") {
-        None => Ok(None),
-        Some(v) if v.is_null() => Ok(None),
-        Some(v) => Ok(Some(serde_json::from_value::<QueryAuthConfig>(v.clone())?)),
-    }
-}
-
-/// Build a [`ClusterConfig`] from a persisted `cluster_configs.config` JSON blob plus parsed auth.
-///
-/// Field keys match `UpsertClusterConfig::from_core` / Studio camelCase JSON.
-pub fn cluster_config_from_persisted_json(
-    engine: EngineConfig,
-    enabled: bool,
-    max_running_queries: Option<u64>,
-    config: &serde_json::Value,
-    auth: Option<ClusterAuth>,
-    query_auth: Option<QueryAuthConfig>,
-) -> ClusterConfig {
-    let tls = if json_bool(config, "tlsInsecureSkipVerify") {
-        Some(TlsConfig {
-            insecure_skip_verify: true,
-        })
-    } else {
-        config
-            .get("tls")
-            .filter(|v| !v.is_null())
-            .and_then(|v| serde_json::from_value::<TlsConfig>(v.clone()).ok())
-    };
-    ClusterConfig {
-        engine: Some(engine),
-        enabled,
-        max_running_queries,
-        endpoint: json_str(config, "endpoint"),
-        database_path: json_str(config, "databasePath"),
-        region: json_str(config, "region"),
-        s3_output_location: json_str(config, "s3OutputLocation"),
-        workgroup: json_str(config, "workgroup"),
-        catalog: json_str(config, "catalog"),
-        tls,
-        auth,
-        query_auth,
-    }
-}
-
-/// Extract an optional string field from a config JSON blob.
-pub fn json_str(json: &serde_json::Value, key: &str) -> Option<String> {
-    json.get(key).and_then(|v| v.as_str()).map(String::from)
-}
-
-/// Extract a boolean field from a config JSON blob (defaults to `false`).
-pub fn json_bool(json: &serde_json::Value, key: &str) -> bool {
-    json.get(key).and_then(|v| v.as_bool()).unwrap_or(false)
-}
+// (moved to crate::config_json — re-exported above)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -391,30 +288,5 @@ impl From<&EngineConfig> for EngineType {
             EngineConfig::ClickHouse => EngineType::ClickHouse,
             EngineConfig::Athena => EngineType::Athena,
         }
-    }
-}
-
-#[cfg(test)]
-mod query_auth_parse_tests {
-    use super::*;
-    use crate::config::QueryAuthConfig;
-
-    #[test]
-    fn parse_query_auth_impersonate() {
-        let blob = serde_json::json!({ "queryAuth": { "type": "impersonate" } });
-        let parsed = parse_query_auth_from_config_json(&blob).unwrap().unwrap();
-        assert!(matches!(parsed, QueryAuthConfig::Impersonate));
-    }
-
-    #[test]
-    fn parse_query_auth_omitted_is_none() {
-        let blob = serde_json::json!({ "endpoint": "http://t:8080" });
-        assert!(parse_query_auth_from_config_json(&blob).unwrap().is_none());
-    }
-
-    #[test]
-    fn parse_query_auth_invalid_is_err() {
-        let blob = serde_json::json!({ "queryAuth": { "type": "notAConfiguredQueryAuth" } });
-        assert!(parse_query_auth_from_config_json(&blob).is_err());
     }
 }

--- a/crates/queryflux-core/src/engine_registry.rs
+++ b/crates/queryflux-core/src/engine_registry.rs
@@ -15,8 +15,8 @@ use crate::query::EngineType;
 
 // Re-export JSON parsing helpers from config_json so existing call sites keep working.
 pub use crate::config_json::{
-    cluster_config_from_persisted_json, json_bool, json_str, parse_auth_from_config_json,
-    parse_query_auth_from_config_json,
+    cluster_config_from_persisted_json, json_bool, json_pool_size, json_str,
+    json_tls_insecure_skip_verify, parse_auth_from_config_json, parse_query_auth_from_config_json,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/queryflux-core/src/lib.rs
+++ b/crates/queryflux-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod config;
+pub mod config_json;
 pub mod engine_registry;
 pub mod error;
 pub mod query;

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -106,9 +106,11 @@ impl TestHarness {
             let adapter = Arc::new(TrinoAdapter::new(
                 cluster.clone(),
                 group.clone(),
-                trino_url,
-                false,
-                None,
+                queryflux_engine_adapters::trino::TrinoConfig {
+                    endpoint: trino_url,
+                    tls_skip_verify: false,
+                    auth: None,
+                },
             )) as Arc<dyn EngineAdapterTrait>;
 
             group_states.insert(group.clone(), (vec![state], strategy_from_config(None)));
@@ -137,8 +139,16 @@ impl TestHarness {
                 true,
             ));
             let adapter = Arc::new(
-                StarRocksAdapter::new(cluster.clone(), group.clone(), sr_url, None)
-                    .map_err(|e| anyhow!("StarRocks adapter: {e}"))?,
+                StarRocksAdapter::new(
+                    cluster.clone(),
+                    group.clone(),
+                    queryflux_engine_adapters::starrocks::StarRocksConfig {
+                        endpoint: sr_url,
+                        auth: None,
+                        pool_size: 2,
+                    },
+                )
+                .map_err(|e| anyhow!("StarRocks adapter: {e}"))?,
             );
 
             group_states.insert(group.clone(), (vec![state], strategy_from_config(None)));

--- a/crates/queryflux-engine-adapters/src/athena/mod.rs
+++ b/crates/queryflux-engine-adapters/src/athena/mod.rs
@@ -83,12 +83,23 @@ impl crate::EngineConfigParseable for AthenaConfig {
                 "cluster '{cluster_name}': missing 's3OutputLocation' for Athena"
             ))
         })?;
+        let auth = match cfg.auth.clone() {
+            Some(a @ ClusterAuth::AccessKey { .. }) | Some(a @ ClusterAuth::RoleArn { .. }) => {
+                Some(a)
+            }
+            Some(_) => {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': Athena only supports accessKey or roleArn auth"
+                )));
+            }
+            None => None,
+        };
         Ok(Self {
             region,
             s3_output_location,
             workgroup: cfg.workgroup.clone(),
             catalog: cfg.catalog.clone(),
-            auth: cfg.auth.clone(),
+            auth,
         })
     }
 }

--- a/crates/queryflux-engine-adapters/src/athena/mod.rs
+++ b/crates/queryflux-engine-adapters/src/athena/mod.rs
@@ -25,6 +25,74 @@ use tracing::warn;
 
 use crate::EngineAdapterTrait;
 
+/// Parsed and validated configuration for an Athena cluster.
+pub struct AthenaConfig {
+    pub region: String,
+    pub s3_output_location: String,
+    pub workgroup: Option<String>,
+    pub catalog: Option<String>,
+    pub auth: Option<ClusterAuth>,
+}
+
+impl crate::EngineConfigParseable for AthenaConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<Self> {
+        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
+        let region = json_str(json, "region").ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing 'region' for Athena"
+            ))
+        })?;
+        let s3_output_location = json_str(json, "s3OutputLocation").ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing 's3OutputLocation' for Athena"
+            ))
+        })?;
+        let raw_auth = parse_auth_from_config_json(json).map_err(|e| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': invalid auth ({e})"
+            ))
+        })?;
+        let auth = match raw_auth {
+            Some(a @ ClusterAuth::AccessKey { .. }) | Some(a @ ClusterAuth::RoleArn { .. }) => {
+                Some(a)
+            }
+            Some(_) => {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': Athena only supports accessKey or roleArn auth"
+                )));
+            }
+            None => None,
+        };
+        Ok(Self {
+            region,
+            s3_output_location,
+            workgroup: json_str(json, "workgroup"),
+            catalog: json_str(json, "catalog"),
+            auth,
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> crate::Result<Self> {
+        let region = cfg.region.clone().ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing 'region' for Athena"
+            ))
+        })?;
+        let s3_output_location = cfg.s3_output_location.clone().ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing 's3OutputLocation' for Athena"
+            ))
+        })?;
+        Ok(Self {
+            region,
+            s3_output_location,
+            workgroup: cfg.workgroup.clone(),
+            catalog: cfg.catalog.clone(),
+            auth: cfg.auth.clone(),
+        })
+    }
+}
+
 /// Walk the `std::error::Error` source chain and join all messages with ": ".
 /// AWS SDK errors expose the real Athena message (e.g. "InvalidRequestException:
 /// Query string is null or empty") only via the source chain; `Display` on the
@@ -72,19 +140,15 @@ impl AthenaAdapter {
     pub async fn new(
         cluster_name: ClusterName,
         group_name: ClusterGroupName,
-        region: String,
-        s3_output_location: String,
-        workgroup: Option<String>,
-        catalog: Option<String>,
-        auth: Option<ClusterAuth>,
+        config: AthenaConfig,
     ) -> Result<Self> {
         use aws_config::BehaviorVersion;
         use aws_credential_types::Credentials;
         use aws_types::region::Region;
 
-        let aws_region = Region::new(region.clone());
+        let aws_region = Region::new(config.region.clone());
 
-        let sdk_config = match auth {
+        let sdk_config = match config.auth {
             Some(ClusterAuth::AccessKey {
                 access_key_id,
                 secret_access_key,
@@ -162,94 +226,12 @@ impl AthenaAdapter {
             cluster_name,
             group_name,
             client,
-            region,
-            s3_output_location,
-            workgroup: workgroup.unwrap_or_else(|| "primary".to_string()),
-            catalog: catalog.unwrap_or_else(|| "AwsDataCatalog".to_string()),
-        })
-    }
-
-    /// Build from a DB config JSON blob (bypasses the `ClusterConfig` god struct).
-    pub async fn try_from_config_json(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        json: &serde_json::Value,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
-
-        let region = json_str(json, "region").ok_or_else(|| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': missing 'region' for Athena"
-            ))
-        })?;
-        let s3_output = json_str(json, "s3OutputLocation").ok_or_else(|| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': missing 's3OutputLocation' for Athena"
-            ))
-        })?;
-        let auth = parse_auth_from_config_json(json).map_err(|e| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': invalid auth ({e})"))
-        })?;
-        let auth = match auth {
-            Some(a @ ClusterAuth::AccessKey { .. }) | Some(a @ ClusterAuth::RoleArn { .. }) => {
-                Some(a)
-            }
-            Some(_) => {
-                return Err(QueryFluxError::Engine(format!(
-                    "cluster '{cluster_name_str}': Athena only supports accessKey or roleArn auth"
-                )));
-            }
-            None => None,
-        };
-        Self::new(
-            cluster_name,
-            group_name,
-            region,
-            s3_output,
-            json_str(json, "workgroup"),
-            json_str(json, "catalog"),
-            auth,
-        )
-        .await
-        .map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': failed to create Athena adapter ({e})"
-            ))
-        })
-    }
-
-    /// Build from persisted / YAML [`ClusterConfig`].
-    pub async fn try_from_cluster_config(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        cfg: &ClusterConfig,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        let region = cfg.region.clone().ok_or_else(|| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': missing 'region' for Athena"
-            ))
-        })?;
-        let s3_output = cfg.s3_output_location.clone().ok_or_else(|| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': missing 's3OutputLocation' for Athena"
-            ))
-        })?;
-        Self::new(
-            cluster_name,
-            group_name,
-            region,
-            s3_output,
-            cfg.workgroup.clone(),
-            cfg.catalog.clone(),
-            cfg.auth.clone(),
-        )
-        .await
-        .map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': failed to create Athena adapter ({e})"
-            ))
+            region: config.region,
+            s3_output_location: config.s3_output_location,
+            workgroup: config.workgroup.unwrap_or_else(|| "primary".to_string()),
+            catalog: config
+                .catalog
+                .unwrap_or_else(|| "AwsDataCatalog".to_string()),
         })
     }
 
@@ -798,9 +780,11 @@ impl crate::EngineAdapterFactory for AthenaFactory {
         group: ClusterGroupName,
         json: &serde_json::Value,
     ) -> Result<Arc<dyn crate::EngineAdapterTrait>> {
+        use crate::EngineConfigParseable;
         let name = cluster_name.0.clone();
+        let config = AthenaConfig::from_json(json, &name)?;
         Ok(Arc::new(
-            AthenaAdapter::try_from_config_json(cluster_name, group, json, name.as_str()).await?,
+            AthenaAdapter::new(cluster_name, group, config).await?,
         ))
     }
 }

--- a/crates/queryflux-engine-adapters/src/duckdb/http.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/http.rs
@@ -36,13 +36,15 @@ pub struct DuckDbHttpConfig {
 impl crate::EngineConfigParseable for DuckDbHttpConfig {
     fn from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<Self> {
         use queryflux_core::config::ClusterAuth;
-        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
+        use queryflux_core::engine_registry::{
+            json_str, json_tls_insecure_skip_verify, parse_auth_from_config_json,
+        };
         let endpoint = json_str(json, "endpoint").ok_or_else(|| {
             queryflux_core::error::QueryFluxError::Engine(format!(
                 "cluster '{cluster_name}': missing endpoint"
             ))
         })?;
-        let tls_skip_verify = json_bool(json, "tlsInsecureSkipVerify");
+        let tls_skip_verify = json_tls_insecure_skip_verify(json);
         let auth = parse_auth_from_config_json(json).map_err(|e| {
             queryflux_core::error::QueryFluxError::Engine(format!(
                 "cluster '{cluster_name}': invalid auth ({e})"

--- a/crates/queryflux-engine-adapters/src/duckdb/http.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/http.rs
@@ -73,10 +73,19 @@ impl crate::EngineConfigParseable for DuckDbHttpConfig {
             .as_ref()
             .map(|t| t.insecure_skip_verify)
             .unwrap_or(false);
+        use queryflux_core::config::ClusterAuth;
+        let auth = cfg.auth.clone();
+        if let Some(ref a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. } | ClusterAuth::Bearer { .. }) {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': DuckDB HTTP supports only basic or bearer auth"
+                )));
+            }
+        }
         Ok(Self {
             endpoint,
             tls_skip_verify,
-            auth: cfg.auth.clone(),
+            auth,
         })
     }
 }

--- a/crates/queryflux-engine-adapters/src/duckdb/http.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/http.rs
@@ -26,6 +26,61 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Parsed and validated configuration for a DuckDB HTTP cluster.
+pub struct DuckDbHttpConfig {
+    pub endpoint: String,
+    pub tls_skip_verify: bool,
+    pub auth: Option<queryflux_core::config::ClusterAuth>,
+}
+
+impl crate::EngineConfigParseable for DuckDbHttpConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<Self> {
+        use queryflux_core::config::ClusterAuth;
+        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
+        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing endpoint"
+            ))
+        })?;
+        let tls_skip_verify = json_bool(json, "tlsInsecureSkipVerify");
+        let auth = parse_auth_from_config_json(json).map_err(|e| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': invalid auth ({e})"
+            ))
+        })?;
+        if let Some(ref a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. } | ClusterAuth::Bearer { .. }) {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': DuckDB HTTP supports only basic or bearer auth"
+                )));
+            }
+        }
+        Ok(Self {
+            endpoint,
+            tls_skip_verify,
+            auth,
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> crate::Result<Self> {
+        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing endpoint"
+            ))
+        })?;
+        let tls_skip_verify = cfg
+            .tls
+            .as_ref()
+            .map(|t| t.insecure_skip_verify)
+            .unwrap_or(false);
+        Ok(Self {
+            endpoint,
+            tls_skip_verify,
+            auth: cfg.auth.clone(),
+        })
+    }
+}
+
 /// DuckDB remote HTTP server adapter.
 ///
 /// Targets the DuckDB community `httpserver` extension API:
@@ -88,18 +143,16 @@ impl DuckDbHttpAdapter {
     pub fn new(
         cluster_name: ClusterName,
         group_name: ClusterGroupName,
-        endpoint: String,
-        tls_skip: bool,
-        auth: Option<queryflux_core::config::ClusterAuth>,
+        config: DuckDbHttpConfig,
     ) -> Result<Self> {
         let mut builder = Client::builder().timeout(std::time::Duration::from_secs(120));
 
-        if tls_skip {
+        if config.tls_skip_verify {
             builder = builder.danger_accept_invalid_certs(true);
         }
 
         // Apply default authorization header if configured.
-        if let Some(auth) = auth {
+        if let Some(auth) = config.auth {
             use queryflux_core::config::ClusterAuth;
             let mut headers = reqwest::header::HeaderMap::new();
             match auth {
@@ -131,72 +184,12 @@ impl DuckDbHttpAdapter {
             .build()
             .map_err(|e| QueryFluxError::Engine(format!("Failed to build HTTP client: {e}")))?;
 
-        let endpoint = endpoint.trim_end_matches('/').to_string();
+        let endpoint = config.endpoint.trim_end_matches('/').to_string();
         Ok(Self {
             cluster_name,
             group_name,
             endpoint,
             client,
-        })
-    }
-
-    /// Build from a DB config JSON blob (bypasses the `ClusterConfig` god struct).
-    pub fn try_from_config_json(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        json: &serde_json::Value,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
-
-        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        let tls_skip = json_bool(json, "tlsInsecureSkipVerify");
-        let auth = parse_auth_from_config_json(json).map_err(|e| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': invalid auth ({e})"))
-        })?;
-        if let Some(ref a) = auth {
-            use queryflux_core::config::ClusterAuth;
-            if !matches!(a, ClusterAuth::Basic { .. } | ClusterAuth::Bearer { .. }) {
-                return Err(QueryFluxError::Engine(format!(
-                    "cluster '{cluster_name_str}': DuckDB HTTP supports only basic or bearer auth"
-                )));
-            }
-        }
-        Self::new(cluster_name, group_name, endpoint, tls_skip, auth).map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': failed to create DuckDB HTTP adapter ({e})"
-            ))
-        })
-    }
-
-    /// Build from persisted / YAML [`ClusterConfig`].
-    pub fn try_from_cluster_config(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        cfg: &ClusterConfig,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        let tls_skip = cfg
-            .tls
-            .as_ref()
-            .map(|t| t.insecure_skip_verify)
-            .unwrap_or(false);
-        Self::new(
-            cluster_name,
-            group_name,
-            endpoint,
-            tls_skip,
-            cfg.auth.clone(),
-        )
-        .map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': failed to create DuckDB HTTP adapter ({e})"
-            ))
         })
     }
 
@@ -596,12 +589,13 @@ impl crate::EngineAdapterFactory for DuckDbHttpFactory {
         group: ClusterGroupName,
         json: &serde_json::Value,
     ) -> Result<Arc<dyn crate::EngineAdapterTrait>> {
+        use crate::EngineConfigParseable;
         let name = cluster_name.0.clone();
-        Ok(Arc::new(DuckDbHttpAdapter::try_from_config_json(
+        let config = DuckDbHttpConfig::from_json(json, &name)?;
+        Ok(Arc::new(DuckDbHttpAdapter::new(
             cluster_name,
             group,
-            json,
-            name.as_str(),
+            config,
         )?))
     }
 }

--- a/crates/queryflux-engine-adapters/src/duckdb/mod.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/mod.rs
@@ -37,27 +37,31 @@ impl crate::EngineConfigParseable for DuckDbConfig {
                 "cluster '{cluster_name}': invalid auth ({e})"
             ))
         })?;
-        let motherduck_token = auth.and_then(|a| {
-            if let ClusterAuth::Bearer { token } = a {
-                Some(token)
-            } else {
-                None
+        let motherduck_token = match auth {
+            None => None,
+            Some(ClusterAuth::Bearer { token }) => Some(token),
+            Some(_) => {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': DuckDB supports only bearer auth (Motherduck token)"
+                )));
             }
-        });
+        };
         Ok(Self {
             database_path,
             motherduck_token,
         })
     }
 
-    fn from_cluster_config(cfg: &ClusterConfig, _cluster_name: &str) -> crate::Result<Self> {
-        let motherduck_token = cfg.auth.as_ref().and_then(|a| {
-            if let ClusterAuth::Bearer { token } = a {
-                Some(token.clone())
-            } else {
-                None
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> crate::Result<Self> {
+        let motherduck_token = match cfg.auth.clone() {
+            None => None,
+            Some(ClusterAuth::Bearer { token }) => Some(token),
+            Some(_) => {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': DuckDB supports only bearer auth (Motherduck token)"
+                )));
             }
-        });
+        };
         Ok(Self {
             database_path: cfg.database_path.clone(),
             motherduck_token,

--- a/crates/queryflux-engine-adapters/src/duckdb/mod.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/mod.rs
@@ -22,6 +22,49 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Parsed and validated configuration for a DuckDB cluster.
+pub struct DuckDbConfig {
+    pub database_path: Option<String>,
+    pub motherduck_token: Option<String>,
+}
+
+impl crate::EngineConfigParseable for DuckDbConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<Self> {
+        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
+        let database_path = json_str(json, "databasePath");
+        let auth = parse_auth_from_config_json(json).map_err(|e| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': invalid auth ({e})"
+            ))
+        })?;
+        let motherduck_token = auth.and_then(|a| {
+            if let ClusterAuth::Bearer { token } = a {
+                Some(token)
+            } else {
+                None
+            }
+        });
+        Ok(Self {
+            database_path,
+            motherduck_token,
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, _cluster_name: &str) -> crate::Result<Self> {
+        let motherduck_token = cfg.auth.as_ref().and_then(|a| {
+            if let ClusterAuth::Bearer { token } = a {
+                Some(token.clone())
+            } else {
+                None
+            }
+        });
+        Ok(Self {
+            database_path: cfg.database_path.clone(),
+            motherduck_token,
+        })
+    }
+}
+
 /// DuckDB embedded engine adapter.
 ///
 /// DuckDB is Arrow-native and runs in-process. All query execution goes through
@@ -38,22 +81,9 @@ impl DuckDbAdapter {
     pub fn new(
         cluster_name: ClusterName,
         group_name: ClusterGroupName,
-        database_path: Option<String>,
+        config: DuckDbConfig,
     ) -> Result<Self> {
-        Self::new_with_token(cluster_name, group_name, database_path, None)
-    }
-
-    /// Create a new DuckDB adapter, optionally injecting a MotherDuck token.
-    ///
-    /// When `database_path` starts with `"md:"` and `motherduck_token` is provided,
-    /// the token is appended to the connection string as a query parameter.
-    pub fn new_with_token(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        database_path: Option<String>,
-        motherduck_token: Option<String>,
-    ) -> Result<Self> {
-        let resolved_path = build_connection_string(database_path, motherduck_token);
+        let resolved_path = build_connection_string(config.database_path, config.motherduck_token);
         let conn = match resolved_path.as_deref() {
             Some(path) => Connection::open(path),
             None => Connection::open_in_memory(),
@@ -64,62 +94,6 @@ impl DuckDbAdapter {
             cluster_name,
             group_name,
             conn: Arc::new(Mutex::new(conn)),
-        })
-    }
-
-    /// Build from a DB config JSON blob (bypasses the `ClusterConfig` god struct).
-    pub fn try_from_config_json(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        json: &serde_json::Value,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
-
-        let database_path = json_str(json, "databasePath");
-        let auth = parse_auth_from_config_json(json).map_err(|e| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': invalid auth ({e})"))
-        })?;
-        let motherduck_token = auth.and_then(|a| {
-            if let ClusterAuth::Bearer { token } = a {
-                Some(token)
-            } else {
-                None
-            }
-        });
-        Self::new_with_token(cluster_name, group_name, database_path, motherduck_token).map_err(
-            |e| {
-                QueryFluxError::Engine(format!(
-                    "cluster '{cluster_name_str}': failed to open DuckDB ({e})"
-                ))
-            },
-        )
-    }
-
-    /// Build from persisted / YAML [`ClusterConfig`] (embedded path + optional MotherDuck bearer).
-    pub fn try_from_cluster_config(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        cfg: &ClusterConfig,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        let motherduck_token = cfg.auth.as_ref().and_then(|a| {
-            if let ClusterAuth::Bearer { token } = a {
-                Some(token.clone())
-            } else {
-                None
-            }
-        });
-        Self::new_with_token(
-            cluster_name,
-            group_name,
-            cfg.database_path.clone(),
-            motherduck_token,
-        )
-        .map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{cluster_name_str}': failed to open DuckDB ({e})"
-            ))
         })
     }
 }
@@ -448,12 +422,9 @@ impl crate::EngineAdapterFactory for DuckDbFactory {
         group: ClusterGroupName,
         json: &serde_json::Value,
     ) -> Result<Arc<dyn crate::EngineAdapterTrait>> {
+        use crate::EngineConfigParseable;
         let name = cluster_name.0.clone();
-        Ok(Arc::new(DuckDbAdapter::try_from_config_json(
-            cluster_name,
-            group,
-            json,
-            name.as_str(),
-        )?))
+        let config = DuckDbConfig::from_json(json, &name)?;
+        Ok(Arc::new(DuckDbAdapter::new(cluster_name, group, config)?))
     }
 }

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -12,6 +12,7 @@ use futures::Stream;
 use queryflux_auth::QueryCredentials;
 use queryflux_core::{
     catalog::TableSchema,
+    config::ClusterConfig,
     engine_registry::EngineDescriptor,
     error::{QueryFluxError, Result},
     query::{
@@ -20,6 +21,18 @@ use queryflux_core::{
     session::SessionContext,
     tags::QueryTags,
 };
+
+/// Implemented by each engine's typed config struct.
+///
+/// Parsing succeeds only when all required fields are present and valid for that engine —
+/// construction IS validation. Engine-specific constraints (required fields, allowed auth types)
+/// live here rather than in core.
+pub trait EngineConfigParseable: Sized {
+    /// Parse and validate from a DB config JSON blob.
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> Result<Self>;
+    /// Parse and validate from a YAML-loaded [`ClusterConfig`].
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> Result<Self>;
+}
 
 /// A stream of Arrow RecordBatches — the universal output type for all adapters.
 pub type ArrowStream = Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>;

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -708,7 +708,7 @@ impl StarRocksAdapter {
                 ConfigField {
                     key: "poolSize",
                     label: "Connection pool size",
-                    description: "Max concurrent MySQL connections for QueryFlux (default 8). Independent of max running queries on the engine.",
+                    description: "Max concurrent MySQL connections QueryFlux opens to StarRocks. Defaults to 8 when poolSize is omitted in JSON/Studio. Typed cluster/YAML paths without this field also use 8; pool size is not derived from max_running_queries.",
                     field_type: FieldType::Number,
                     required: false,
                     example: Some("8"),

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -29,6 +29,39 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Default MySQL connection pool size for StarRocks (YAML / cluster API without `poolSize` in JSON).
+/// Independent of `max_running_queries`: not all load goes through QueryFlux.
+const DEFAULT_STARROCKS_POOL_SIZE: usize = 8;
+
+fn parse_pool_size_from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<usize> {
+    match json.get("poolSize") {
+        None => Ok(DEFAULT_STARROCKS_POOL_SIZE),
+        Some(v) => {
+            let n = parse_positive_json_integer(v).ok_or_else(|| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': poolSize must be a positive integer"
+                ))
+            })?;
+            usize::try_from(n).map_err(|_| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': poolSize is too large for this platform"
+                ))
+            })
+        }
+    }
+}
+
+fn parse_positive_json_integer(v: &serde_json::Value) -> Option<u64> {
+    if let Some(u) = v.as_u64() {
+        return (u >= 1).then_some(u);
+    }
+    if let Some(i) = v.as_i64() {
+        return (i >= 1).then_some(i as u64);
+    }
+    let f = v.as_f64()?;
+    (f.fract() == 0.0 && f >= 1.0).then_some(f as u64)
+}
+
 /// Parsed and validated configuration for a StarRocks cluster.
 pub struct StarRocksConfig {
     pub endpoint: String,
@@ -56,11 +89,7 @@ impl crate::EngineConfigParseable for StarRocksConfig {
                 )));
             }
         }
-        let pool_size = json
-            .get("poolSize")
-            .and_then(|v| v.as_u64())
-            .map(|n| n as usize)
-            .unwrap_or(8);
+        let pool_size = parse_pool_size_from_json(json, cluster_name)?;
         Ok(Self {
             endpoint,
             auth,
@@ -84,7 +113,7 @@ impl crate::EngineConfigParseable for StarRocksConfig {
         Ok(Self {
             endpoint,
             auth: cfg.auth.clone(),
-            pool_size: cfg.max_running_queries.map(|n| n as usize).unwrap_or(8),
+            pool_size: DEFAULT_STARROCKS_POOL_SIZE,
         })
     }
 }
@@ -98,10 +127,15 @@ impl crate::EngineConfigParseable for StarRocksConfig {
 ///   `mysql://root:password@sr-fe-host:9030`
 ///
 /// Alternatively, omit credentials from the URL and supply them via `auth: basic`.
+///
+/// The query pool uses lazy connections: `mysql_async` opens connections on demand up to
+/// the configured max; setting min == max only caps the upper bound, not eager opens.
 pub struct StarRocksAdapter {
     pub cluster_name: ClusterName,
     pub group_name: ClusterGroupName,
     pool: Pool,
+    /// Dedicated 1×1 pool for `health_check` so probes do not compete with query traffic.
+    control_pool: Pool,
     endpoint: String,
 }
 
@@ -111,42 +145,51 @@ impl StarRocksAdapter {
         group_name: ClusterGroupName,
         config: StarRocksConfig,
     ) -> Result<Self> {
-        let base_opts = Opts::from_url(&config.endpoint).map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{}': StarRocks invalid endpoint URL: {e}",
-                cluster_name.0
-            ))
-        })?;
+        let make_builder = || -> Result<OptsBuilder> {
+            // Always disable Unix socket preference — StarRocks doesn't support the
+            // `@@socket` system variable that mysql_async queries when prefer_socket=true.
+            let base_opts = Opts::from_url(&config.endpoint).map_err(|e| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': StarRocks invalid endpoint URL: {e}",
+                    cluster_name.0
+                ))
+            })?;
+            let mut b = OptsBuilder::from_opts(base_opts).prefer_socket(false);
+            if let Some(ClusterAuth::Basic { username, password }) = &config.auth {
+                b = b.user(Some(username.clone())).pass(Some(password.clone()));
+            }
+            Ok(b)
+        };
 
-        // Always disable Unix socket preference — StarRocks doesn't support the
-        // `@@socket` system variable that mysql_async queries when prefer_socket=true.
-        let mut builder = OptsBuilder::from_opts(base_opts).prefer_socket(false);
+        let pool_opts_for = |size: usize| -> Result<PoolOpts> {
+            let size = size.max(1);
+            let constraints = PoolConstraints::new(size, size).ok_or_else(|| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': invalid StarRocks pool size",
+                    cluster_name.0
+                ))
+            })?;
+            Ok(PoolOpts::default()
+                .with_constraints(constraints)
+                .with_abs_conn_ttl(Some(Duration::from_secs(1800))))
+        };
 
-        // Override credentials from the explicit auth block if provided.
-        if let Some(ClusterAuth::Basic { username, password }) = config.auth {
-            builder = builder.user(Some(username)).pass(Some(password));
-        }
+        let main_builder = make_builder()?;
+        let main_opts = Opts::from(
+            main_builder
+                .clone()
+                .pool_opts(pool_opts_for(config.pool_size)?),
+        );
+        let pool = Pool::new(main_opts);
 
-        // Build a persistent connection pool. min == max so the pool always holds
-        // exactly `pool_size` connections — no idle eviction below that floor.
-        // COM_RESET_CONNECTION is sent on return (default) so every checkout gets a clean
-        // slate — no leftover USE db / SET vars from a previous caller (execute_as_arrow,
-        // execute_ddl, catalog ops) can bleed through.
-        let pool_size = config.pool_size.max(1);
-        let constraints = PoolConstraints::new(pool_size, pool_size)
-            .expect("pool_size >= 1 guarantees valid constraints");
-        let pool_opts = PoolOpts::default()
-            .with_constraints(constraints)
-            // Recycle connections older than 30 min on return to avoid using stale TCP sessions
-            // that may have been silently dropped by firewalls or StarRocks FE restarts.
-            .with_abs_conn_ttl(Some(Duration::from_secs(1800)));
-        let opts = Opts::from(builder.pool_opts(pool_opts));
-        let pool = Pool::new(opts);
+        let control_opts = Opts::from(make_builder()?.pool_opts(pool_opts_for(1)?));
+        let control_pool = Pool::new(control_opts);
 
         Ok(Self {
             cluster_name,
             group_name,
             pool,
+            control_pool,
             endpoint: config.endpoint,
         })
     }
@@ -167,6 +210,19 @@ impl StarRocksAdapter {
                 QueryFluxError::Engine("StarRocks pool checkout timed out (10s)".to_string())
             })?
             .map_err(|e| QueryFluxError::Engine(format!("StarRocks pool get_conn failed: {e}")))
+    }
+
+    async fn acquire_control_conn(&self) -> Result<Conn> {
+        tokio::time::timeout(Duration::from_secs(10), self.control_pool.get_conn())
+            .await
+            .map_err(|_| {
+                QueryFluxError::Engine(
+                    "StarRocks control pool checkout timed out (10s)".to_string(),
+                )
+            })?
+            .map_err(|e| {
+                QueryFluxError::Engine(format!("StarRocks control pool get_conn failed: {e}"))
+            })
     }
 
     async fn run_query(&self, sql: &str) -> Result<Vec<Row>> {
@@ -221,7 +277,7 @@ impl EngineAdapterTrait for StarRocksAdapter {
 
     async fn health_check(&self) -> bool {
         use mysql_async::prelude::Queryable;
-        match self.acquire_conn().await {
+        match self.acquire_control_conn().await {
             Ok(mut conn) => match conn.ping().await {
                 Ok(_) => true,
                 Err(e) => {
@@ -242,6 +298,21 @@ impl EngineAdapterTrait for StarRocksAdapter {
                 false
             }
         }
+    }
+
+    async fn fetch_running_query_count(&self) -> Option<u64> {
+        // Query the FE's processlist for all actively executing queries — not just the ones
+        // routed through QueryFlux. This gives a true picture of StarRocks load and prevents
+        // the reconciler from overcorrecting when the engine is busy with external traffic.
+        let rows = self
+            .run_query(
+                "SELECT COUNT(*) FROM information_schema.processlist WHERE COMMAND = 'Query'",
+            )
+            .await
+            .ok()?;
+        rows.into_iter()
+            .next()
+            .and_then(|mut row| row.take::<u64, usize>(0))
     }
 
     fn engine_type(&self) -> EngineType {
@@ -637,7 +708,7 @@ impl StarRocksAdapter {
                 ConfigField {
                     key: "poolSize",
                     label: "Connection pool size",
-                    description: "Number of persistent MySQL connections to keep open. Defaults to max_running_queries (8) when omitted.",
+                    description: "Max concurrent MySQL connections for QueryFlux (default 8). Independent of max running queries on the engine.",
                     field_type: FieldType::Number,
                     required: false,
                     example: Some("8"),

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -29,7 +29,7 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
-/// Default MySQL connection pool size for StarRocks (YAML / cluster API without `poolSize` in JSON).
+/// Default MySQL connection pool size for StarRocks when [`ClusterConfig::pool_size`] / JSON `poolSize` is omitted.
 /// Independent of `max_running_queries`: not all load goes through QueryFlux.
 const DEFAULT_STARROCKS_POOL_SIZE: usize = 8;
 
@@ -113,7 +113,7 @@ impl crate::EngineConfigParseable for StarRocksConfig {
         Ok(Self {
             endpoint,
             auth: cfg.auth.clone(),
-            pool_size: DEFAULT_STARROCKS_POOL_SIZE,
+            pool_size: cfg.pool_size.unwrap_or(DEFAULT_STARROCKS_POOL_SIZE).max(1),
         })
     }
 }
@@ -708,7 +708,7 @@ impl StarRocksAdapter {
                 ConfigField {
                     key: "poolSize",
                     label: "Connection pool size",
-                    description: "Max concurrent MySQL connections QueryFlux opens to StarRocks. Defaults to 8 when poolSize is omitted in JSON/Studio. Typed cluster/YAML paths without this field also use 8; pool size is not derived from max_running_queries.",
+                    description: "Max concurrent MySQL connections QueryFlux opens to StarRocks. Defaults to 8 when poolSize is omitted in JSON or in typed cluster/YAML config; set poolSize to override. Not derived from max_running_queries.",
                     field_type: FieldType::Number,
                     required: false,
                     example: Some("8"),

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -9,7 +9,10 @@ use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use futures::stream;
-use mysql_async::{consts::ColumnType, prelude::Queryable, Conn, Opts, OptsBuilder, Row, Value};
+use mysql_async::{
+    consts::ColumnType, prelude::Queryable, Conn, Opts, OptsBuilder, Pool, PoolConstraints,
+    PoolOpts, Row, Value,
+};
 use queryflux_core::{
     catalog::TableSchema,
     config::{ClusterAuth, ClusterConfig},
@@ -26,6 +29,66 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Parsed and validated configuration for a StarRocks cluster.
+pub struct StarRocksConfig {
+    pub endpoint: String,
+    pub auth: Option<ClusterAuth>,
+    pub pool_size: usize,
+}
+
+impl crate::EngineConfigParseable for StarRocksConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> crate::Result<Self> {
+        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
+        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing endpoint"
+            ))
+        })?;
+        let auth = parse_auth_from_config_json(json).map_err(|e| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': invalid auth ({e})"
+            ))
+        })?;
+        if let Some(ref a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. }) {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': StarRocks only supports basic auth (MySQL username/password)"
+                )));
+            }
+        }
+        let pool_size = json
+            .get("poolSize")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize)
+            .unwrap_or(8);
+        Ok(Self {
+            endpoint,
+            auth,
+            pool_size,
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> crate::Result<Self> {
+        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
+            queryflux_core::error::QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': missing endpoint"
+            ))
+        })?;
+        if let Some(ref a) = cfg.auth {
+            if !matches!(a, ClusterAuth::Basic { .. }) {
+                return Err(queryflux_core::error::QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': StarRocks only supports basic auth (MySQL username/password)"
+                )));
+            }
+        }
+        Ok(Self {
+            endpoint,
+            auth: cfg.auth.clone(),
+            pool_size: cfg.max_running_queries.map(|n| n as usize).unwrap_or(8),
+        })
+    }
+}
+
 /// StarRocks adapter — connects over the MySQL wire protocol to a StarRocks FE node.
 ///
 /// StarRocks is synchronous: `submit_query` executes the full query and returns
@@ -38,35 +101,17 @@ use queryflux_core::engine_registry::{
 pub struct StarRocksAdapter {
     pub cluster_name: ClusterName,
     pub group_name: ClusterGroupName,
-    opts: Opts,
+    pool: Pool,
     endpoint: String,
 }
 
 impl StarRocksAdapter {
-    /// When `auth` is [`Some`](Option::Some), it must be [`ClusterAuth::Basic`]; other variants error.
     pub fn new(
         cluster_name: ClusterName,
         group_name: ClusterGroupName,
-        endpoint: String,
-        auth: Option<ClusterAuth>,
+        config: StarRocksConfig,
     ) -> Result<Self> {
-        if let Some(ref a) = auth {
-            let unsupported = match a {
-                ClusterAuth::Basic { .. } => None,
-                ClusterAuth::Bearer { .. } => Some("bearer"),
-                ClusterAuth::KeyPair { .. } => Some("keyPair"),
-                ClusterAuth::AccessKey { .. } => Some("accessKey"),
-                ClusterAuth::RoleArn { .. } => Some("roleArn"),
-            };
-            if let Some(kind) = unsupported {
-                return Err(QueryFluxError::Engine(format!(
-                    "cluster '{}': StarRocks only supports ClusterAuth::basic (MySQL username/password); unsupported auth type '{kind}'",
-                    cluster_name.0
-                )));
-            }
-        }
-
-        let base_opts = Opts::from_url(&endpoint).map_err(|e| {
+        let base_opts = Opts::from_url(&config.endpoint).map_err(|e| {
             QueryFluxError::Engine(format!(
                 "cluster '{}': StarRocks invalid endpoint URL: {e}",
                 cluster_name.0
@@ -78,68 +123,54 @@ impl StarRocksAdapter {
         let mut builder = OptsBuilder::from_opts(base_opts).prefer_socket(false);
 
         // Override credentials from the explicit auth block if provided.
-        if let Some(ClusterAuth::Basic { username, password }) = auth {
+        if let Some(ClusterAuth::Basic { username, password }) = config.auth {
             builder = builder.user(Some(username)).pass(Some(password));
         }
 
-        let opts = Opts::from(builder);
+        // Build a persistent connection pool. min == max so the pool always holds
+        // exactly `pool_size` connections — no idle eviction below that floor.
+        // COM_RESET_CONNECTION is sent on return (default) so every checkout gets a clean
+        // slate — no leftover USE db / SET vars from a previous caller (execute_as_arrow,
+        // execute_ddl, catalog ops) can bleed through.
+        let pool_size = config.pool_size.max(1);
+        let constraints = PoolConstraints::new(pool_size, pool_size)
+            .expect("pool_size >= 1 guarantees valid constraints");
+        let pool_opts = PoolOpts::default()
+            .with_constraints(constraints)
+            // Recycle connections older than 30 min on return to avoid using stale TCP sessions
+            // that may have been silently dropped by firewalls or StarRocks FE restarts.
+            .with_abs_conn_ttl(Some(Duration::from_secs(1800)));
+        let opts = Opts::from(builder.pool_opts(pool_opts));
+        let pool = Pool::new(opts);
 
         Ok(Self {
             cluster_name,
             group_name,
-            opts,
-            endpoint,
+            pool,
+            endpoint: config.endpoint,
         })
-    }
-
-    /// Build from a DB config JSON blob (bypasses the `ClusterConfig` god struct).
-    pub fn try_from_config_json(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        json: &serde_json::Value,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_str, parse_auth_from_config_json};
-
-        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        let auth = parse_auth_from_config_json(json).map_err(|e| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': invalid auth ({e})"))
-        })?;
-        Self::new(cluster_name, group_name, endpoint, auth)
-    }
-
-    /// Build from persisted / YAML [`ClusterConfig`].
-    pub fn try_from_cluster_config(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        cfg: &ClusterConfig,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        Self::new(cluster_name, group_name, endpoint, cfg.auth.clone())
     }
 
     /// Execute a DDL/setup statement that returns no rows (CREATE EXTERNAL CATALOG, etc.).
     pub async fn execute_ddl(&self, sql: &str) -> Result<()> {
-        let mut conn = self.connect().await?;
+        let mut conn = self.acquire_conn().await?;
         conn.query_drop(sql)
             .await
             .map_err(|e| QueryFluxError::Engine(format!("StarRocks DDL failed: {e}")))
     }
 
-    async fn connect(&self) -> Result<Conn> {
-        tokio::time::timeout(Duration::from_secs(10), Conn::new(self.opts.clone()))
+    /// Check out a connection from the pool, with a 10-second timeout.
+    async fn acquire_conn(&self) -> Result<Conn> {
+        tokio::time::timeout(Duration::from_secs(10), self.pool.get_conn())
             .await
-            .map_err(|_| QueryFluxError::Engine("StarRocks connect timed out (10s)".to_string()))?
-            .map_err(|e| QueryFluxError::Engine(format!("StarRocks connect failed: {e}")))
+            .map_err(|_| {
+                QueryFluxError::Engine("StarRocks pool checkout timed out (10s)".to_string())
+            })?
+            .map_err(|e| QueryFluxError::Engine(format!("StarRocks pool get_conn failed: {e}")))
     }
 
     async fn run_query(&self, sql: &str) -> Result<Vec<Row>> {
-        let mut conn = self.connect().await?;
+        let mut conn = self.acquire_conn().await?;
         conn.query::<Row, _>(sql)
             .await
             .map_err(|e| QueryFluxError::Engine(format!("StarRocks query failed: {e}")))
@@ -189,13 +220,24 @@ impl EngineAdapterTrait for StarRocksAdapter {
     }
 
     async fn health_check(&self) -> bool {
-        match self.run_query("SELECT 1").await {
-            Ok(_) => true,
+        use mysql_async::prelude::Queryable;
+        match self.acquire_conn().await {
+            Ok(mut conn) => match conn.ping().await {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::warn!(
+                        cluster = %self.cluster_name,
+                        error = %e,
+                        "StarRocks health check ping failed"
+                    );
+                    false
+                }
+            },
             Err(e) => {
                 tracing::warn!(
                     cluster = %self.cluster_name,
                     error = %e,
-                    "StarRocks health check error"
+                    "StarRocks health check: pool checkout failed"
                 );
                 false
             }
@@ -221,7 +263,7 @@ impl EngineAdapterTrait for StarRocksAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         tags: &QueryTags,
     ) -> Result<crate::ArrowStream> {
-        let mut conn = self.connect().await?;
+        let mut conn = self.acquire_conn().await?;
 
         if let Some(db) = session.database() {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
@@ -592,6 +634,14 @@ impl StarRocksAdapter {
                     required: false,
                     example: None,
                 },
+                ConfigField {
+                    key: "poolSize",
+                    label: "Connection pool size",
+                    description: "Number of persistent MySQL connections to keep open. Defaults to max_running_queries (8) when omitted.",
+                    field_type: FieldType::Number,
+                    required: false,
+                    example: Some("8"),
+                },
             ],
         }
     }
@@ -615,12 +665,13 @@ impl crate::EngineAdapterFactory for StarRocksFactory {
         group: ClusterGroupName,
         json: &serde_json::Value,
     ) -> Result<Arc<dyn crate::EngineAdapterTrait>> {
+        use crate::EngineConfigParseable;
         let name = cluster_name.0.clone();
-        Ok(Arc::new(StarRocksAdapter::try_from_config_json(
+        let config = StarRocksConfig::from_json(json, &name)?;
+        Ok(Arc::new(StarRocksAdapter::new(
             cluster_name,
             group,
-            json,
-            name.as_str(),
+            config,
         )?))
     }
 }

--- a/crates/queryflux-engine-adapters/src/trino/mod.rs
+++ b/crates/queryflux-engine-adapters/src/trino/mod.rs
@@ -49,6 +49,13 @@ impl crate::EngineConfigParseable for TrinoConfig {
         let auth = parse_auth_from_config_json(json).map_err(|e| {
             QueryFluxError::Engine(format!("cluster '{cluster_name}': invalid auth ({e})"))
         })?;
+        if let Some(ref a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. } | ClusterAuth::Bearer { .. }) {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': Trino supports only basic or bearer auth"
+                )));
+            }
+        }
         Ok(Self {
             endpoint,
             tls_skip_verify: json_bool(json, "tlsInsecureSkipVerify"),
@@ -60,6 +67,14 @@ impl crate::EngineConfigParseable for TrinoConfig {
         let endpoint = cfg.endpoint.clone().ok_or_else(|| {
             QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
         })?;
+        let auth = cfg.auth.clone();
+        if let Some(ref a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. } | ClusterAuth::Bearer { .. }) {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': Trino supports only basic or bearer auth"
+                )));
+            }
+        }
         Ok(Self {
             endpoint,
             tls_skip_verify: cfg
@@ -67,7 +82,7 @@ impl crate::EngineConfigParseable for TrinoConfig {
                 .as_ref()
                 .map(|t| t.insecure_skip_verify)
                 .unwrap_or(false),
-            auth: cfg.auth.clone(),
+            auth,
         })
     }
 }

--- a/crates/queryflux-engine-adapters/src/trino/mod.rs
+++ b/crates/queryflux-engine-adapters/src/trino/mod.rs
@@ -33,6 +33,45 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Parsed and validated configuration for a Trino cluster.
+pub struct TrinoConfig {
+    pub endpoint: String,
+    pub tls_skip_verify: bool,
+    pub auth: Option<ClusterAuth>,
+}
+
+impl crate::EngineConfigParseable for TrinoConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> Result<Self> {
+        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
+        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
+        })?;
+        let auth = parse_auth_from_config_json(json).map_err(|e| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': invalid auth ({e})"))
+        })?;
+        Ok(Self {
+            endpoint,
+            tls_skip_verify: json_bool(json, "tlsInsecureSkipVerify"),
+            auth,
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> Result<Self> {
+        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
+        })?;
+        Ok(Self {
+            endpoint,
+            tls_skip_verify: cfg
+                .tls
+                .as_ref()
+                .map(|t| t.insecure_skip_verify)
+                .unwrap_or(false),
+            auth: cfg.auth.clone(),
+        })
+    }
+}
+
 /// Trino HTTP adapter.
 ///
 /// For Trino→Trino transparent forwarding, `submit_query` and `poll_query` return
@@ -50,72 +89,21 @@ impl TrinoAdapter {
     pub fn new(
         cluster_name: ClusterName,
         group_name: ClusterGroupName,
-        endpoint: String,
-        tls_skip_verify: bool,
-        auth: Option<ClusterAuth>,
+        config: TrinoConfig,
     ) -> Self {
         let http_client = Client::builder()
             .timeout(Duration::from_secs(30))
-            .danger_accept_invalid_certs(tls_skip_verify)
+            .danger_accept_invalid_certs(config.tls_skip_verify)
             .build()
             .expect("Failed to build HTTP client");
 
         Self {
             cluster_name,
             group_name,
-            endpoint,
+            endpoint: config.endpoint,
             http_client,
-            auth,
+            auth: config.auth,
         }
-    }
-
-    /// Build from persisted / YAML [`ClusterConfig`] (Trino-specific field usage).
-    pub fn try_from_cluster_config(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        cfg: &ClusterConfig,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        let tls_skip = cfg
-            .tls
-            .as_ref()
-            .map(|t| t.insecure_skip_verify)
-            .unwrap_or(false);
-        Ok(Self::new(
-            cluster_name,
-            group_name,
-            endpoint,
-            tls_skip,
-            cfg.auth.clone(),
-        ))
-    }
-
-    /// Build from a DB config JSON blob (bypasses the `ClusterConfig` god struct).
-    pub fn try_from_config_json(
-        cluster_name: ClusterName,
-        group_name: ClusterGroupName,
-        json: &serde_json::Value,
-        cluster_name_str: &str,
-    ) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
-
-        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': missing endpoint"))
-        })?;
-        let tls_skip = json_bool(json, "tlsInsecureSkipVerify");
-        let auth = parse_auth_from_config_json(json).map_err(|e| {
-            QueryFluxError::Engine(format!("cluster '{cluster_name_str}': invalid auth ({e})"))
-        })?;
-        Ok(Self::new(
-            cluster_name,
-            group_name,
-            endpoint,
-            tls_skip,
-            auth,
-        ))
     }
 
     /// Apply cluster-level auth credentials to a request builder.
@@ -920,12 +908,9 @@ impl crate::EngineAdapterFactory for TrinoFactory {
         group: ClusterGroupName,
         json: &serde_json::Value,
     ) -> Result<Arc<dyn crate::EngineAdapterTrait>> {
+        use crate::EngineConfigParseable;
         let name = cluster_name.0.clone();
-        Ok(Arc::new(TrinoAdapter::try_from_config_json(
-            cluster_name,
-            group,
-            json,
-            name.as_str(),
-        )?))
+        let config = TrinoConfig::from_json(json, &name)?;
+        Ok(Arc::new(TrinoAdapter::new(cluster_name, group, config)))
     }
 }

--- a/crates/queryflux-engine-adapters/src/trino/mod.rs
+++ b/crates/queryflux-engine-adapters/src/trino/mod.rs
@@ -42,7 +42,9 @@ pub struct TrinoConfig {
 
 impl crate::EngineConfigParseable for TrinoConfig {
     fn from_json(json: &serde_json::Value, cluster_name: &str) -> Result<Self> {
-        use queryflux_core::engine_registry::{json_bool, json_str, parse_auth_from_config_json};
+        use queryflux_core::engine_registry::{
+            json_str, json_tls_insecure_skip_verify, parse_auth_from_config_json,
+        };
         let endpoint = json_str(json, "endpoint").ok_or_else(|| {
             QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
         })?;
@@ -58,7 +60,7 @@ impl crate::EngineConfigParseable for TrinoConfig {
         }
         Ok(Self {
             endpoint,
-            tls_skip_verify: json_bool(json, "tlsInsecureSkipVerify"),
+            tls_skip_verify: json_tls_insecure_skip_verify(json),
             auth,
         })
     }

--- a/crates/queryflux-persistence/src/cluster_config.rs
+++ b/crates/queryflux-persistence/src/cluster_config.rs
@@ -152,6 +152,9 @@ impl UpsertClusterConfig {
         if let Some(v) = &cfg.catalog {
             config.insert("catalog".into(), v.clone().into());
         }
+        if let Some(n) = cfg.pool_size {
+            config.insert("poolSize".into(), serde_json::json!(n));
+        }
 
         match &cfg.auth {
             Some(ClusterAuth::Basic { username, password }) => {

--- a/crates/queryflux/src/registered_engines.rs
+++ b/crates/queryflux/src/registered_engines.rs
@@ -8,12 +8,14 @@ use queryflux_core::config::{ClusterConfig, EngineConfig};
 use queryflux_core::engine_registry::EngineDescriptor;
 use queryflux_core::error::QueryFluxError;
 use queryflux_core::query::{ClusterGroupName, ClusterName};
-use queryflux_engine_adapters::athena::{AthenaAdapter, AthenaFactory};
-use queryflux_engine_adapters::duckdb::http::{DuckDbHttpAdapter, DuckDbHttpFactory};
-use queryflux_engine_adapters::duckdb::{DuckDbAdapter, DuckDbFactory};
-use queryflux_engine_adapters::starrocks::{StarRocksAdapter, StarRocksFactory};
-use queryflux_engine_adapters::trino::{TrinoAdapter, TrinoFactory};
-use queryflux_engine_adapters::{EngineAdapterFactory, EngineAdapterTrait};
+use queryflux_engine_adapters::athena::{AthenaAdapter, AthenaConfig, AthenaFactory};
+use queryflux_engine_adapters::duckdb::http::{
+    DuckDbHttpAdapter, DuckDbHttpConfig, DuckDbHttpFactory,
+};
+use queryflux_engine_adapters::duckdb::{DuckDbAdapter, DuckDbConfig, DuckDbFactory};
+use queryflux_engine_adapters::starrocks::{StarRocksAdapter, StarRocksConfig, StarRocksFactory};
+use queryflux_engine_adapters::trino::{TrinoAdapter, TrinoConfig, TrinoFactory};
+use queryflux_engine_adapters::{EngineAdapterFactory, EngineAdapterTrait, EngineConfigParseable};
 
 /// All registered engine adapter factories.
 ///
@@ -74,52 +76,43 @@ pub async fn build_adapter(
     ))?;
 
     let adapter: Arc<dyn EngineAdapterTrait> = match engine {
-        EngineConfig::Trino => Arc::new(
-            TrinoAdapter::try_from_cluster_config(
-                cluster_name,
-                placeholder_group,
-                cluster_cfg,
-                cluster_name_str,
+        EngineConfig::Trino => {
+            let config = TrinoConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            Arc::new(TrinoAdapter::new(cluster_name, placeholder_group, config))
+        }
+        EngineConfig::DuckDb => {
+            let config = DuckDbConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            Arc::new(
+                DuckDbAdapter::new(cluster_name, placeholder_group, config).map_err(map_qf_err)?,
             )
-            .map_err(map_qf_err)?,
-        ),
-        EngineConfig::DuckDb => Arc::new(
-            DuckDbAdapter::try_from_cluster_config(
-                cluster_name,
-                placeholder_group,
-                cluster_cfg,
-                cluster_name_str,
+        }
+        EngineConfig::DuckDbHttp => {
+            let config = DuckDbHttpConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            Arc::new(
+                DuckDbHttpAdapter::new(cluster_name, placeholder_group, config)
+                    .map_err(map_qf_err)?,
             )
-            .map_err(map_qf_err)?,
-        ),
-        EngineConfig::DuckDbHttp => Arc::new(
-            DuckDbHttpAdapter::try_from_cluster_config(
-                cluster_name,
-                placeholder_group,
-                cluster_cfg,
-                cluster_name_str,
+        }
+        EngineConfig::StarRocks => {
+            let config = StarRocksConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            Arc::new(
+                StarRocksAdapter::new(cluster_name, placeholder_group, config)
+                    .map_err(map_qf_err)?,
             )
-            .map_err(map_qf_err)?,
-        ),
-        EngineConfig::StarRocks => Arc::new(
-            StarRocksAdapter::try_from_cluster_config(
-                cluster_name,
-                placeholder_group,
-                cluster_cfg,
-                cluster_name_str,
+        }
+        EngineConfig::Athena => {
+            let config = AthenaConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            Arc::new(
+                AthenaAdapter::new(cluster_name, placeholder_group, config)
+                    .await
+                    .map_err(map_qf_err)?,
             )
-            .map_err(map_qf_err)?,
-        ),
-        EngineConfig::Athena => Arc::new(
-            AthenaAdapter::try_from_cluster_config(
-                cluster_name,
-                placeholder_group,
-                cluster_cfg,
-                cluster_name_str,
-            )
-            .await
-            .map_err(map_qf_err)?,
-        ),
+        }
         EngineConfig::ClickHouse => {
             anyhow::bail!("Engine ClickHouse not yet implemented")
         }

--- a/queryflux-studio/components/cluster-config/starrocks-cluster-config.tsx
+++ b/queryflux-studio/components/cluster-config/starrocks-cluster-config.tsx
@@ -79,6 +79,28 @@ export function StarRocksClusterConfig({
             autoComplete="new-password"
           />
         </div>
+        <div>
+          <label
+            htmlFor="sr-pool"
+            className="block text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-1.5"
+          >
+            Connection pool size
+          </label>
+          <input
+            id="sr-pool"
+            type="number"
+            min={1}
+            step={1}
+            value={flat.poolSize ?? ""}
+            onChange={(e) => onPatch({ poolSize: e.target.value })}
+            placeholder="8"
+            className="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            autoComplete="off"
+          />
+          <p className="text-[10px] text-slate-400 mt-1">
+            Persistent MySQL connections to the FE. Leave empty to use the default (8).
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/queryflux-studio/components/cluster-config/trino-cluster-config.tsx
+++ b/queryflux-studio/components/cluster-config/trino-cluster-config.tsx
@@ -113,6 +113,9 @@ export function TrinoClusterConfig({
               className="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
               autoComplete="new-password"
             />
+            <p className="text-[10px] text-slate-400 mt-1">
+              Optional if the coordinator has no password (e.g. open dev clusters).
+            </p>
           </div>
         </div>
       )}

--- a/queryflux-studio/lib/cluster-persist-form.ts
+++ b/queryflux-studio/lib/cluster-persist-form.ts
@@ -36,6 +36,16 @@ function jsonScalarToString(v: unknown): string {
   return "";
 }
 
+/** Positive integer only; rejects floats, NaN, and non-integer `number` values. */
+export function parsePositiveIntString(s: string | undefined): number | undefined {
+  if (s === undefined) return undefined;
+  const t = s.trim();
+  if (t === "") return undefined;
+  const n = Number(t);
+  if (!Number.isInteger(n) || n < 1) return undefined;
+  return n;
+}
+
 /** DB / API `config` object → flat keys expected by cluster-config components. */
 export function persistedClusterConfigToFlat(
   config: Record<string, unknown>,
@@ -95,10 +105,8 @@ export function flatToPersistedConfig(flat: Record<string, string>): Record<stri
   if (flat.warehouse?.trim()) cfg.warehouse = flat.warehouse.trim();
   if (flat.role?.trim()) cfg.role = flat.role.trim();
   if (flat.schema?.trim()) cfg.schema = flat.schema.trim();
-  if (flat.poolSize?.trim()) {
-    const n = Number.parseInt(flat.poolSize.trim(), 10);
-    if (!Number.isNaN(n) && n >= 1) cfg.poolSize = n;
-  }
+  const poolN = parsePositiveIntString(flat.poolSize);
+  if (poolN !== undefined) cfg.poolSize = poolN;
   return cfg;
 }
 
@@ -153,8 +161,8 @@ export function mergeClusterConfigFromFlat(
   if (flat.poolSize !== undefined) {
     const t = flat.poolSize.trim();
     if (t) {
-      const n = Number.parseInt(t, 10);
-      if (!Number.isNaN(n) && n >= 1) out.poolSize = n;
+      const n = parsePositiveIntString(flat.poolSize);
+      if (n !== undefined) out.poolSize = n;
       else delete out.poolSize;
     } else delete out.poolSize;
   }
@@ -193,10 +201,8 @@ export function buildValidateShape(flat: Record<string, string>): Record<string,
   if (flat.warehouse) o.warehouse = flat.warehouse;
   if (flat.role) o.role = flat.role;
   if (flat.schema) o.schema = flat.schema;
-  if (flat.poolSize?.trim()) {
-    const n = Number.parseInt(flat.poolSize.trim(), 10);
-    if (!Number.isNaN(n) && n >= 1) o.poolSize = n;
-  }
+  const poolN = parsePositiveIntString(flat.poolSize);
+  if (poolN !== undefined) o.poolSize = poolN;
   const auth: Record<string, string> = {};
   if (flat["auth.type"]) auth.type = flat["auth.type"];
   if (flat["auth.username"]) auth.username = flat["auth.username"];

--- a/queryflux-studio/lib/cluster-persist-form.ts
+++ b/queryflux-studio/lib/cluster-persist-form.ts
@@ -26,6 +26,7 @@ export const MANAGED_CONFIG_JSON_KEYS = new Set([
   "warehouse",
   "role",
   "schema",
+  "poolSize",
 ]);
 
 function jsonScalarToString(v: unknown): string {
@@ -62,6 +63,8 @@ export function persistedClusterConfigToFlat(
   flat["tls.insecureSkipVerify"] =
     config.tlsInsecureSkipVerify === true ? "true" : "false";
 
+  flat.poolSize = jsonScalarToString(config.poolSize);
+
   if (descriptor) {
     for (const f of descriptor.configFields) {
       if (flat[f.key] === undefined) flat[f.key] = "";
@@ -92,6 +95,10 @@ export function flatToPersistedConfig(flat: Record<string, string>): Record<stri
   if (flat.warehouse?.trim()) cfg.warehouse = flat.warehouse.trim();
   if (flat.role?.trim()) cfg.role = flat.role.trim();
   if (flat.schema?.trim()) cfg.schema = flat.schema.trim();
+  if (flat.poolSize?.trim()) {
+    const n = Number.parseInt(flat.poolSize.trim(), 10);
+    if (!Number.isNaN(n) && n >= 1) cfg.poolSize = n;
+  }
   return cfg;
 }
 
@@ -143,6 +150,15 @@ export function mergeClusterConfigFromFlat(
   setOrDel("role", flat.role, "role");
   setOrDel("schema", flat.schema, "schema");
 
+  if (flat.poolSize !== undefined) {
+    const t = flat.poolSize.trim();
+    if (t) {
+      const n = Number.parseInt(t, 10);
+      if (!Number.isNaN(n) && n >= 1) out.poolSize = n;
+      else delete out.poolSize;
+    } else delete out.poolSize;
+  }
+
   return out;
 }
 
@@ -177,6 +193,10 @@ export function buildValidateShape(flat: Record<string, string>): Record<string,
   if (flat.warehouse) o.warehouse = flat.warehouse;
   if (flat.role) o.role = flat.role;
   if (flat.schema) o.schema = flat.schema;
+  if (flat.poolSize?.trim()) {
+    const n = Number.parseInt(flat.poolSize.trim(), 10);
+    if (!Number.isNaN(n) && n >= 1) o.poolSize = n;
+  }
   const auth: Record<string, string> = {};
   if (flat["auth.type"]) auth.type = flat["auth.type"];
   if (flat["auth.username"]) auth.username = flat["auth.username"];

--- a/queryflux-studio/lib/studio-engines/engines/starrocks.ts
+++ b/queryflux-studio/lib/studio-engines/engines/starrocks.ts
@@ -7,8 +7,8 @@ function validateStarRocksClusterFlat(flat: FlatClusterForm): string[] {
   }
   const ps = flat.poolSize?.trim();
   if (ps) {
-    const n = Number.parseInt(ps, 10);
-    if (Number.isNaN(n) || n < 1) {
+    const n = Number(ps);
+    if (!Number.isInteger(n) || n < 1) {
       return ["StarRocks: connection pool size must be a positive integer."];
     }
   }
@@ -64,7 +64,7 @@ export const starRocksStudioEngine: StudioEngineModule = {
         key: "poolSize",
         label: "Connection pool size",
         description:
-          "Number of persistent MySQL connections to keep open. Defaults to 8 when omitted.",
+          "Max concurrent MySQL connections for QueryFlux (default 8). Separate from max running queries on the engine.",
         fieldType: "number",
         required: false,
         example: "8",

--- a/queryflux-studio/lib/studio-engines/engines/starrocks.ts
+++ b/queryflux-studio/lib/studio-engines/engines/starrocks.ts
@@ -5,6 +5,13 @@ function validateStarRocksClusterFlat(flat: FlatClusterForm): string[] {
   if (!flat["auth.username"]?.trim() || !flat["auth.password"]) {
     return ["StarRocks: username and password are required."];
   }
+  const ps = flat.poolSize?.trim();
+  if (ps) {
+    const n = Number.parseInt(ps, 10);
+    if (Number.isNaN(n) || n < 1) {
+      return ["StarRocks: connection pool size must be a positive integer."];
+    }
+  }
   return [];
 }
 
@@ -52,6 +59,15 @@ export const starRocksStudioEngine: StudioEngineModule = {
         description: "MySQL password.",
         fieldType: "secret",
         required: false,
+      },
+      {
+        key: "poolSize",
+        label: "Connection pool size",
+        description:
+          "Number of persistent MySQL connections to keep open. Defaults to 8 when omitted.",
+        fieldType: "number",
+        required: false,
+        example: "8",
       },
     ],
   },

--- a/queryflux-studio/lib/studio-engines/engines/trino.ts
+++ b/queryflux-studio/lib/studio-engines/engines/trino.ts
@@ -7,8 +7,8 @@ function validateTrinoClusterFlat(flat: FlatClusterForm): string[] {
     return ["Trino: choose an authentication method."];
   }
   if (at === "basic") {
-    if (!flat["auth.username"]?.trim() || !flat["auth.password"]) {
-      return ["Trino: username and password are required for basic authentication."];
+    if (!flat["auth.username"]?.trim()) {
+      return ["Trino: username is required for basic authentication (password may be empty)."];
     }
   }
   if (at === "bearer") {
@@ -60,7 +60,8 @@ export const trinoStudioEngine: StudioEngineModule = {
       {
         key: "auth.password",
         label: "Password",
-        description: "Basic auth password.",
+        description:
+          "Basic auth password. Leave empty if Trino has no password (e.g. dev / no authentication).",
         fieldType: "secret",
         required: false,
       },


### PR DESCRIPTION
Allow empty authPassword for basic auth in parse_auth_from_config_json; relax Studio Trino validation and clarify the password field. Add StarRocks poolSize to the studio descriptor, persist form, and cluster form. Remove broken Snowflake frontend links from the roadmap. Reject negative max_running_queries from Postgres with u64::try_from. Pin versioned backend doc source links to a commit SHA. Merge main (CI, Makefile, libduckdb). Docs and ClusterAuth comments updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StarRocks: configurable connection pool size now persisted and editable in Studio.

* **Improvements**
  * StarRocks: pooled persistent connections for queries and health checks for better reliability.
  * Trino: basic-auth password may be left empty; UI helper text and validation updated.
  * General: more robust parsing and validation of engine cluster configuration inputs across adapters.

* **Tests**
  * Added unit tests covering auth, per-query auth, pool-size parsing, and TLS precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->