### PR TITLE
fix: point favicon and OG image to existing hero banner, bump hero te…

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,7 +11,7 @@ const socialPreviewDescription =
 const config: Config = {
   title: 'QueryFlux',
   tagline: 'Universal SQL query proxy and router in Rust',
-  favicon: 'img/queryflux-hero-cover.png',
+  favicon: 'img/queryflux-hero-banner.png',
 
   url: siteUrl,
   baseUrl: '/',
@@ -110,8 +110,8 @@ const config: Config = {
   ],
 
   themeConfig: {
-    // Default og/twitter image (homepage hero cover); width/height in metadata below.
-    image: 'img/queryflux-hero-cover.png',
+    // Default og/twitter image (homepage hero banner); width/height in metadata below.
+    image: 'img/queryflux-hero-banner.png',
     // New visitors start in dark; do not follow OS prefers-color-scheme.
     colorMode: {
       defaultMode: 'dark',

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -87,7 +87,7 @@ html[data-theme='dark'] .heroTitleFlux {
 }
 
 .heroTagline {
-  font-size: clamp(1.14rem, 2.2vw, 1.34rem);
+  font-size: clamp(1.28rem, 2.5vw, 1.52rem);
   font-weight: 650;
   color: #334155;
   margin: 0 0 1rem;
@@ -100,7 +100,7 @@ html[data-theme='dark'] .heroTagline {
 }
 
 .heroLeadin {
-  font-size: 1.02rem;
+  font-size: 1.14rem;
   line-height: 1.65;
   color: #475569;
   margin: 0 auto 1.75rem;


### PR DESCRIPTION
…xt sizes

Favicon and themeConfig.image referenced a non-existent queryflux-hero-cover.png — switch both to the actual hero asset queryflux-hero-banner.png. Also slightly increase heroTagline and heroLeadin font sizes for better readability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased font sizes in the hero section for improved readability and visual hierarchy, with responsive scaling across all device sizes.
  * Updated website favicon and social sharing preview image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->