### PR TITLE
docs(website): community page and Slack invite

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -130,6 +130,11 @@ const config: Config = {
           className: 'navbar-item-docs-mobile',
         },
         {
+          to: '/community',
+          label: 'Community',
+          position: 'left',
+        },
+        {
           type: 'docsVersionDropdown',
           position: 'left',
           className: 'navbar-item-collapse-mobile',
@@ -163,6 +168,7 @@ const config: Config = {
         {
           title: 'Project',
           items: [
+            {label: 'Community', to: '/community'},
             {label: 'Development', to: '/docs/development'},
             {label: 'Contribute', to: '/docs/contribute'},
             {label: 'Roadmap', to: '/docs/roadmap'},

--- a/website/src/pages/community.module.css
+++ b/website/src/pages/community.module.css
@@ -1,0 +1,223 @@
+/* Community page — hero + two-column involvement cards (Slack + docs) */
+
+.page {
+  --community-card-radius: 14px;
+}
+
+.hero {
+  position: relative;
+  padding: 3rem 0 2.5rem;
+  overflow: hidden;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.heroGlow {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(to bottom, rgba(237, 233, 254, 0.45) 0%, rgba(255, 255, 255, 0.4) 45%, transparent 100%),
+    radial-gradient(ellipse 70% 55% at 50% -10%, rgba(167, 139, 250, 0.22) 0%, transparent 55%),
+    radial-gradient(ellipse 50% 40% at 90% 20%, rgba(192, 132, 252, 0.12) 0%, transparent 50%),
+    radial-gradient(ellipse 45% 35% at 10% 30%, rgba(124, 58, 237, 0.08) 0%, transparent 50%);
+}
+
+html[data-theme='dark'] .hero {
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+  color: #e7e7e7;
+}
+
+html[data-theme='dark'] .heroGlow {
+  background:
+    linear-gradient(to bottom, rgba(88, 28, 135, 0.2) 0%, rgba(0, 0, 0, 0.92) 55%, #000000 100%),
+    radial-gradient(ellipse 68% 52% at 50% 0%, rgba(124, 58, 237, 0.22) 0%, transparent 58%),
+    radial-gradient(ellipse 48% 38% at 82% 12%, rgba(234, 88, 12, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse 40% 32% at 18% 28%, rgba(167, 139, 250, 0.06) 0%, transparent 50%);
+}
+
+.heroInner {
+  position: relative;
+  text-align: center;
+  max-width: var(--qf-content-max);
+  margin: 0 auto;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 2.65rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  margin: 0 0 0.65rem;
+}
+
+.lead {
+  font-size: 1.15rem;
+  line-height: 1.65;
+  color: #475569;
+  margin: 0 auto 1.5rem;
+  max-width: var(--qf-leadin-max);
+}
+
+html[data-theme='dark'] .lead {
+  color: #cbd5e1;
+}
+
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+}
+
+.slackButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #4a154b;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #fff !important;
+  box-shadow: 0 4px 18px rgba(74, 21, 75, 0.35);
+}
+
+.slackButton:hover {
+  background: #5c1a5e;
+  color: #fff !important;
+  box-shadow: 0 6px 24px rgba(74, 21, 75, 0.45);
+}
+
+.slackIcon {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.main {
+  padding: 2.75rem 0 3.5rem;
+  background: var(--ifm-background-color);
+}
+
+.sectionTitle {
+  text-align: center;
+  font-size: clamp(1.35rem, 2.5vw, 1.6rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+}
+
+.sectionSub {
+  text-align: center;
+  color: #64748b;
+  max-width: var(--qf-section-sub-max);
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+}
+
+html[data-theme='dark'] .sectionSub {
+  color: #94a3b8;
+}
+
+.cardGrid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: var(--qf-page-max);
+  margin: 0 auto;
+}
+
+@media screen and (max-width: 996px) {
+  .cardGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  position: relative;
+  padding: 1.5rem 1.5rem 1.4rem;
+  border-radius: var(--community-card-radius);
+  border: 1px solid rgba(124, 58, 237, 0.18);
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 2px 16px rgba(15, 23, 42, 0.06);
+}
+
+html[data-theme='dark'] .card {
+  border-color: rgba(167, 139, 250, 0.2);
+  box-shadow: 0 2px 20px rgba(0, 0, 0, 0.35);
+}
+
+.cardAccent {
+  position: absolute;
+  top: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 3px;
+  border-radius: 0 0 4px 4px;
+  background: linear-gradient(90deg, #7c3aed, #ea580c);
+  opacity: 0.85;
+}
+
+.cardIcon {
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-bottom: 0.85rem;
+  color: var(--ifm-color-primary);
+}
+
+.cardIcon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.cardTitle {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.65rem;
+  letter-spacing: -0.02em;
+}
+
+.cardText {
+  margin: 0 0 1rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.98rem;
+}
+
+html[data-theme='dark'] .cardText {
+  color: #cbd5e1;
+}
+
+.bullets {
+  margin: 0 0 1.15rem;
+  padding-left: 1.15rem;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.95rem;
+}
+
+html[data-theme='dark'] .bullets {
+  color: #94a3b8;
+}
+
+.bullets li {
+  margin-bottom: 0.35rem;
+}
+
+.cardActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.wideCard {
+  margin-top: 1.25rem;
+  max-width: var(--qf-page-max);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media screen and (max-width: 996px) {
+  .hero {
+    padding: 2.25rem 0 2rem;
+  }
+}

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -1,0 +1,168 @@
+import type {ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+import styles from './community.module.css';
+
+/** Slack workspace invite (Queryflux / query-flux). */
+const SLACK_WORKSPACE_URL =
+  'https://join.slack.com/t/query-flux/shared_invite/zt-3v7qedxj9-o8ElCLGK0UXT8xBU0_bD8w';
+
+const COMMUNITY_DESCRIPTION =
+  'Connect with QueryFlux users and contributors: documentation, GitHub, and the Queryflux Slack workspace.';
+
+const SlackGlyph = (): ReactNode => (
+  <svg className={styles.slackIcon} viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="currentColor"
+      d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834V5.042zm0 1.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.876a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.123 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.876a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.876zm-1.313 0a2.528 2.528 0 0 1-2.521 2.521 2.527 2.527 0 0 1-2.521-2.521V2.522A2.528 2.528 0 0 1 15.165 0a2.528 2.528 0 0 1 2.521 2.522v6.354zm-2.521 10.123a2.528 2.528 0 0 1 2.521 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.521-2.522v-2.522h2.521zm0-1.313a2.527 2.527 0 0 1-2.521-2.521 2.527 2.527 0 0 1 2.521-2.521h6.313A2.528 2.528 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.521h-6.313z"
+    />
+  </svg>
+);
+
+export default function Community(): ReactNode {
+  return (
+    <Layout title="Community" description={COMMUNITY_DESCRIPTION}>
+      <div className={styles.page}>
+        <header className={styles.hero}>
+          <div className={styles.heroGlow} aria-hidden />
+          <div className={clsx('container', styles.heroInner)}>
+            <Heading as="h1" className={styles.title}>
+              Community
+            </Heading>
+            <p className={styles.lead}>
+              Open and inclusive — help shape QueryFlux. Use the docs for deep dives, GitHub for
+              code and issues, and Slack for quick questions and real-time chat with other users.
+            </p>
+            <div className={styles.ctaRow}>
+              <Link
+                className={clsx('button button--lg', styles.slackButton)}
+                href={SLACK_WORKSPACE_URL}
+                target="_blank"
+                rel="noopener noreferrer">
+                <SlackGlyph />
+                Join Slack (Queryflux)
+              </Link>
+              <Link className="button button--lg button--primary" to="/docs/intro">
+                Documentation
+              </Link>
+              <Link
+                className="button button--lg button--outline"
+                href="https://github.com/lakeops-org/queryflux"
+                target="_blank"
+                rel="noopener noreferrer">
+                GitHub
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        <main className={styles.main}>
+          <div className="container">
+            <h2 className={styles.sectionTitle}>How to get involved</h2>
+            <p className={styles.sectionSub}>
+              Pick the channel that fits your question — searchable reference here, fast feedback
+              in Slack, and contributions always welcome on GitHub.
+            </p>
+
+            <div className={styles.cardGrid}>
+              <article className={styles.card}>
+                <div className={styles.cardAccent} aria-hidden />
+                <div className={styles.cardIcon} aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+                    <line x1="8" y1="7" x2="16" y2="7" />
+                    <line x1="8" y1="11" x2="14" y2="11" />
+                  </svg>
+                </div>
+                <Heading as="h3" className={styles.cardTitle}>
+                  Documentation
+                </Heading>
+                <p className={styles.cardText}>
+                  Tutorials, configuration reference, and architecture — ideal for technical depth
+                  and answers you can bookmark.
+                </p>
+                <ul className={styles.bullets}>
+                  <li>Searchable guides and YAML reference</li>
+                  <li>Best for setup, routing rules, and operations</li>
+                </ul>
+                <div className={styles.cardActions}>
+                  <Link className="button button--primary" to="/docs/intro">
+                    Open docs
+                  </Link>
+                </div>
+              </article>
+
+              <article className={styles.card}>
+                <div className={styles.cardAccent} aria-hidden />
+                <div className={styles.cardIcon} aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834V5.042zm0 1.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.876a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.123 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.876a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.876zm-1.313 0a2.528 2.528 0 0 1-2.521 2.521 2.527 2.527 0 0 1-2.521-2.521V2.522A2.528 2.528 0 0 1 15.165 0a2.528 2.528 0 0 1 2.521 2.522v6.354zm-2.521 10.123a2.528 2.528 0 0 1 2.521 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.521-2.522v-2.522h2.521zm0-1.313a2.527 2.527 0 0 1-2.521-2.521 2.527 2.527 0 0 1 2.521-2.521h6.313A2.528 2.528 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.521h-6.313z" />
+                  </svg>
+                </div>
+                <Heading as="h3" className={styles.cardTitle}>
+                  Slack — Queryflux workspace
+                </Heading>
+                <p className={styles.cardText}>
+                  Chat with peers, ask quick questions, and share what you are building. Use the invite
+                  link to join the Queryflux workspace if you are not a member yet.
+                </p>
+                <ul className={styles.bullets}>
+                  <li>Real-time help and shorter threads</li>
+                  <li>Workspace URL: query-flux.slack.com</li>
+                </ul>
+                <div className={styles.cardActions}>
+                  <Link
+                    className={clsx('button', styles.slackButton)}
+                    href={SLACK_WORKSPACE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    <SlackGlyph />
+                    Open Slack
+                  </Link>
+                </div>
+              </article>
+            </div>
+
+            <article className={clsx(styles.card, styles.wideCard)}>
+              <div className={styles.cardAccent} aria-hidden />
+              <div className={styles.cardIcon} aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+                  <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+                </svg>
+              </div>
+              <Heading as="h3" className={styles.cardTitle}>
+                Contribute
+              </Heading>
+              <p className={styles.cardText}>
+                We welcome issues, design discussion, and pull requests. Star the repo, read the
+                contribute guide, and open an issue when you are unsure where to start.
+              </p>
+              <div className={styles.cardActions}>
+                <Link
+                  className="button button--primary"
+                  href="https://github.com/lakeops-org/queryflux"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  GitHub repository
+                </Link>
+                <Link className="button button--secondary" to="/docs/contribute">
+                  Contribute guide
+                </Link>
+                <Link
+                  className="button button--outline"
+                  href="https://github.com/lakeops-org/queryflux/issues"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Issues
+                </Link>
+              </div>
+            </article>
+          </div>
+        </main>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Adds a /community page (docs vs Slack, contribute), Slack invite link for the query-flux workspace, and navbar/footer links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Community section to the website with navigation links in the header and footer
  * Community page features a dedicated landing page with information on getting involved, including direct access to documentation, Slack workspace, and GitHub repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->