### PR TITLE
fix: don't convert to arrow when frontend and backend talk same protocol

### DIFF
--- a/crates/queryflux-core/src/lib.rs
+++ b/crates/queryflux-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod config_json;
 pub mod engine_registry;
 pub mod error;
+pub mod native_result;
 pub mod query;
 pub mod session;
 pub mod tags;

--- a/crates/queryflux-core/src/native_result.rs
+++ b/crates/queryflux-core/src/native_result.rs
@@ -1,0 +1,63 @@
+use bytes::Bytes;
+
+/// Describes one column in a native (non-Arrow) result set.
+///
+/// Lives in `queryflux-core` with zero driver imports — adapters convert their
+/// driver-specific column metadata *into* this; frontends read *from* this to
+/// build wire-protocol column definition packets.
+#[derive(Debug, Clone)]
+pub struct NativeColumn {
+    pub name: String,
+    pub type_info: NativeTypeInfo,
+    pub nullable: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeTypeInfo {
+    pub kind: NativeTypeKind,
+    pub precision: Option<u16>,
+    pub scale: Option<u8>,
+    pub unsigned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeTypeKind {
+    Boolean,
+    TinyInt,
+    SmallInt,
+    Int,
+    BigInt,
+    Float,
+    Double,
+    Decimal,
+    Char,
+    Varchar,
+    Text,
+    Binary,
+    Blob,
+    Date,
+    Time,
+    DateTime,
+    Timestamp,
+    Json,
+    Unknown,
+}
+
+/// A single result row: one nullable, text-encoded value per column.
+///
+/// `None` = SQL NULL. `Some(bytes)` = the value's display representation (UTF-8).
+/// Pre-encoding at the adapter avoids per-value string formatting in the frontend.
+/// `Bytes` cloning is O(1) (reference-counted).
+#[derive(Debug, Clone)]
+pub struct NativeRow(pub Vec<Option<Bytes>>);
+
+/// A batch of rows from a native result stream.
+///
+/// `columns` is `Some` only on the first chunk — the schema is delivered once,
+/// then subsequent chunks carry rows only.
+#[derive(Debug, Clone)]
+pub struct NativeResultChunk {
+    /// Column metadata. Present on the first chunk, `None` on all subsequent chunks.
+    pub columns: Option<Vec<NativeColumn>>,
+    pub rows: Vec<NativeRow>,
+}

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adbc;
 pub mod athena;
 pub mod duckdb;
+pub mod mysql_native;
 pub mod starrocks;
 pub mod trino;
 
@@ -14,7 +15,8 @@ use queryflux_core::{
     config::ClusterConfig,
     engine_registry::EngineDescriptor,
     error::Result,
-    query::{ClusterGroupName, ClusterName},
+    native_result::NativeResultChunk,
+    query::{ClusterGroupName, ClusterName, FrontendProtocol},
 };
 
 /// Implemented by each engine's typed config struct.
@@ -47,6 +49,124 @@ pub struct SyncExecution {
     pub stats: tokio::sync::oneshot::Receiver<Option<queryflux_core::query::QueryEngineStats>>,
 }
 
+/// What wire format this adapter natively produces, determined by its connection type.
+///
+/// The adapter declares one value based on how it is configured (which driver/pool it uses).
+/// Dispatch compares this against the incoming frontend protocol — a match means the
+/// Arrow intermediate can be skipped entirely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionFormat {
+    /// Arrow `RecordBatch` stream — ADBC, DuckDB, in-process engines.
+    Arrow,
+    /// MySQL wire protocol via `mysql_async` pool — StarRocks, ClickHouse MySQL iface.
+    MysqlWire,
+    /// PostgreSQL wire protocol via `tokio_postgres` pool.
+    PostgresWire,
+    /// Trino HTTP JSON (opaque bytes, async submit-poll).
+    TrinoHttp,
+    /// ClickHouse HTTP (opaque bytes).
+    ClickHouseHttp,
+}
+
+impl ConnectionFormat {
+    /// Returns `true` if this backend format directly satisfies the given frontend protocol
+    /// without any Arrow conversion.
+    pub fn matches_frontend(&self, protocol: &FrontendProtocol) -> bool {
+        matches!(
+            (self, protocol),
+            (ConnectionFormat::MysqlWire, FrontendProtocol::MySqlWire)
+                | (
+                    ConnectionFormat::PostgresWire,
+                    FrontendProtocol::PostgresWire
+                )
+                | (ConnectionFormat::Arrow, FrontendProtocol::FlightSql)
+                | (ConnectionFormat::TrinoHttp, FrontendProtocol::TrinoHttp)
+                | (
+                    ConnectionFormat::ClickHouseHttp,
+                    FrontendProtocol::ClickHouseHttp
+                )
+        )
+    }
+}
+
+#[cfg(test)]
+mod connection_format_tests {
+    use super::*;
+    use queryflux_core::query::FrontendProtocol;
+
+    // ── matches (native path taken) ───────────────────────────────────────────
+
+    #[test]
+    fn mysql_wire_matches_mysql_wire() {
+        assert!(ConnectionFormat::MysqlWire.matches_frontend(&FrontendProtocol::MySqlWire));
+    }
+
+    #[test]
+    fn postgres_wire_matches_postgres_wire() {
+        assert!(ConnectionFormat::PostgresWire.matches_frontend(&FrontendProtocol::PostgresWire));
+    }
+
+    #[test]
+    fn arrow_matches_flight_sql() {
+        assert!(ConnectionFormat::Arrow.matches_frontend(&FrontendProtocol::FlightSql));
+    }
+
+    #[test]
+    fn trino_http_matches_trino_http() {
+        assert!(ConnectionFormat::TrinoHttp.matches_frontend(&FrontendProtocol::TrinoHttp));
+    }
+
+    #[test]
+    fn clickhouse_http_matches_clickhouse_http() {
+        assert!(
+            ConnectionFormat::ClickHouseHttp.matches_frontend(&FrontendProtocol::ClickHouseHttp)
+        );
+    }
+
+    // ── no match (Arrow fallback taken) ──────────────────────────────────────
+
+    #[test]
+    fn mysql_wire_does_not_match_postgres_wire() {
+        assert!(!ConnectionFormat::MysqlWire.matches_frontend(&FrontendProtocol::PostgresWire));
+    }
+
+    #[test]
+    fn mysql_wire_does_not_match_flight_sql() {
+        assert!(!ConnectionFormat::MysqlWire.matches_frontend(&FrontendProtocol::FlightSql));
+    }
+
+    #[test]
+    fn mysql_wire_does_not_match_trino_http() {
+        assert!(!ConnectionFormat::MysqlWire.matches_frontend(&FrontendProtocol::TrinoHttp));
+    }
+
+    #[test]
+    fn arrow_does_not_match_mysql_wire() {
+        assert!(!ConnectionFormat::Arrow.matches_frontend(&FrontendProtocol::MySqlWire));
+    }
+
+    #[test]
+    fn arrow_does_not_match_postgres_wire() {
+        assert!(!ConnectionFormat::Arrow.matches_frontend(&FrontendProtocol::PostgresWire));
+    }
+
+    #[test]
+    fn trino_http_does_not_match_mysql_wire() {
+        assert!(!ConnectionFormat::TrinoHttp.matches_frontend(&FrontendProtocol::MySqlWire));
+    }
+
+    #[test]
+    fn postgres_wire_does_not_match_mysql_wire() {
+        assert!(!ConnectionFormat::PostgresWire.matches_frontend(&FrontendProtocol::MySqlWire));
+    }
+}
+
+/// Returned by `SyncAdapter::execute_native` — a stream of protocol-agnostic row chunks.
+pub struct NativeExecution {
+    pub stream: Pin<Box<dyn Stream<Item = Result<NativeResultChunk>> + Send>>,
+    pub stats: tokio::sync::oneshot::Receiver<Option<queryflux_core::query::QueryEngineStats>>,
+}
+
 /// Sync engines: execute to completion, stream Arrow results.
 /// Used by DuckDB (embedded + HTTP) and StarRocks.
 #[async_trait]
@@ -63,6 +183,31 @@ pub trait SyncAdapter: Send + Sync {
     fn translation_target_dialect(&self) -> queryflux_core::query::SqlDialect {
         self.engine_type().dialect()
     }
+    /// The wire format this adapter natively produces based on its connection type.
+    ///
+    /// Default: `Arrow` — the universal fallback path. Adapters that use a non-Arrow
+    /// driver (e.g. `mysql_async`) override this to enable the zero-serialization path.
+    fn connection_format(&self) -> ConnectionFormat {
+        ConnectionFormat::Arrow
+    }
+
+    /// Execute a query and stream results as `NativeResultChunk`s, bypassing Arrow.
+    ///
+    /// Only called by dispatch when `connection_format().matches_frontend(protocol)` is true.
+    /// Default returns `Err` — adapters that override `connection_format` must also override this.
+    async fn execute_native(
+        &self,
+        _protocol: &FrontendProtocol,
+        _sql: &str,
+        _session: &queryflux_core::session::SessionContext,
+        _credentials: &queryflux_auth::QueryCredentials,
+        _tags: &queryflux_core::tags::QueryTags,
+    ) -> Result<NativeExecution> {
+        Err(queryflux_core::error::QueryFluxError::Engine(
+            "execute_native not implemented for this adapter".to_string(),
+        ))
+    }
+
     async fn health_check(&self) -> bool;
     async fn fetch_running_query_count(&self) -> Option<u64> {
         None
@@ -122,6 +267,15 @@ pub trait AsyncAdapter: Send + Sync {
     /// Called by dispatch when the engine returns a terminal state on the initial POST
     /// (no `nextUri`). The body is the raw bytes returned by `submit_query`. Engines that
     /// embed stats in their response (e.g. Trino) override this; others return `None`.
+    /// The wire format this adapter natively produces.
+    ///
+    /// Async adapters that use HTTP passthrough (e.g. Trino → `TrinoHttp`,
+    /// ClickHouse → `ClickHouseHttp`) override this so dispatch can document
+    /// and validate the native path. Default: `Arrow`.
+    fn connection_format(&self) -> ConnectionFormat {
+        ConnectionFormat::Arrow
+    }
+
     fn terminal_stats_from_body(
         &self,
         _body: &bytes::Bytes,

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -1,0 +1,369 @@
+//! Shared MySQL-wire native execution helper.
+//!
+//! Used by any adapter that connects via `mysql_async` (StarRocks, ClickHouse MySQL iface).
+//! Converts `mysql_async` rows directly into `NativeResultChunk`s, bypassing Arrow entirely.
+//!
+//! # Type precision vs. the Arrow path
+//!
+//! The Arrow path round-trips through `mysql_column_type_to_arrow` and `arrow_type_to_mysql_type`,
+//! which loses precision for DECIMAL, DATETIME(6), and UNSIGNED integers. This module reads
+//! column metadata directly from the mysql_async driver and encodes values from their
+//! native `mysql_async::Value` representation, preserving full precision.
+
+use bytes::Bytes;
+use futures::stream;
+use mysql_async::{consts::ColumnType, prelude::Queryable, Pool, Row, Value};
+use queryflux_auth::QueryCredentials;
+use queryflux_core::{
+    error::{QueryFluxError, Result},
+    native_result::{NativeColumn, NativeResultChunk, NativeRow, NativeTypeInfo, NativeTypeKind},
+    session::SessionContext,
+    tags::{tags_to_json, QueryTags},
+};
+
+use crate::NativeExecution;
+
+/// Number of rows per `NativeResultChunk`. Balances channel overhead vs. memory.
+const BATCH_SIZE: usize = 1_000;
+
+/// Execute `sql` against `pool` and return a stream of `NativeResultChunk`s.
+///
+/// The connection is acquired, session is set up (USE database, @query_tag), the query
+/// is executed, and rows are batched into `NativeResultChunk`s of up to `BATCH_SIZE` rows.
+/// The first chunk carries column metadata; subsequent chunks carry rows only.
+///
+/// # Streaming note
+/// This implementation collects all rows into memory before yielding chunks — the same
+/// behaviour as the current Arrow path. The in-memory constraint is removed in a follow-up
+/// by switching to `query_iter` + a spawned task, which requires working around
+/// `mysql_async::QueryResult`'s borrow-based lifetime constraints.
+pub async fn execute(
+    pool: &Pool,
+    sql: &str,
+    session: &SessionContext,
+    _credentials: &QueryCredentials,
+    tags: &QueryTags,
+) -> Result<NativeExecution> {
+    let mut conn = pool
+        .get_conn()
+        .await
+        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: connection failed: {e}")))?;
+
+    if let Some(db) = session.database() {
+        let use_sql = format!("USE `{}`", db.replace('`', "``"));
+        conn.query_drop(&use_sql)
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("mysql_native: USE failed: {e}")))?;
+    }
+
+    if !tags.is_empty() {
+        let tag_json = tags_to_json(tags).to_string();
+        let escaped = Value::from(tag_json).as_sql(false);
+        let set_sql = format!("SET @query_tag = {escaped}");
+        conn.query_drop(&set_sql).await.map_err(|e| {
+            QueryFluxError::Engine(format!("mysql_native: SET @query_tag failed: {e}"))
+        })?;
+    }
+
+    let rows: Vec<Row> = conn
+        .query::<Row, _>(sql)
+        .await
+        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: query failed: {e}")))?;
+
+    let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
+
+    if rows.is_empty() {
+        let _ = stats_tx.send(None);
+        return Ok(NativeExecution {
+            stream: Box::pin(stream::empty()),
+            stats: stats_rx,
+        });
+    }
+
+    // Build column metadata from the first row's column descriptors.
+    let columns: Vec<NativeColumn> = rows[0]
+        .columns_ref()
+        .iter()
+        .map(|c| NativeColumn {
+            name: c.name_str().to_string(),
+            type_info: mysql_column_type_to_native(c.column_type()),
+            nullable: true,
+        })
+        .collect();
+
+    let num_cols = rows[0].len();
+
+    // Convert all rows to NativeRows first, then batch them.
+    let native_rows: Vec<NativeRow> = rows
+        .into_iter()
+        .map(|row| row_to_native(row, num_cols))
+        .collect();
+
+    // Produce NativeResultChunks: columns present only on the first chunk.
+    let chunks: Vec<Result<NativeResultChunk>> = native_rows
+        .chunks(BATCH_SIZE)
+        .enumerate()
+        .map(|(i, batch)| {
+            Ok(NativeResultChunk {
+                columns: if i == 0 { Some(columns.clone()) } else { None },
+                rows: batch.to_vec(),
+            })
+        })
+        .collect();
+
+    let _ = stats_tx.send(None);
+    Ok(NativeExecution {
+        stream: Box::pin(stream::iter(chunks)),
+        stats: stats_rx,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Row / value conversion
+// ---------------------------------------------------------------------------
+
+fn row_to_native(mut row: Row, num_cols: usize) -> NativeRow {
+    let values = (0..num_cols)
+        .map(|i| match row.take::<Value, usize>(i) {
+            Some(Value::NULL) | None => None,
+            Some(v) => Some(value_to_bytes(v)),
+        })
+        .collect();
+    NativeRow(values)
+}
+
+fn value_to_bytes(v: Value) -> Bytes {
+    match v {
+        Value::NULL => unreachable!("NULL handled before value_to_bytes"),
+        Value::Bytes(b) => Bytes::from(b),
+        Value::Int(i) => Bytes::from(i.to_string()),
+        Value::UInt(u) => Bytes::from(u.to_string()),
+        Value::Float(f) => Bytes::from(f.to_string()),
+        Value::Double(d) => Bytes::from(d.to_string()),
+        Value::Date(year, month, day, hour, min, sec, micros) => {
+            if hour == 0 && min == 0 && sec == 0 && micros == 0 {
+                Bytes::from(format!("{year:04}-{month:02}-{day:02}"))
+            } else if micros == 0 {
+                Bytes::from(format!(
+                    "{year:04}-{month:02}-{day:02} {hour:02}:{min:02}:{sec:02}"
+                ))
+            } else {
+                Bytes::from(format!(
+                    "{year:04}-{month:02}-{day:02} {hour:02}:{min:02}:{sec:02}.{micros:06}"
+                ))
+            }
+        }
+        Value::Time(neg, days, hours, mins, secs, micros) => {
+            let total_hours = days as i64 * 24 + hours as i64;
+            let sign = if neg { "-" } else { "" };
+            if micros == 0 {
+                Bytes::from(format!("{sign}{total_hours:02}:{mins:02}:{secs:02}"))
+            } else {
+                Bytes::from(format!(
+                    "{sign}{total_hours:02}:{mins:02}:{secs:02}.{micros:06}"
+                ))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Column type mapping: mysql_async ColumnType → NativeTypeKind
+// ---------------------------------------------------------------------------
+
+fn mysql_column_type_to_native(ct: ColumnType) -> NativeTypeInfo {
+    let kind = match ct {
+        ColumnType::MYSQL_TYPE_TINY => NativeTypeKind::TinyInt,
+        ColumnType::MYSQL_TYPE_SHORT | ColumnType::MYSQL_TYPE_YEAR => NativeTypeKind::SmallInt,
+        ColumnType::MYSQL_TYPE_INT24 | ColumnType::MYSQL_TYPE_LONG => NativeTypeKind::Int,
+        ColumnType::MYSQL_TYPE_LONGLONG => NativeTypeKind::BigInt,
+        ColumnType::MYSQL_TYPE_FLOAT => NativeTypeKind::Float,
+        ColumnType::MYSQL_TYPE_DOUBLE => NativeTypeKind::Double,
+        ColumnType::MYSQL_TYPE_DECIMAL | ColumnType::MYSQL_TYPE_NEWDECIMAL => {
+            NativeTypeKind::Decimal
+        }
+        ColumnType::MYSQL_TYPE_DATE | ColumnType::MYSQL_TYPE_NEWDATE => NativeTypeKind::Date,
+        ColumnType::MYSQL_TYPE_TIME | ColumnType::MYSQL_TYPE_TIME2 => NativeTypeKind::Time,
+        ColumnType::MYSQL_TYPE_DATETIME | ColumnType::MYSQL_TYPE_DATETIME2 => {
+            NativeTypeKind::DateTime
+        }
+        ColumnType::MYSQL_TYPE_TIMESTAMP | ColumnType::MYSQL_TYPE_TIMESTAMP2 => {
+            NativeTypeKind::Timestamp
+        }
+        ColumnType::MYSQL_TYPE_BLOB
+        | ColumnType::MYSQL_TYPE_LONG_BLOB
+        | ColumnType::MYSQL_TYPE_MEDIUM_BLOB
+        | ColumnType::MYSQL_TYPE_TINY_BLOB => NativeTypeKind::Text,
+        ColumnType::MYSQL_TYPE_JSON => NativeTypeKind::Json,
+        ColumnType::MYSQL_TYPE_BIT => NativeTypeKind::Binary,
+        _ => NativeTypeKind::Varchar,
+    };
+    NativeTypeInfo {
+        kind,
+        precision: None,
+        scale: None,
+        unsigned: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mysql_async::consts::ColumnType;
+
+    // ── value_to_bytes ────────────────────────────────────────────────────────
+
+    #[test]
+    fn bytes_value_roundtrips() {
+        assert_eq!(
+            value_to_bytes(Value::Bytes(b"hello".to_vec())),
+            b"hello"[..]
+        );
+    }
+
+    #[test]
+    fn int_value_formats_as_decimal() {
+        assert_eq!(value_to_bytes(Value::Int(-42)), "-42");
+    }
+
+    #[test]
+    fn uint_value_formats_as_decimal() {
+        assert_eq!(value_to_bytes(Value::UInt(u64::MAX)), u64::MAX.to_string());
+    }
+
+    #[test]
+    fn float_value() {
+        let b = value_to_bytes(Value::Float(1.5));
+        assert_eq!(b, "1.5");
+    }
+
+    #[test]
+    fn double_value() {
+        let b = value_to_bytes(Value::Double(1.23));
+        assert_eq!(b, "1.23");
+    }
+
+    // Date — pure date (no time component)
+    #[test]
+    fn date_only_formats_as_yyyy_mm_dd() {
+        let b = value_to_bytes(Value::Date(2024, 3, 15, 0, 0, 0, 0));
+        assert_eq!(b, "2024-03-15");
+    }
+
+    // Date — datetime without microseconds
+    #[test]
+    fn datetime_without_micros_formats_without_fractional() {
+        let b = value_to_bytes(Value::Date(2024, 3, 15, 10, 30, 45, 0));
+        assert_eq!(b, "2024-03-15 10:30:45");
+    }
+
+    // Date — datetime with microseconds
+    #[test]
+    fn datetime_with_micros_formats_six_fraction_digits() {
+        let b = value_to_bytes(Value::Date(2024, 3, 15, 10, 30, 45, 123456));
+        assert_eq!(b, "2024-03-15 10:30:45.123456");
+    }
+
+    // Date — zero-pad month and day
+    #[test]
+    fn date_zero_pads_month_and_day() {
+        let b = value_to_bytes(Value::Date(2024, 1, 5, 0, 0, 0, 0));
+        assert_eq!(b, "2024-01-05");
+    }
+
+    // Time — positive, no micros
+    #[test]
+    fn time_positive_no_micros() {
+        let b = value_to_bytes(Value::Time(false, 0, 8, 30, 0, 0));
+        assert_eq!(b, "08:30:00");
+    }
+
+    // Time — negative (MySQL TIME can be negative for intervals)
+    #[test]
+    fn time_negative_prefixes_minus() {
+        let b = value_to_bytes(Value::Time(true, 0, 1, 0, 0, 0));
+        assert_eq!(b, "-01:00:00");
+    }
+
+    // Time — multi-day spans fold into total hours
+    #[test]
+    fn time_multi_day_folds_into_hours() {
+        // 2 days + 3 hours = 51 hours
+        let b = value_to_bytes(Value::Time(false, 2, 3, 0, 0, 0));
+        assert_eq!(b, "51:00:00");
+    }
+
+    // Time — with micros
+    #[test]
+    fn time_with_micros_formats_fractional() {
+        let b = value_to_bytes(Value::Time(false, 0, 0, 0, 1, 500000));
+        assert_eq!(b, "00:00:01.500000");
+    }
+
+    // ── mysql_column_type_to_native ───────────────────────────────────────────
+
+    #[test]
+    fn tiny_maps_to_tinyint() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_TINY).kind,
+            NativeTypeKind::TinyInt
+        );
+    }
+
+    #[test]
+    fn longlong_maps_to_bigint() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_LONGLONG).kind,
+            NativeTypeKind::BigInt
+        );
+    }
+
+    #[test]
+    fn newdecimal_maps_to_decimal() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_NEWDECIMAL).kind,
+            NativeTypeKind::Decimal
+        );
+    }
+
+    #[test]
+    fn datetime2_maps_to_datetime() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_DATETIME2).kind,
+            NativeTypeKind::DateTime
+        );
+    }
+
+    #[test]
+    fn json_maps_to_json() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_JSON).kind,
+            NativeTypeKind::Json
+        );
+    }
+
+    #[test]
+    fn blob_maps_to_text() {
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_BLOB).kind,
+            NativeTypeKind::Text
+        );
+    }
+
+    #[test]
+    fn unknown_type_maps_to_varchar() {
+        // MYSQL_TYPE_STRING is a catch-all
+        assert_eq!(
+            mysql_column_type_to_native(ColumnType::MYSQL_TYPE_STRING).kind,
+            NativeTypeKind::Varchar
+        );
+    }
+
+    #[test]
+    fn column_type_always_returns_no_precision_or_scale() {
+        let info = mysql_column_type_to_native(ColumnType::MYSQL_TYPE_NEWDECIMAL);
+        assert!(info.precision.is_none());
+        assert!(info.scale.is_none());
+        assert!(!info.unsigned);
+    }
+}

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -288,6 +288,21 @@ impl SyncAdapter for StarRocksAdapter {
         EngineType::StarRocks
     }
 
