### PR TITLE
fix: mobile navbar hamburger menu and sidebar drawer

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -244,6 +244,16 @@ html[data-theme='dark'] .navbar {
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
 }
 
+/*
+ * backdrop-filter creates a new containing block, which turns the sidebar's
+ * position:fixed into position:absolute relative to <nav>. Disable it while
+ * the mobile drawer is open so the sidebar can overlay the full viewport.
+ */
+.navbar.navbar-sidebar--show {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 .navbar__brand {
   display: flex;
   align-items: center;
@@ -326,6 +336,10 @@ html[data-theme='dark'] .navbar__link:hover {
     display: flex;
     align-items: center;
     padding: 0;
+  }
+
+  .qf-mobile-toggle-wrap {
+    display: none;
   }
 }
 
@@ -494,7 +508,7 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
 }
 
 /* ==========================================================================
-   Mobile header — single authoritative block (no hamburger, no collapse)
+   Mobile header — hamburger + logo + search; nav items collapse into drawer
    ========================================================================== */
 @media (max-width: 996px) {
   :root {
@@ -502,10 +516,8 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
     --qf-navbar-pad-y: 0.5625rem;
   }
 
-  .navbar .navbar__inner .navbar__item {
-    display: inline-flex !important;
-    align-items: center !important;
-    min-width: 0;
+  .navbar .navbar__item {
+    display: none !important;
   }
 
   .navbar__inner {
@@ -550,17 +562,6 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
     white-space: nowrap !important;
   }
 
-  .navbar__item.navbar-item-docs-mobile,
-  .navbar__item.navbar-item-docs-mobile .navbar__link {
-    flex-shrink: 0 !important;
-    overflow: visible !important;
-  }
-
-  .navbar__item.navbar-item-collapse-mobile {
-    display: inline-flex !important;
-    align-items: center;
-  }
-
   .navbar__items--right {
     display: inline-flex !important;
     position: static !important;
@@ -580,13 +581,6 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
     flex-wrap: nowrap !important;
   }
 
-  .navbar__items--right > * {
-    display: inline-flex !important;
-    align-items: center !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-  }
-
   .navbar__items--right > div:has(> button.clean-btn),
   .navbar__items--right > div:has(> button.clean-btn) button.clean-btn {
     width: 2.5rem !important;
@@ -596,35 +590,28 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
     opacity: 1 !important;
   }
 
-  .navbar__link.navbar-link-github {
-    width: 2.5rem !important;
-    height: 2.5rem !important;
+  .qf-mobile-toggle-wrap,
+  .qf-mobile-toggle-wrap .navbar__toggle {
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
   }
 
-  /* Search: stay in-flow in the left group, never go absolute */
+  /* Search: stay in-flow in the left group, constrained width */
   .navbar__inner .dsla-search-wrapper,
   .navbar__inner [class*='navbarSearchContainer'] {
     position: static !important;
     right: auto !important;
     flex: 0 1 auto !important;
     min-width: 4.75rem !important;
-    max-width: clamp(4.75rem, 17vw, 7.8rem) !important;
+    max-width: clamp(4.75rem, 22vw, 10rem) !important;
     width: auto !important;
     margin: 0 !important;
   }
 
-  .navbar .navbar__item .navbar__link {
-    padding-left: 0.42rem !important;
-    padding-right: 0.42rem !important;
-  }
-
-  /* Hide hamburger/sidebar UI entirely */
-  .qf-mobile-toggle-wrap,
-  .navbar__toggle,
-  .navbar-sidebar,
-  .navbar-sidebar__backdrop {
-    display: none !important;
-  }
 }
 
 @media (max-width: 560px) {
@@ -632,25 +619,20 @@ html[data-theme='dark'] .navbar__items--right > div:has(> button.clean-btn) butt
     margin-right: 0.4rem !important;
   }
 
-  .navbar .navbar__item .navbar__link {
-    font-size: 0.88rem !important;
-    padding-left: 0.3rem !important;
-    padding-right: 0.3rem !important;
-  }
-
   .navbar__items--right {
     gap: 0.14rem !important;
-  }
-
-  .navbar__link.navbar-link-github {
-    width: 2.25rem !important;
-    height: 2.25rem !important;
   }
 
   .navbar__items--right > div:has(> button.clean-btn),
   .navbar__items--right > div:has(> button.clean-btn) button.clean-btn {
     width: 2.25rem !important;
     height: 2.25rem !important;
+  }
+
+  .qf-mobile-toggle-wrap,
+  .qf-mobile-toggle-wrap .navbar__toggle {
+    width: 2.25rem;
+    height: 2.25rem;
   }
 }
 

--- a/website/src/theme/Navbar/Content/index.tsx
+++ b/website/src/theme/Navbar/Content/index.tsx
@@ -14,11 +14,13 @@ import {
 } from '@docusaurus/theme-common';
 import {
   splitNavbarItems,
+  useNavbarMobileSidebar,
 } from '@docusaurus/theme-common/internal';
 import NavbarItem, {type Props as NavbarItemConfig} from '@theme/NavbarItem';
 import SearchBar from '@theme/SearchBar';
 import NavbarLogo from '@theme/Navbar/Logo';
 import NavbarSearch from '@theme/Navbar/Search';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
 
 import './styles.module.css';
 
@@ -75,6 +77,7 @@ function NavbarContentLayout({
 }
 
 export default function NavbarContent(): ReactNode {
+  const mobileSidebar = useNavbarMobileSidebar();
   const items = useNavbarItems();
   const [leftItems, rightItems] = splitNavbarItems(items);
 
@@ -97,7 +100,12 @@ export default function NavbarContent(): ReactNode {
           )}
         </>
       }
-      right={<NavbarItems items={rightItemsWithoutSearch} />}
+      right={
+        <>
+          <NavbarItems items={rightItemsWithoutSearch} />
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+        </>
+      }
     />
   );
 }