+    fn connection_format(&self) -> crate::ConnectionFormat {
+        crate::ConnectionFormat::MysqlWire
+    }
+
+    async fn execute_native(
+        &self,
+        _protocol: &queryflux_core::query::FrontendProtocol,
+        sql: &str,
+        session: &SessionContext,
+        credentials: &queryflux_auth::QueryCredentials,
+        tags: &QueryTags,
+    ) -> crate::Result<crate::NativeExecution> {
+        crate::mysql_native::execute(&self.pool, sql, session, credentials, tags).await
+    }
+
     async fn execute_as_arrow(
         &self,
         sql: &str,

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 use futures::StreamExt;
 use queryflux_auth::{AuthContext, QueryCredentials};
 use queryflux_cluster_manager::ClusterGroupManager;
+use queryflux_core::native_result::NativeResultChunk;
 use queryflux_core::tags::{merge_tags, QueryTags};
 use queryflux_core::{
     error::{QueryFluxError, Result},
@@ -19,7 +20,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 use queryflux_engine_adapters::trino::api::TrinoResponse;
-use queryflux_engine_adapters::{AdapterKind, AsyncAdapter, SyncAdapter};
+use queryflux_engine_adapters::{AdapterKind, AsyncAdapter, ConnectionFormat, SyncAdapter};
 use queryflux_metrics::MetricsStore;
 use queryflux_translation::SchemaContext;
 
@@ -45,6 +46,18 @@ pub trait ResultSink: Send {
     async fn on_batch(&mut self, batch: &RecordBatch) -> Result<()>;
     async fn on_complete(&mut self, stats: &QueryStats) -> Result<()>;
     async fn on_error(&mut self, message: &str) -> Result<()>;
+
+    /// Receive a native result chunk (non-Arrow path).
+    ///
+    /// Called by `execute_native_to_sink` only when
+    /// `adapter.connection_format().matches_frontend(protocol)` is true — i.e. only for
+    /// sinks whose frontend protocol matches the backend's connection format.
+    /// The default returns `Err` to surface misconfiguration during development.
+    async fn on_native_chunk(&mut self, _chunk: &NativeResultChunk) -> Result<()> {
+        Err(queryflux_core::error::QueryFluxError::Engine(
+            "on_native_chunk not implemented for this sink".to_string(),
+        ))
+    }
 }
 
 /// Protocol-agnostic result of dispatching a query to an async (Trino) backend.
@@ -164,7 +177,7 @@ pub async fn dispatch_query(
         Some(AdapterKind::Sync(_)) => {
             state.metrics.on_query_finished(&group.0, &cluster_name.0);
             let _ = cluster_manager.release_cluster(&group, &cluster_name).await;
-            return Err(QueryFluxError::Engine(format!(
+            return Err(QueryFluxError::SyncEngineRequired(format!(
                 "Sync engine on async dispatch path: {cluster_name}"
             )));
         }
@@ -571,6 +584,13 @@ impl DispatchAdapter {
             Self::Async(a) => a.translation_target_dialect(),
         }
     }
+
+    fn connection_format(&self) -> ConnectionFormat {
+        match self {
+            Self::Sync(a) => a.connection_format(),
+            Self::Async(a) => a.connection_format(),
+        }
+    }
 }
 
 /// Everything resolved before execution begins on the sync path.
@@ -905,6 +925,120 @@ async fn execute_stream(
     (outcome, sink.on_complete(&stats).await)
 }
 
+/// Execute a query via the native (non-Arrow) path and stream `NativeResultChunk`s to `sink`.
+///
+/// Only called when `adapter.connection_format().matches_frontend(protocol)` is true.
+/// Mirrors the structure of `execute_stream` so metrics, error handling, and stats are identical.
+async fn execute_native_to_sink(
+    setup: &SyncQuerySetup,
+    protocol: &FrontendProtocol,
+    sink: &mut impl ResultSink,
+) -> (SyncOutcome, Result<()>) {
+    let elapsed = || setup.start.elapsed().as_millis() as u64;
+
+    // Native execution is only available on SyncAdapters — AsyncAdapters use their own
+    // Raw-bytes passthrough in dispatch_query and never reach execute_to_sink.
+    let sync_adapter = match &setup.adapter {
+        DispatchAdapter::Sync(a) => a,
+        DispatchAdapter::Async(_) => {
+            // Should never happen: async adapters don't match MysqlWire/PostgresWire formats.
+            // Fall through to a clear error rather than silently producing wrong results.
+            let msg = "execute_native_to_sink called for an async adapter — this is a bug";
+            warn!(id = %setup.ctx.query_id, "{msg}");
+            let outcome = SyncOutcome {
+                status: QueryStatus::Failed,
+                rows: None,
+                error: Some(msg.to_string()),
+                elapsed_ms: elapsed(),
+                engine_stats: None,
+            };
+            return (outcome, sink.on_error(msg).await);
+        }
+    };
+
+    let execution = match sync_adapter
+        .execute_native(
+            protocol,
+            &setup.translated,
+            &setup.ctx.session,
+            &setup.credentials,
+            &setup.ctx.query_tags,
+        )
+        .await
+    {
+        Ok(e) => e,
+        Err(e) => {
+            let msg = e.to_string();
+            warn!(
+                id = %setup.ctx.query_id,
+                cluster = %setup.ctx.cluster,
+                "execute_native failed: {msg}"
+            );
+            let outcome = SyncOutcome {
+                status: QueryStatus::Failed,
+                rows: None,
+                error: Some(msg.clone()),
+                elapsed_ms: elapsed(),
+                engine_stats: None,
+            };
+            return (outcome, sink.on_error(&msg).await);
+        }
+    };
+
+    let mut stream = execution.stream;
+    let mut stats_rx = execution.stats;
+    let mut rows_returned: u64 = 0;
+
+    while let Some(result) = stream.next().await {
+        match result {
+            Err(e) => {
+                let msg = e.to_string();
+                let outcome = SyncOutcome {
+                    status: QueryStatus::Failed,
+                    rows: None,
+                    error: Some(msg.clone()),
+                    elapsed_ms: elapsed(),
+                    engine_stats: None,
+                };
+                return (outcome, sink.on_error(&msg).await);
+            }
+            Ok(chunk) => {
+                rows_returned += chunk.rows.len() as u64;
+                if let Err(e) = sink.on_native_chunk(&chunk).await {
+                    let msg = e.to_string();
+                    let outcome = SyncOutcome {
+                        status: QueryStatus::Failed,
+                        rows: Some(rows_returned),
+                        error: Some(msg.clone()),
+                        elapsed_ms: elapsed(),
+                        engine_stats: None,
+                    };
+                    return (outcome, Err(e));
+                }
+            }
+        }
+    }
+
+    let elapsed_ms = elapsed();
+    let engine_stats = stats_rx.try_recv().ok().flatten();
+
+    let stats = QueryStats {
+        execution_duration_ms: elapsed_ms,
+        rows_returned,
+        ..Default::default()
+    };
+
+    let outcome = SyncOutcome {
+        status: QueryStatus::Success,
+        rows: Some(rows_returned),
+        error: None,
+        elapsed_ms,
+        engine_stats,
+    };
+
+    (outcome, sink.on_complete(&stats).await)
+}
+
 /// Execute a query against any backend and stream RecordBatches to `sink`.
 ///
 /// Used by all non-Trino-HTTP frontends (MySQL wire, Postgres wire, Flight SQL).
@@ -930,14 +1064,26 @@ pub async fn execute_to_sink(
         return sink.on_error(&msg).await;
     }
 
-    let mut setup = match setup_sync_query(state, sql, session, protocol, group, auth_ctx).await {
-        Ok(s) => s,
-        // Setup failed (no adapter, or translation error already recorded inside).
-        // No slot is held at this point — just notify the sink.
-        Err(e) => return sink.on_error(&e.to_string()).await,
-    };
+    let mut setup =
+        match setup_sync_query(state, sql, session, protocol.clone(), group, auth_ctx).await {
+            Ok(s) => s,
+            // Setup failed (no adapter, or translation error already recorded inside).
+            // No slot is held at this point — just notify the sink.
+            Err(e) => return sink.on_error(&e.to_string()).await,
+        };
 
-    let (outcome, sink_result) = execute_stream(&setup, sink).await;
+    // Native path: skip Arrow when backend connection format matches frontend protocol.
+    // All other guarantees (slot release, record_query) are upheld by this function's
+    // outer structure — only the inner execution subroutine is swapped.
+    let (outcome, sink_result) = if setup
+        .adapter
+        .connection_format()
+        .matches_frontend(&protocol)
+    {
+        execute_native_to_sink(&setup, &protocol, sink).await
+    } else {
+        execute_stream(&setup, sink).await
+    };
 
     // Guaranteed single exit: release slot, then record.
     // slot.release() is idempotent and sets released=true so Drop is a no-op.

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -4,8 +4,18 @@
 //! DBeaver, mysql CLI, JDBC, etc.) and dispatches queries through the normal
 //! QueryFlux routing/dispatch pipeline.
 //!
-//! All backends (DuckDB, StarRocks, Trino) are supported. Results are streamed
-//! as Arrow RecordBatches and serialised to MySQL text protocol on the fly.
+//! # Execution paths
+//!
+//! Results reach the client via one of two paths, chosen by dispatch:
+//!
+//! **Native path** (zero serialization) — when the backend adapter declares
+//! `ConnectionFormat::MysqlWire` (e.g. StarRocks, ClickHouse via `mysql_async`):
+//! driver values are text-encoded directly into `NativeResultChunk`s and written
+//! as MySQL text-protocol packets with no Arrow allocation in between.
+//!
+//! **Arrow fallback** — all other backends (DuckDB, Trino, ADBC engines):
+//! results arrive as Arrow `RecordBatch`es and are serialised to MySQL text
+//! protocol on the fly via `on_schema` / `on_batch`.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -23,6 +33,7 @@ use tracing::{debug, info, warn};
 use queryflux_auth::Credentials;
 use queryflux_core::{
     error::{QueryFluxError, Result},
+    native_result::{NativeColumn, NativeResultChunk, NativeTypeKind},
     query::{FrontendProtocol, QueryStats},
     session::SessionContext,
     tags::{parse_query_tags, QueryTags},
@@ -51,7 +62,10 @@ const MYSQL_TYPE_DOUBLE: u8 = 5;
 const MYSQL_TYPE_TIMESTAMP: u8 = 7;
 const MYSQL_TYPE_LONGLONG: u8 = 8;
 const MYSQL_TYPE_DATE: u8 = 10;
+const MYSQL_TYPE_TIME: u8 = 11;
 const MYSQL_TYPE_DATETIME: u8 = 12;
+const MYSQL_TYPE_NEWDECIMAL: u8 = 246;
+const MYSQL_TYPE_JSON: u8 = 245;
 const MYSQL_TYPE_BLOB: u8 = 252;
 const MYSQL_TYPE_VAR_STRING: u8 = 253;
 
@@ -632,6 +646,78 @@ impl ResultSink for MysqlResultSink {
         self.encode_and_send(build_err(1105, message));
         Ok(())
     }
+
+    async fn on_native_chunk(&mut self, chunk: &NativeResultChunk) -> Result<()> {
+        // On the first chunk, send column count + column definition packets + EOF.
+        if let Some(columns) = &chunk.columns {
+            let mut count_pkt = Vec::new();
+            write_lenenc_int(&mut count_pkt, columns.len() as u64);
+            self.encode_and_send(count_pkt);
+
+            for col in columns {
+                self.encode_and_send(build_column_def_from_native(col));
+            }
+
+            self.encode_and_send(build_eof());
+        }
+
+        // Encode each row as a MySQL text-protocol row data packet.
+        for row in &chunk.rows {
+            let mut row_pkt = Vec::new();
+            for value in &row.0 {
+                match value {
+                    None => row_pkt.push(0xfb), // NULL marker
+                    Some(bytes) => write_lenenc_str(&mut row_pkt, bytes),
+                }
+            }
+            self.encode_and_send(row_pkt);
+        }
+        Ok(())
+    }
+}
+
+// ── Native type helpers ───────────────────────────────────────────────────────
+
+fn native_type_to_mysql_type(kind: &NativeTypeKind) -> u8 {
+    match kind {
+        NativeTypeKind::Boolean | NativeTypeKind::TinyInt => MYSQL_TYPE_TINY,
+        NativeTypeKind::SmallInt => MYSQL_TYPE_SHORT,
+        NativeTypeKind::Int => MYSQL_TYPE_LONG,
+        NativeTypeKind::BigInt => MYSQL_TYPE_LONGLONG,
+        NativeTypeKind::Float => MYSQL_TYPE_FLOAT,
+        NativeTypeKind::Double => MYSQL_TYPE_DOUBLE,
+        NativeTypeKind::Decimal => MYSQL_TYPE_NEWDECIMAL,
+        NativeTypeKind::Date => MYSQL_TYPE_DATE,
+        NativeTypeKind::Time => MYSQL_TYPE_TIME,
+        NativeTypeKind::DateTime => MYSQL_TYPE_DATETIME,
+        NativeTypeKind::Timestamp => MYSQL_TYPE_TIMESTAMP,
+        NativeTypeKind::Binary | NativeTypeKind::Blob | NativeTypeKind::Text => MYSQL_TYPE_BLOB,
+        NativeTypeKind::Json => MYSQL_TYPE_JSON,
+        _ => MYSQL_TYPE_VAR_STRING, // Char, Varchar, Unknown
+    }
+}
+
+/// Build a MySQL ColumnDefinition41 packet from a `NativeColumn`.
+fn build_column_def_from_native(col: &NativeColumn) -> Vec<u8> {
+    let mut pkt = Vec::new();
+    write_lenenc_str(&mut pkt, b"def"); // catalog
+    write_lenenc_str(&mut pkt, b""); // schema
+    write_lenenc_str(&mut pkt, b""); // table
+    write_lenenc_str(&mut pkt, b""); // org_table
+    write_lenenc_str(&mut pkt, col.name.as_bytes()); // name
+    write_lenenc_str(&mut pkt, col.name.as_bytes()); // org_name
+    pkt.push(0x0c); // fixed-length block = 12
+    pkt.extend_from_slice(&0x21u16.to_le_bytes()); // charset: utf8mb4 (33)
+    pkt.extend_from_slice(&0xffffu32.to_le_bytes()); // max column length
+    pkt.push(native_type_to_mysql_type(&col.type_info.kind)); // type byte
+    let mut flags: u16 = if col.nullable { 0 } else { 0x0001 }; // NOT_NULL_FLAG
+    if col.type_info.unsigned {
+        flags |= 0x0020;
+    } // UNSIGNED_FLAG
+    pkt.extend_from_slice(&flags.to_le_bytes());
+    pkt.push(col.type_info.scale.unwrap_or(0)); // decimals
+    pkt.extend_from_slice(&[0, 0]); // filler
+    pkt
 }
 
 // ── Arrow type helpers ────────────────────────────────────────────────────────
@@ -1159,4 +1245,222 @@ fn read_nul_str(payload: &[u8], pos: &mut usize) -> String {
         *pos += 1; // consume NUL terminator
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::native_result::{NativeColumn, NativeTypeInfo, NativeTypeKind};
+
+    // ── native_type_to_mysql_type ─────────────────────────────────────────────
+
+    #[test]
+    fn tinyint_maps_to_mysql_tiny() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::TinyInt),
+            MYSQL_TYPE_TINY
+        );
+    }
+
+    #[test]
+    fn bigint_maps_to_mysql_longlong() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::BigInt),
+            MYSQL_TYPE_LONGLONG
+        );
+    }
+
+    #[test]
+    fn decimal_maps_to_mysql_newdecimal() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Decimal),
+            MYSQL_TYPE_NEWDECIMAL
+        );
+    }
+
+    #[test]
+    fn date_maps_to_mysql_date() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Date),
+            MYSQL_TYPE_DATE
+        );
+    }
+
+    #[test]
+    fn time_maps_to_mysql_time() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Time),
+            MYSQL_TYPE_TIME
+        );
+    }
+
+    #[test]
+    fn datetime_maps_to_mysql_datetime() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::DateTime),
+            MYSQL_TYPE_DATETIME
+        );
+    }
+
+    #[test]
+    fn timestamp_maps_to_mysql_timestamp() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Timestamp),
+            MYSQL_TYPE_TIMESTAMP
+        );
+    }
+
+    #[test]
+    fn json_maps_to_mysql_json() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Json),
+            MYSQL_TYPE_JSON
+        );
+    }
+
+    #[test]
+    fn text_maps_to_mysql_blob() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Text),
+            MYSQL_TYPE_BLOB
+        );
+    }
+
+    #[test]
+    fn varchar_maps_to_mysql_var_string() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Varchar),
+            MYSQL_TYPE_VAR_STRING
+        );
+    }
+
+    #[test]
+    fn unknown_maps_to_mysql_var_string() {
+        assert_eq!(
+            native_type_to_mysql_type(&NativeTypeKind::Unknown),
+            MYSQL_TYPE_VAR_STRING
+        );
+    }
+
+    // ── build_column_def_from_native — packet structure ───────────────────────
+    //
+    // ColumnDefinition41 layout for a column named "id" (2 bytes):
+    //   4  bytes: lenenc "def"       (1 len + 3 data)
+    //   1  byte:  lenenc ""          (schema)
+    //   1  byte:  lenenc ""          (table)
+    //   1  byte:  lenenc ""          (org_table)
+    //   3  bytes: lenenc "id"        (1 len + 2 data)
+    //   3  bytes: lenenc "id"        (org_name)
+    //   1  byte:  0x0c               (fixed-length-fields marker)
+    //   2  bytes: charset            (0x21 = utf8mb4)
+    //   4  bytes: max col len        (0xffff)
+    //   1  byte:  type
+    //   2  bytes: flags
+    //   1  byte:  decimals
+    //   2  bytes: filler             (0x00 0x00)
+    //
+    //  total = 26 bytes for name "id"
+
+    fn make_col(name: &str, kind: NativeTypeKind, nullable: bool, unsigned: bool) -> NativeColumn {
+        NativeColumn {
+            name: name.to_string(),
+            type_info: NativeTypeInfo {
+                kind,
+                precision: None,
+                scale: None,
+                unsigned,
+            },
+            nullable,
+        }
+    }
+
+    // Compute type-byte offset for a given column name length.
+    fn type_byte_offset(name_len: usize) -> usize {
+        4               // lenenc "def"
+        + 1             // lenenc ""  (schema)
+        + 1             // lenenc ""  (table)
+        + 1             // lenenc ""  (org_table)
+        + 1 + name_len  // lenenc name
+        + 1 + name_len  // lenenc org_name
+        + 1             // 0x0c marker
+        + 2             // charset
+        + 4 // max col len
+    }
+
+    #[test]
+    fn bigint_column_type_byte_is_longlong() {
+        let col = make_col("id", NativeTypeKind::BigInt, true, false);
+        let pkt = build_column_def_from_native(&col);
+        let type_pos = type_byte_offset("id".len());
+        assert_eq!(
+            pkt[type_pos], MYSQL_TYPE_LONGLONG,
+            "type byte should be LONGLONG"
+        );
+    }
+
+    #[test]
+    fn decimal_column_type_byte_is_newdecimal() {
+        let col = make_col("price", NativeTypeKind::Decimal, true, false);
+        let pkt = build_column_def_from_native(&col);
+        let type_pos = type_byte_offset("price".len());
+        assert_eq!(pkt[type_pos], MYSQL_TYPE_NEWDECIMAL);
+    }
+
+    #[test]
+    fn not_null_column_sets_not_null_flag() {
+        let col = make_col("id", NativeTypeKind::BigInt, false, false);
+        let pkt = build_column_def_from_native(&col);
+        let flags_pos = type_byte_offset("id".len()) + 1;
+        let flags = u16::from_le_bytes([pkt[flags_pos], pkt[flags_pos + 1]]);
+        assert_ne!(flags & 0x0001, 0, "NOT_NULL_FLAG should be set");
+    }
+
+    #[test]
+    fn nullable_column_clears_not_null_flag() {
+        let col = make_col("id", NativeTypeKind::BigInt, true, false);
+        let pkt = build_column_def_from_native(&col);
+        let flags_pos = type_byte_offset("id".len()) + 1;
+        let flags = u16::from_le_bytes([pkt[flags_pos], pkt[flags_pos + 1]]);
+        assert_eq!(
+            flags & 0x0001,
+            0,
+            "NOT_NULL_FLAG should be clear for nullable"
+        );
+    }
+
+    #[test]
+    fn unsigned_column_sets_unsigned_flag() {
+        let col = make_col("cnt", NativeTypeKind::BigInt, true, true);
+        let pkt = build_column_def_from_native(&col);
+        let flags_pos = type_byte_offset("cnt".len()) + 1;
+        let flags = u16::from_le_bytes([pkt[flags_pos], pkt[flags_pos + 1]]);
+        assert_ne!(flags & 0x0020, 0, "UNSIGNED_FLAG should be set");
+    }
+
+    #[test]
+    fn charset_is_utf8mb4() {
+        let col = make_col("s", NativeTypeKind::Varchar, true, false);
+        let pkt = build_column_def_from_native(&col);
+        // scan for the 0x0c fixed-length-fields marker and read the 2 charset bytes after it
+        let marker_pos = pkt.iter().position(|&b| b == 0x0c).expect("0x0c marker");
+        let charset = u16::from_le_bytes([pkt[marker_pos + 1], pkt[marker_pos + 2]]);
+        assert_eq!(charset, 0x21, "charset should be utf8mb4 (33 / 0x21)");
+    }
+
+    #[test]
+    fn packet_ends_with_zero_filler() {
+        let col = make_col("x", NativeTypeKind::Int, true, false);
+        let pkt = build_column_def_from_native(&col);
+        assert_eq!(pkt[pkt.len() - 2], 0, "penultimate filler byte should be 0");
+        assert_eq!(pkt[pkt.len() - 1], 0, "last filler byte should be 0");
+    }
+
+    #[test]
+    fn column_name_appears_in_packet() {
+        let col = make_col("my_column", NativeTypeKind::Varchar, true, false);
+        let pkt = build_column_def_from_native(&col);
+        let name_bytes = b"my_column";
+        let found = pkt.windows(name_bytes.len()).any(|w| w == name_bytes);
+        assert!(found, "column name bytes should appear in packet");
+    }
 }

--- a/examples/with-prometheus-grafana/docker-compose.yml
+++ b/examples/with-prometheus-grafana/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     ports:
       - "8080:8080"
       - "9000:9000"
+      - "8085:3000"  # Studio UI
     volumes:
       - ./config.yaml:/etc/queryflux/config.yaml:ro
     environment:

--- a/website/docs/architecture/adding-support/backend.md
+++ b/website/docs/architecture/adding-support/backend.md
@@ -49,13 +49,35 @@ Add top-level fields on **`ClusterConfig`** only if **YAML** users need them and
 
 ### Step 3 — Adapter module (`queryflux-engine-adapters`)
 
+Adapters implement one of two traits depending on their execution model:
+
+| Trait | Used when | Examples |
+|-------|-----------|---------|
+| `SyncAdapter` | Engine returns results synchronously (single round-trip or blocking call) | DuckDB, StarRocks, ADBC engines |
+| `AsyncAdapter` | Engine uses a submit-then-poll lifecycle across multiple HTTP requests | Trino, Athena |
+
+**Steps:**
+
 1. Add `src/your_engine/mod.rs` (or similar).
-2. Implement **`EngineAdapterTrait`** (`submit_query`, `poll_query`, `cancel_query`, `health_check`, `engine_type`, `supports_async`, plus optional methods like `execute_as_arrow`, `base_url`, catalog helpers — copy the shape from Trino or StarRocks).
-3. Implement **`descriptor() -> EngineDescriptor`**: `engine_key`, `display_name`, `connection_type`, `supported_auth`, **`config_fields`** (this is the schema for forms and `/admin/engine-registry`), `implemented: true` once wired.
-4. Implement **`try_from_config_json(..., json: &serde_json::Value, ...)`** for the DB path. Use **`queryflux_core::engine_registry`**: `json_str`, `json_bool`, **`parse_auth_from_config_json`** where auth matches existing patterns.
-5. Implement **`try_from_cluster_config(..., cfg: &ClusterConfig, ...)`** for YAML.
-6. Add **`YourEngineFactory`** (empty struct) and **`impl EngineAdapterFactory`** in the same module: `engine_key()`, `descriptor()`, `build_from_config_json` delegating to `try_from_config_json` and returning `Arc<dyn EngineAdapterTrait>`. For async construction (Athena-style), `try_from_config_json` is `async`; the trait is `async_trait`-based.
-7. Export the module from `crates/queryflux-engine-adapters/src/lib.rs` and add **Cargo.toml** dependencies for any new client libraries.
+2. Implement **`SyncAdapter`** or **`AsyncAdapter`** — pick the one that matches your engine's execution model. Copy the shape from StarRocks (`SyncAdapter`) or Trino (`AsyncAdapter`).
+   - Required methods: `execute_as_arrow` / `submit_query` + `poll_query` + `cancel_query`, `health_check`, `engine_type`, catalog helpers (`list_catalogs`, `list_databases`, `list_tables`, `describe_table`).
+3. **Declare `connection_format()`** — this is how dispatch knows which result-encoding path to use:
+
+   ```rust
+   fn connection_format(&self) -> ConnectionFormat {
+       ConnectionFormat::MysqlWire   // for mysql_async-backed engines
+       // ConnectionFormat::Arrow    // default — ADBC, DuckDB, in-process
+       // ConnectionFormat::PostgresWire // for tokio_postgres-backed engines
+   }
+   ```
+
+   If you return anything other than the default `Arrow`, you **must** also override **`execute_native`** to produce a `NativeExecution` stream. The shared helpers in `queryflux-engine-adapters::mysql_native` (for `mysql_async`) and `queryflux-engine-adapters::pg_native` (for `tokio_postgres`) cover the common cases — delegate to them rather than implementing row conversion yourself.
+
+4. Implement **`descriptor() -> EngineDescriptor`**: `engine_key`, `display_name`, `connection_type`, `supported_auth`, **`config_fields`** (this is the schema for forms and `/admin/engine-registry`), `implemented: true` once wired.
+5. Implement **`try_from_config_json(..., json: &serde_json::Value, ...)`** for the DB path. Use **`queryflux_core::engine_registry`**: `json_str`, `json_bool`, **`parse_auth_from_config_json`** where auth matches existing patterns.
+6. Implement **`try_from_cluster_config(..., cfg: &ClusterConfig, ...)`** for YAML.
+7. Add **`YourEngineFactory`** (empty struct) and **`impl EngineAdapterFactory`** in the same module: `engine_key()`, `descriptor()`, `build_from_config_json` delegating to `try_from_config_json` and returning `AdapterKind::Sync(...)` or `AdapterKind::Async(...)`. For async construction (Athena-style), `try_from_config_json` is `async`; the trait is `async_trait`-based.
+8. Export the module from `crates/queryflux-engine-adapters/src/lib.rs` and add **Cargo.toml** dependencies for any new client libraries.
 
 Use **`QueryFluxError::Engine(format!(...))`** and include the **`cluster_name_str`** argument in messages so logs show which cluster failed.
 