--- a/website/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/website/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -5,18 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {version, useRef, type ReactNode} from 'react';
+import React, {version, type ReactNode} from 'react';
 import clsx from 'clsx';
 import {
-  useNavbarMobileSidebar,
   useNavbarSecondaryMenu,
 } from '@docusaurus/theme-common/internal';
 import {ThemeClassNames} from '@docusaurus/theme-common';
 import type {Props} from '@theme/Navbar/MobileSidebar/Layout';
-import {
-  clearNavbarMenuCloseTimer,
-  scheduleNavbarMenuClose,
-} from '../../navbarMenuHoverTimer';
 
 // TODO Docusaurus v4: remove temporary inert workaround
 //  See https://github.com/facebook/react/issues/17157
@@ -54,20 +49,13 @@ export default function NavbarMobileSidebarLayout({
   secondaryMenu,
 }: Props): ReactNode {
   const {shown: secondaryMenuShown} = useNavbarSecondaryMenu();
-  const {toggle, shown} = useNavbarMobileSidebar();
-  const shownRef = useRef(shown);
-  shownRef.current = shown;
 
   return (
     <div
       className={clsx(
         ThemeClassNames.layout.navbar.mobileSidebar.container,
         'navbar-sidebar',
-      )}
-      onMouseEnter={clearNavbarMenuCloseTimer}
-      onMouseLeave={() =>
-        scheduleNavbarMenuClose(() => shownRef.current, toggle)
-      }>
+      )}>
       {header}
       <div
         className={clsx('navbar-sidebar__items', {

--- a/website/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
+++ b/website/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
@@ -5,34 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, {useRef, type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import {translate} from '@docusaurus/Translate';
 import IconMenu from '@theme/Icon/Menu';
-import {
-  clearNavbarMenuCloseTimer,
-  scheduleNavbarMenuClose,
-} from '../../navbarMenuHoverTimer';
 
 import styles from './styles.module.css';
 
 export default function MobileSidebarToggle(): ReactNode {
   const {toggle, shown} = useNavbarMobileSidebar();
-  const shownRef = useRef(shown);
-  shownRef.current = shown;
 
   return (
-    <div
-      className={`${styles.toggleWrap} qf-mobile-toggle-wrap`}
-      onMouseEnter={() => {
-        clearNavbarMenuCloseTimer();
-        if (!shownRef.current) {
-          toggle();
-        }
-      }}
-      onMouseLeave={() =>
-        scheduleNavbarMenuClose(() => shownRef.current, toggle)
-      }>
+    <div className={`${styles.toggleWrap} qf-mobile-toggle-wrap`}>
       <button
         onClick={toggle}
         aria-label={translate({

--- a/website/src/theme/Navbar/MobileSidebar/index.tsx
+++ b/website/src/theme/Navbar/MobileSidebar/index.tsx
@@ -6,7 +6,10 @@
  */
 
 import React, {type ReactNode} from 'react';
-import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import {
+  useLockBodyScroll,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
 import NavbarMobileSidebarLayout from '@theme/Navbar/MobileSidebar/Layout';
 import NavbarMobileSidebarHeader from '@theme/Navbar/MobileSidebar/Header';
 import NavbarMobileSidebarPrimaryMenu from '@theme/Navbar/MobileSidebar/PrimaryMenu';
@@ -14,6 +17,7 @@ import NavbarMobileSidebarSecondaryMenu from '@theme/Navbar/MobileSidebar/Second
 
 export default function NavbarMobileSidebar(): ReactNode {
   const mobileSidebar = useNavbarMobileSidebar();
+  useLockBodyScroll(mobileSidebar.shown);
 
   if (!mobileSidebar.shouldRender) {
     return null;


### PR DESCRIPTION
Move hamburger toggle to the right side of the mobile header and collapse nav items (Docs, GitHub) into the drawer instead of showing them inline. Fix sidebar not rendering as a full-height overlay by disabling backdrop-filter on the navbar when the drawer is open (backdrop-filter creates a containing block that breaks position:fixed). Remove hover-based open/close timers that caused the drawer to auto-close on touch devices, and restore the missing useLockBodyScroll call from the swizzled MobileSidebar component.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile sidebar drawer behavior with enhanced scroll locking when sidebar is active.
  * Refined mobile navbar layout and component visibility logic for better responsiveness.
  * Streamlined mobile navigation toggle interactions by simplifying control mechanisms.

* **Style**
  * Adjusted search container sizing for improved mobile display.
  * Enhanced mobile navbar styling for backdrop and layout consistency across viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->