@@ -74,7 +96,7 @@ You normally **do not** edit `queryflux-persistence` for engine-specific JSON ke
 
 ### Step 6 — Frontends and tests
 
-- **`queryflux-frontend`**: Most engines need **no** change; execution goes through **`dispatch_query`** / **`execute_to_sink`**. Only add branches if you need a special path (like Trino raw HTTP).
+- **`queryflux-frontend`**: Most engines need **no** change; execution goes through **`dispatch_query`** / **`execute_to_sink`**. The native path (zero Arrow) is activated purely by returning the right `ConnectionFormat` in your adapter — no frontend changes required.
 - **E2E**: Add tests under **`crates/queryflux-e2e-tests`** if you can run the engine in Docker; see **`docker/test/docker-compose.test.yml`**.
 - Update **[system-map.md](../system-map.md)** if you maintain a supported-engines list there.
 
@@ -111,8 +133,8 @@ Studio lives in **`queryflux-studio/`** at the repo root (Next.js). It talks to 
 ### Rust
 
 - [ ] `EngineConfig` + `EngineType` + `engine_key` / `parse_engine_key` / `From<&EngineConfig> for EngineType` + `dialect()` if needed
-- [ ] `EngineAdapterTrait` + `descriptor()` + `try_from_config_json` + `try_from_cluster_config`
-- [ ] `YourEngineFactory` + `EngineAdapterFactory`
+- [ ] `SyncAdapter` or `AsyncAdapter` + `connection_format()` (+ `execute_native` if non-Arrow) + `descriptor()` + `try_from_config_json` + `try_from_cluster_config`
+- [ ] `YourEngineFactory` + `EngineAdapterFactory` returning `AdapterKind::Sync` or `AdapterKind::Async`
 - [ ] `registered_engines.rs`: `all_factories()` + `build_adapter` YAML arm
 - [ ] `cargo build -p queryflux` and smoke-test Postgres + YAML cluster load
 
@@ -137,6 +159,6 @@ Studio lives in **`queryflux-studio/`** at the repo root (Next.js). It talks to 
 **Key Rust files**
 
 - [`crates/queryflux/src/registered_engines.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux/src/registered_engines.rs) — `all_factories`, `build_adapter`, `build_adapter_from_record`
-- [`crates/queryflux-engine-adapters/src/lib.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-engine-adapters/src/lib.rs) — `EngineAdapterFactory`, `EngineAdapterTrait`
+- [`crates/queryflux-engine-adapters/src/lib.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-engine-adapters/src/lib.rs) — `EngineAdapterFactory`, `SyncAdapter`, `AsyncAdapter`, `ConnectionFormat`, `AdapterKind`
 - [`crates/queryflux-core/src/engine_registry.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-core/src/engine_registry.rs) — `engine_key`, `parse_engine_key`, `parse_auth_from_config_json`
 - [`crates/queryflux-persistence/src/cluster_config.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-persistence/src/cluster_config.rs) — row types; engine config stored as JSONB

--- a/website/docs/architecture/frontends/mysql-wire.md
+++ b/website/docs/architecture/frontends/mysql-wire.md
@@ -50,6 +50,18 @@ Queries execute **synchronously** via `execute_to_sink`. Results stream as MySQL
 3. Row data packets (text values).
 4. EOF / OK packet.
 
+### Native path vs. Arrow fallback
+
+The dispatch layer chooses between two result-encoding paths based on the backend's `ConnectionFormat`:
+
+| Backend | `ConnectionFormat` | Path |
+|---------|-------------------|------|
+| StarRocks, ClickHouse (`mysql_async` pool) | `MysqlWire` | **Native** — driver values encoded directly to `NativeResultChunk`; no Arrow allocation |
+| DuckDB, ADBC engines (Snowflake, Databricks) | `Arrow` | **Arrow fallback** — `RecordBatch` stream re-encoded to MySQL text protocol |
+| Trino (HTTP async) | `TrinoHttp` | **Arrow fallback** — internal submit+poll loop returns Arrow |
+
+When backend and frontend formats match (`MysqlWire` ↔ `MySqlWire`), the entire Arrow columnar allocation is skipped. This also preserves type precision for `DECIMAL`, `DATETIME(6)`, and unsigned integers that would otherwise be approximated through the Arrow type system.
+
 ## Built-in query handling
 
 The MySQL frontend intercepts several common queries that clients and drivers send during connection setup:

--- a/website/docs/architecture/frontends/overview.md
+++ b/website/docs/architecture/frontends/overview.md
@@ -44,12 +44,30 @@ Client  ──(native protocol)──►  Frontend Listener
 
 ### Dispatch paths
 
-The dispatch layer offers two execution models:
+The dispatch layer offers three execution paths:
 
 | Path | Used by | Behavior |
 |------|---------|----------|
-| **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. |
-| **`execute_to_sink`** | All other frontends + Trino HTTP sync fallback | Wait for cluster capacity (backoff), execute query to completion, stream Arrow batches through a `ResultSink` that encodes the native protocol response. |
+| **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. Falls back to `execute_to_sink` when a sync adapter is selected from a mixed-engine group. |
+| **`execute_to_sink` — native** | MySQL wire ↔ `MysqlWire` backend; Postgres wire ↔ `PostgresWire` backend | Wait for cluster capacity, call `execute_native` on the adapter, stream `NativeResultChunk`s directly to the sink. **Zero Arrow allocation.** |
+| **`execute_to_sink` — Arrow** | All other frontend/backend combinations | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
+
+#### Protocol matching (`ConnectionFormat`)
+
+Each adapter declares the wire format it natively produces via `connection_format()`. Dispatch compares this against the incoming frontend protocol — when they match, the native (zero-serialization) path is taken; otherwise the Arrow path is used as a universal fallback.
+
+```
+Adapter declares:            Frontend needs:         Dispatch:
+Arrow (ADBC/DuckDB)      ↔  FlightSql       → match  → Arrow passthrough (optimal)
+MysqlWire (mysql_async)  ↔  MySqlWire       → match  → native NativeResultChunk path
+PostgresWire (tokio-pg)  ↔  PostgresWire    → match  → native NativeResultChunk path
+TrinoHttp                ↔  TrinoHttp       → match  → Raw bytes passthrough
+
+MysqlWire                ↔  FlightSql       → no match → Arrow conversion
+Arrow                    ↔  MySqlWire       → no match → Arrow conversion
+```
+
+The `ConnectionFormat` declaration is the only thing an adapter needs to change to opt into the native path — dispatch and frontends require no per-engine changes.
 
 ### SessionContext
 

--- a/website/docs/architecture/system-map.md
+++ b/website/docs/architecture/system-map.md
@@ -48,6 +48,8 @@ Client (Trino CLI / psql / mysql / DBI)
 
 The frontend never knows which engine it's talking to. The engine adapter never knows which client protocol was used. The dispatch layer in the middle is the only place that bridges them.
 
+When the backend's connection format matches the frontend protocol (e.g. `mysql_async` backend → MySQL wire client), dispatch takes a **native path** that skips Arrow entirely — driver values are text-encoded directly into the client's wire format with no columnar allocation in between.
+
 ---
 
 ## Workspace Layout
@@ -178,13 +180,14 @@ pub trait RouterTrait: Send + Sync {
 
 ### Engine Adapters
 
-| Engine | Status | Execution model |
-|---|---|---|
-| Trino | **Done** | Async HTTP — transparent `nextUri` proxying |
-| DuckDB | **Done** | Sync embedded — `spawn_blocking` + Arrow result set |
-| StarRocks | **Done** | MySQL protocol — sync Arrow path via `execute_as_arrow` |
-| Athena | **Done** | Async AWS SDK — `StartQueryExecution` → poll → `GetQueryResults` |
-| ClickHouse | Planned | — |
+| Engine | Status | `ConnectionFormat` | Execution model |
+|---|---|---|---|
+| Trino (HTTP) | **Done** | `TrinoHttp` | Async — transparent `nextUri` proxying; raw bytes, zero copy |
+| Trino (ADBC) | **Done** | `Arrow` | Sync — ADBC driver, Arrow result set |
+| DuckDB | **Done** | `Arrow` | Sync embedded — `spawn_blocking` + Arrow result set |
+| StarRocks | **Done** | `MysqlWire` | Sync — `mysql_async` pool; native path (zero Arrow) for MySQL wire clients |
+| Athena | **Done** | `Arrow` | Async AWS SDK — `StartQueryExecution` → poll → `GetQueryResults` |
+| ClickHouse | Planned | `MysqlWire` / `Arrow` / `ClickHouseHttp` | Depends on configured connection type |
 
 ### Routers
 

--- a/website/versioned_docs/version-0.1.0/architecture/adding-support/backend.md
+++ b/website/versioned_docs/version-0.1.0/architecture/adding-support/backend.md
@@ -49,13 +49,35 @@ Add top-level fields on **`ClusterConfig`** only if **YAML** users need them and
 
 ### Step 3 — Adapter module (`queryflux-engine-adapters`)
 
+Adapters implement one of two traits depending on their execution model:
+
+| Trait | Used when | Examples |
+|-------|-----------|---------|
+| `SyncAdapter` | Engine returns results synchronously (single round-trip or blocking call) | DuckDB, StarRocks, ADBC engines |
+| `AsyncAdapter` | Engine uses a submit-then-poll lifecycle across multiple HTTP requests | Trino, Athena |
+
+**Steps:**
+
 1. Add `src/your_engine/mod.rs` (or similar).
-2. Implement **`EngineAdapterTrait`** (`submit_query`, `poll_query`, `cancel_query`, `health_check`, `engine_type`, `supports_async`, plus optional methods like `execute_as_arrow`, `base_url`, catalog helpers — copy the shape from Trino or StarRocks).
-3. Implement **`descriptor() -> EngineDescriptor`**: `engine_key`, `display_name`, `connection_type`, `supported_auth`, **`config_fields`** (this is the schema for forms and `/admin/engine-registry`), `implemented: true` once wired.
-4. Implement **`try_from_config_json(..., json: &serde_json::Value, ...)`** for the DB path. Use **`queryflux_core::engine_registry`**: `json_str`, `json_bool`, **`parse_auth_from_config_json`** where auth matches existing patterns.
-5. Implement **`try_from_cluster_config(..., cfg: &ClusterConfig, ...)`** for YAML.
-6. Add **`YourEngineFactory`** (empty struct) and **`impl EngineAdapterFactory`** in the same module: `engine_key()`, `descriptor()`, `build_from_config_json` delegating to `try_from_config_json` and returning `Arc<dyn EngineAdapterTrait>`. For async construction (Athena-style), `try_from_config_json` is `async`; the trait is `async_trait`-based.
-7. Export the module from `crates/queryflux-engine-adapters/src/lib.rs` and add **Cargo.toml** dependencies for any new client libraries.
+2. Implement **`SyncAdapter`** or **`AsyncAdapter`** — pick the one that matches your engine's execution model. Copy the shape from StarRocks (`SyncAdapter`) or Trino (`AsyncAdapter`).
+   - Required methods: `execute_as_arrow` / `submit_query` + `poll_query` + `cancel_query`, `health_check`, `engine_type`, catalog helpers (`list_catalogs`, `list_databases`, `list_tables`, `describe_table`).
+3. **Declare `connection_format()`** — this is how dispatch knows which result-encoding path to use:
+
+   ```rust
+   fn connection_format(&self) -> ConnectionFormat {
+       ConnectionFormat::MysqlWire   // for mysql_async-backed engines
+       // ConnectionFormat::Arrow    // default — ADBC, DuckDB, in-process
+       // ConnectionFormat::PostgresWire // for tokio_postgres-backed engines
+   }
+   ```
+
+   If you return anything other than the default `Arrow`, you **must** also override **`execute_native`** to produce a `NativeExecution` stream. The shared helpers in `queryflux-engine-adapters::mysql_native` (for `mysql_async`) and `queryflux-engine-adapters::pg_native` (for `tokio_postgres`) cover the common cases — delegate to them rather than implementing row conversion yourself.
+
+4. Implement **`descriptor() -> EngineDescriptor`**: `engine_key`, `display_name`, `connection_type`, `supported_auth`, **`config_fields`** (this is the schema for forms and `/admin/engine-registry`), `implemented: true` once wired.
+5. Implement **`try_from_config_json(..., json: &serde_json::Value, ...)`** for the DB path. Use **`queryflux_core::engine_registry`**: `json_str`, `json_bool`, **`parse_auth_from_config_json`** where auth matches existing patterns.
+6. Implement **`try_from_cluster_config(..., cfg: &ClusterConfig, ...)`** for YAML.
+7. Add **`YourEngineFactory`** (empty struct) and **`impl EngineAdapterFactory`** in the same module: `engine_key()`, `descriptor()`, `build_from_config_json` delegating to `try_from_config_json` and returning `AdapterKind::Sync(...)` or `AdapterKind::Async(...)`. For async construction (Athena-style), `try_from_config_json` is `async`; the trait is `async_trait`-based.
+8. Export the module from `crates/queryflux-engine-adapters/src/lib.rs` and add **Cargo.toml** dependencies for any new client libraries.
 
 Use **`QueryFluxError::Engine(format!(...))`** and include the **`cluster_name_str`** argument in messages so logs show which cluster failed.
 
@@ -74,7 +96,7 @@ You normally **do not** edit `queryflux-persistence` for engine-specific JSON ke
 
 ### Step 6 — Frontends and tests
 
-- **`queryflux-frontend`**: Most engines need **no** change; execution goes through **`dispatch_query`** / **`execute_to_sink`**. Only add branches if you need a special path (like Trino raw HTTP).
+- **`queryflux-frontend`**: Most engines need **no** change; execution goes through **`dispatch_query`** / **`execute_to_sink`**. The native path (zero Arrow) is activated purely by returning the right `ConnectionFormat` in your adapter — no frontend changes required.
 - **E2E**: Add tests under **`crates/queryflux-e2e-tests`** if you can run the engine in Docker; see **`docker/test/docker-compose.test.yml`**.
 - Update **[system-map.md](../system-map.md)** if you maintain a supported-engines list there.
 
@@ -111,8 +133,8 @@ Studio lives in **`queryflux-studio/`** at the repo root (Next.js). It talks to 
 ### Rust
 
 - [ ] `EngineConfig` + `EngineType` + `engine_key` / `parse_engine_key` / `From<&EngineConfig> for EngineType` + `dialect()` if needed
-- [ ] `EngineAdapterTrait` + `descriptor()` + `try_from_config_json` + `try_from_cluster_config`
-- [ ] `YourEngineFactory` + `EngineAdapterFactory`
+- [ ] `SyncAdapter` or `AsyncAdapter` + `connection_format()` (+ `execute_native` if non-Arrow) + `descriptor()` + `try_from_config_json` + `try_from_cluster_config`
+- [ ] `YourEngineFactory` + `EngineAdapterFactory` returning `AdapterKind::Sync` or `AdapterKind::Async`
 - [ ] `registered_engines.rs`: `all_factories()` + `build_adapter` YAML arm
 - [ ] `cargo build -p queryflux` and smoke-test Postgres + YAML cluster load
 
@@ -137,6 +159,6 @@ Studio lives in **`queryflux-studio/`** at the repo root (Next.js). It talks to 
 **Key Rust files**
 
 - [`crates/queryflux/src/registered_engines.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux/src/registered_engines.rs) — `all_factories`, `build_adapter`, `build_adapter_from_record`
-- [`crates/queryflux-engine-adapters/src/lib.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-engine-adapters/src/lib.rs) — `EngineAdapterFactory`, `EngineAdapterTrait`
+- [`crates/queryflux-engine-adapters/src/lib.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-engine-adapters/src/lib.rs) — `EngineAdapterFactory`, `SyncAdapter`, `AsyncAdapter`, `ConnectionFormat`, `AdapterKind`
 - [`crates/queryflux-core/src/engine_registry.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-core/src/engine_registry.rs) — `engine_key`, `parse_engine_key`, `parse_auth_from_config_json`
 - [`crates/queryflux-persistence/src/cluster_config.rs`](https://github.com/lakeops-org/queryflux/blob/main/crates/queryflux-persistence/src/cluster_config.rs) — row types; engine config stored as JSONB

--- a/website/versioned_docs/version-0.1.0/architecture/frontends/mysql-wire.md
+++ b/website/versioned_docs/version-0.1.0/architecture/frontends/mysql-wire.md
@@ -50,6 +50,18 @@ Queries execute **synchronously** via `execute_to_sink`. Results stream as MySQL
 3. Row data packets (text values).
 4. EOF / OK packet.
 
+### Native path vs. Arrow fallback
+
+The dispatch layer chooses between two result-encoding paths based on the backend's `ConnectionFormat`:
+
+| Backend | `ConnectionFormat` | Path |
+|---------|-------------------|------|
+| StarRocks, ClickHouse (`mysql_async` pool) | `MysqlWire` | **Native** — driver values encoded directly to `NativeResultChunk`; no Arrow allocation |
+| DuckDB, ADBC engines (Snowflake, Databricks) | `Arrow` | **Arrow fallback** — `RecordBatch` stream re-encoded to MySQL text protocol |
+| Trino (HTTP async) | `TrinoHttp` | **Arrow fallback** — internal submit+poll loop returns Arrow |
+
+When backend and frontend formats match (`MysqlWire` ↔ `MySqlWire`), the entire Arrow columnar allocation is skipped. This also preserves type precision for `DECIMAL`, `DATETIME(6)`, and unsigned integers that would otherwise be approximated through the Arrow type system.
+
 ## Built-in query handling
 
 The MySQL frontend intercepts several common queries that clients and drivers send during connection setup:

--- a/website/versioned_docs/version-0.1.0/architecture/frontends/overview.md
+++ b/website/versioned_docs/version-0.1.0/architecture/frontends/overview.md
@@ -44,12 +44,30 @@ Client  ──(native protocol)──►  Frontend Listener
 
 ### Dispatch paths
 
-The dispatch layer offers two execution models:
+The dispatch layer offers three execution paths:
 
 | Path | Used by | Behavior |
 |------|---------|----------|
-| **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. |
-| **`execute_to_sink`** | All other frontends + Trino HTTP sync fallback | Wait for cluster capacity (backoff), execute query to completion, stream Arrow batches through a `ResultSink` that encodes the native protocol response. |
+| **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. Falls back to `execute_to_sink` when a sync adapter is selected from a mixed-engine group. |
+| **`execute_to_sink` — native** | MySQL wire ↔ `MysqlWire` backend; Postgres wire ↔ `PostgresWire` backend | Wait for cluster capacity, call `execute_native` on the adapter, stream `NativeResultChunk`s directly to the sink. **Zero Arrow allocation.** |
+| **`execute_to_sink` — Arrow** | All other frontend/backend combinations | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
+
+#### Protocol matching (`ConnectionFormat`)
+
+Each adapter declares the wire format it natively produces via `connection_format()`. Dispatch compares this against the incoming frontend protocol — when they match, the native (zero-serialization) path is taken; otherwise the Arrow path is used as a universal fallback.
+
+```
+Adapter declares:            Frontend needs:         Dispatch:
+Arrow (ADBC/DuckDB)      ↔  FlightSql       → match  → Arrow passthrough (optimal)
+MysqlWire (mysql_async)  ↔  MySqlWire       → match  → native NativeResultChunk path
+PostgresWire (tokio-pg)  ↔  PostgresWire    → match  → native NativeResultChunk path
+TrinoHttp                ↔  TrinoHttp       → match  → Raw bytes passthrough
+
+MysqlWire                ↔  FlightSql       → no match → Arrow conversion
+Arrow                    ↔  MySqlWire       → no match → Arrow conversion
+```
+
+The `ConnectionFormat` declaration is the only thing an adapter needs to change to opt into the native path — dispatch and frontends require no per-engine changes.
 
 ### SessionContext
 

--- a/website/versioned_docs/version-0.1.0/architecture/system-map.md
+++ b/website/versioned_docs/version-0.1.0/architecture/system-map.md
@@ -48,6 +48,8 @@ Client (Trino CLI / psql / mysql / DBI)
 
 The frontend never knows which engine it's talking to. The engine adapter never knows which client protocol was used. The dispatch layer in the middle is the only place that bridges them.
 
+When the backend's connection format matches the frontend protocol (e.g. `mysql_async` backend → MySQL wire client), dispatch takes a **native path** that skips Arrow entirely — driver values are text-encoded directly into the client's wire format with no columnar allocation in between.
+
 ---
 
 ## Workspace Layout
@@ -178,13 +180,14 @@ pub trait RouterTrait: Send + Sync {
 
 ### Engine Adapters
 
-| Engine | Status | Execution model |
-|---|---|---|
-| Trino | **Done** | Async HTTP — transparent `nextUri` proxying |
-| DuckDB | **Done** | Sync embedded — `spawn_blocking` + Arrow result set |
-| StarRocks | **Done** | MySQL protocol — sync Arrow path via `execute_as_arrow` |
-| Athena | **Done** | Async AWS SDK — `StartQueryExecution` → poll → `GetQueryResults` |
-| ClickHouse | Planned | — |
+| Engine | Status | `ConnectionFormat` | Execution model |
+|---|---|---|---|
+| Trino (HTTP) | **Done** | `TrinoHttp` | Async — transparent `nextUri` proxying; raw bytes, zero copy |
+| Trino (ADBC) | **Done** | `Arrow` | Sync — ADBC driver, Arrow result set |
+| DuckDB | **Done** | `Arrow` | Sync embedded — `spawn_blocking` + Arrow result set |
+| StarRocks | **Done** | `MysqlWire` | Sync — `mysql_async` pool; native path (zero Arrow) for MySQL wire clients |
+| Athena | **Done** | `Arrow` | Async AWS SDK — `StartQueryExecution` → poll → `GetQueryResults` |
+| ClickHouse | Planned | `MysqlWire` / `Arrow` / `ClickHouseHttp` | Depends on configured connection type |
 
 ### Routers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native query result streaming support for MySQL-wire protocol backends, eliminating Arrow serialization overhead when backend and frontend wire formats match.
  * StarRocks adapter now supports direct MySQL-wire protocol result encoding without Arrow conversion.
  * Dispatch logic automatically selects optimal result-encoding path based on backend connection format.

* **Documentation**
  * Updated backend adapter integration guide and architecture documentation to reflect new native execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->