### PR TITLE
docs: add snowflake docs to readme and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ QueryFlux sits between SQL clients and multiple backend query engines, providing
 
 ## Overview
 
-QueryFlux lets you connect any SQL client using standard protocols (Trino HTTP, PostgreSQL wire, MySQL wire) and route queries to the right backend engine — Trino, DuckDB, StarRocks, Athena, or ClickHouse — based on flexible routing rules. SQL dialects are translated automatically when needed via [sqlglot](https://github.com/tobymao/sqlglot).
+QueryFlux lets you connect any SQL client using standard protocols (Trino HTTP, PostgreSQL wire, MySQL wire, Snowflake HTTP wire + SQL API v2, and Arrow Flight SQL) and route queries to the right backend engine — Trino, DuckDB, StarRocks, Athena, or ClickHouse — based on flexible routing rules. SQL dialects are translated automatically when needed via [sqlglot](https://github.com/tobymao/sqlglot).
 
 ```
-Client (Trino CLI / psql / mysql)
+Client (Trino CLI / psql / mysql / Snowflake connectors)
     ↓ native protocol
 QueryFlux
     ↓ routing + dialect translation
@@ -50,7 +50,25 @@ Trino / DuckDB / StarRocks / ClickHouse
 - Trino HTTP (port 8080)
 - PostgreSQL wire (port 5432)
 - MySQL wire (port 3306)
+- Snowflake HTTP wire + SQL REST API v2 on one listener (`snowflakeHttp` in YAML; pick a port, e.g. 8443)
 - Arrow Flight SQL (query execution)
+
+### Snowflake HTTP (wire + SQL API v2)
+
+The Snowflake **HTTP wire** (JDBC/ODBC/Python connector, SnowSQL) and **SQL API v2** share the **`snowflakeHttp`** listener; routing distinguishes `snowflakeHttp` vs `snowflakeSqlApi` for `protocolBased` routers. See [`config.example.yaml`](config.example.yaml) for a commented block (`sessionAffinityAcknowledged`, optional session TTL fields). Full reference: [Snowflake frontend](website/docs/architecture/frontends/snowflake.md).
+
+```yaml
+queryflux:
+  frontends:
+    snowflakeHttp:
+      enabled: true
+      port: 8443
+routers:
+  - type: protocolBased
+    trinoHttp: trino-default
+    snowflakeHttp: duckdb-local
+    snowflakeSqlApi: duckdb-local
+```
 
 **Backend Engines**
 - Trino — async HTTP polling
@@ -216,7 +234,7 @@ queryflux/
 │   ├── queryflux/                  # Main binary
 │   ├── queryflux-core/             # Shared types and traits
 │   ├── queryflux-config/           # Config loading
-│   ├── queryflux-frontend/         # Protocol frontends (Trino HTTP, PG wire, ...)
+│   ├── queryflux-frontend/         # Protocol frontends (Trino HTTP, PG/MySQL wire, Snowflake HTTP, …)
 │   ├── queryflux-engine-adapters/  # Backend engine adapters
 │   ├── queryflux-cluster-manager/  # Load balancing and queueing
 │   ├── queryflux-routing/          # Router implementations

--- a/website/docs/architecture/frontends/overview.md
+++ b/website/docs/architecture/frontends/overview.md
@@ -15,8 +15,10 @@ A **frontend** is the entry point for client traffic into QueryFlux. Each fronte
 | [PostgreSQL wire](postgres-wire.md) | `postgresWire` | 5432 | PostgreSQL v3 wire | Postgres | **Done** |
 | [MySQL wire](mysql-wire.md) | `mysqlWire` | 3306 | MySQL wire | MySQL | **Done** |
 | [Arrow Flight SQL](flight-sql.md) | `flightSql` | 50051 | gRPC (Arrow Flight) | Generic | **Done** |
-| [Snowflake](snowflake.md) | `snowflakeHttp` | 8443 | Snowflake HTTP wire + SQL API v2 | Snowflake | **Done** |
+| [Snowflake](snowflake.md) | `snowflakeHttp` | 8443* | Snowflake HTTP wire + SQL API v2 | Snowflake | **Done** |
 | ClickHouse HTTP | `clickhouseHttp` | 8123 | HTTP | ClickHouse | Planned |
+
+\*Snowflake is optional: you must set `snowflakeHttp.port` in YAML (no implicit default). `8443` is typical; some repo examples use `8445`. Wire and SQL API v2 share this listener; routing uses `snowflakeHttp` vs `snowflakeSqlApi` — see [Snowflake](snowflake.md).
 
 ## Shared architecture
 
@@ -51,7 +53,7 @@ The dispatch layer offers three execution paths:
 |------|---------|----------|
 | **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. Falls back to `execute_to_sink` when a sync adapter is selected from a mixed-engine group. |
 | **`execute_to_sink` — native** | MySQL wire ↔ `MysqlWire` backend; Postgres wire ↔ `PostgresWire` backend | Wait for cluster capacity, call `execute_native` on the adapter, stream `NativeResultChunk`s directly to the sink. **Zero Arrow allocation.** |
-| **`execute_to_sink` — Arrow** | All other frontend/backend combinations | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
+| **`execute_to_sink` — Arrow** | All other frontend/backend combinations (including Snowflake HTTP wire and SQL API v2) | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
 
 #### Protocol matching (`ConnectionFormat`)
 
@@ -81,7 +83,7 @@ Each frontend builds a `SessionContext` that travels with the query through rout
 | `tags` | `QueryTags` | Query tags for routing and metrics. |
 | `extra` | `HashMap<String, String>` | Protocol-specific key-value bag (headers, session params, etc.). |
 
-Each frontend is responsible for extracting `user` and `database` from its protocol's native fields and placing remaining data into `extra`. Key conventions for `extra`: Trino/ClickHouse HTTP store lowercased header names; Postgres wire stores startup parameters; MySQL wire stores session variables.
+Each frontend is responsible for extracting `user` and `database` from its protocol's native fields and placing remaining data into `extra`. Key conventions for `extra`: Trino/ClickHouse HTTP store lowercased header names; Postgres wire stores startup parameters; MySQL wire stores session variables; Snowflake HTTP / SQL API v2 store session and account-related fields from login or request metadata.
 
 ### Authentication
 
@@ -98,6 +100,8 @@ routers:
     postgresWire: trino-default
     mysqlWire: starrocks-group
     flightSql: flight-analytics
+    snowflakeHttp: trino-default
+    snowflakeSqlApi: trino-default
 ```
 
 ### SQL dialect and translation
@@ -123,6 +127,12 @@ queryflux:
     flightSql:
       enabled: true
       port: 50051
+    snowflakeHttp:
+      enabled: true
+      port: 8443
+      sessionAffinityAcknowledged: false
 ```
 
-Omitting a frontend block or setting `enabled: false` disables that listener entirely.
+Omitting `postgresWire`, `mysqlWire`, `flightSql`, or `snowflakeHttp` disables that listener. For any frontend block, `enabled: false` turns the listener off while keeping other settings. When `trinoHttp` is omitted from YAML, serde defaults apply (`enabled: true`, port `8080`).
+
+See **[Snowflake](snowflake.md)** for session affinity, TTL fields, and SQL API v2 behavior.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 sidebar_label: Overview
 description:
-  QueryFlux documentation — universal SQL proxy for Trino, PostgreSQL, MySQL, and Flight;
+  QueryFlux documentation — universal SQL proxy for Trino, PostgreSQL, MySQL, Snowflake HTTP, and Flight;
   routing, dialect translation, and one place to run queries against many engines.
 keywords:
   - QueryFlux
@@ -12,7 +12,7 @@ keywords:
 
 # QueryFlux documentation
 
-QueryFlux is a **high-performance, protocol-aware SQL proxy** for analytical and operational engines. Clients connect with the drivers they already use (Trino HTTP, PostgreSQL wire, MySQL wire, Arrow Flight). QueryFlux routes each query to the right backend, translates SQL dialects when needed, and exposes a single observability surface — so you stop wiring **N clients × M engines** by hand.
+QueryFlux is a **high-performance, protocol-aware SQL proxy** for analytical and operational engines. Clients connect with the drivers they already use (Trino HTTP, PostgreSQL wire, MySQL wire, Snowflake HTTP wire and SQL API v2, Arrow Flight). QueryFlux routes each query to the right backend, translates SQL dialects when needed, and exposes a single observability surface — so you stop wiring **N clients × M engines** by hand.
 
 > **One endpoint.** Multiple engines. Native protocols.
 
@@ -57,9 +57,10 @@ QueryFlux listens on multiple frontends at once:
 | Trino HTTP | 8080 | Trino CLI, JDBC, Python |
 | PostgreSQL wire | 5432 | `psql`, Postgres drivers |
 | MySQL wire | 3306 | `mysql`, JDBC, BI tools |
+| Snowflake HTTP + SQL API v2 | configurable (e.g. 8443) | Snowflake JDBC/ODBC/Python, SnowSQL, REST v2 |
 | Arrow Flight SQL | gRPC | Flight-native clients |
 
-Details: **[Frontends](/docs/architecture/frontends/overview)**.
+Details: **[Frontends](/docs/architecture/frontends/overview)** and **[Snowflake frontend](/docs/architecture/frontends/snowflake)**.
 
 ### 2. Routing
 
@@ -72,7 +73,7 @@ Details: **[Routing and clusters](/docs/architecture/routing-and-clusters)**.
 QueryFlux picks a healthy cluster (round-robin, least-loaded, failover, weighted), optionally **rewrites SQL** for the target dialect, and runs the query. If the group is at capacity, queries **queue** at the proxy.
 
 ```
-Client (psql / Trino CLI / mysql / BI)
+Client (psql / Trino CLI / mysql / Snowflake / BI)
         │  native protocol
         ▼
 ┌──────────────────────────┐

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ const siteUrl = 'https://queryflux.dev';
 const siteCanonicalUrl = siteUrl;
 const socialPreviewTitle = 'QueryFlux — Multi-engine query routing proxy';
 const socialPreviewDescription =
-  'Universal SQL query proxy and router in Rust. One endpoint for Trino, PostgreSQL, MySQL, and Flight clients with routing, queueing, and observability.';
+  'Universal SQL query proxy and router in Rust. One endpoint for Trino, PostgreSQL, MySQL, Snowflake HTTP, Flight, and more — with routing, queueing, and observability.';
 
 const config: Config = {
   title: 'QueryFlux',
@@ -44,7 +44,7 @@ const config: Config = {
         '@type': 'SoftwareSourceCode',
         name: 'QueryFlux',
         description:
-          'Universal SQL query proxy and router in Rust. Front protocols include Trino HTTP, PostgreSQL wire, MySQL wire, and Arrow Flight; backends include Trino, DuckDB, StarRocks, and more with routing and sqlglot dialect translation.',
+          'Universal SQL query proxy and router in Rust. Front protocols include Trino HTTP, PostgreSQL wire, MySQL wire, Snowflake HTTP wire + SQL API v2, and Arrow Flight; backends include Trino, DuckDB, StarRocks, and more with routing and sqlglot dialect translation.',
         url: siteCanonicalUrl,
         codeRepository: 'https://github.com/lakeops-org/queryflux',
         license: 'https://www.apache.org/licenses/LICENSE-2.0',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
         'architecture/frontends/postgres-wire',
         'architecture/frontends/mysql-wire',
         'architecture/frontends/flight-sql',
+        'architecture/frontends/snowflake',
       ],
     },
     {

--- a/website/versioned_docs/version-0.1.2/architecture/frontends/overview.md
+++ b/website/versioned_docs/version-0.1.2/architecture/frontends/overview.md
@@ -15,8 +15,10 @@ A **frontend** is the entry point for client traffic into QueryFlux. Each fronte
 | [PostgreSQL wire](postgres-wire.md) | `postgresWire` | 5432 | PostgreSQL v3 wire | Postgres | **Done** |
 | [MySQL wire](mysql-wire.md) | `mysqlWire` | 3306 | MySQL wire | MySQL | **Done** |
 | [Arrow Flight SQL](flight-sql.md) | `flightSql` | 50051 | gRPC (Arrow Flight) | Generic | **Done** |
-| [Snowflake](snowflake.md) | `snowflakeHttp` | 8443 | Snowflake HTTP wire + SQL API v2 | Snowflake | **Done** |
+| [Snowflake](snowflake.md) | `snowflakeHttp` | 8443* | Snowflake HTTP wire + SQL API v2 | Snowflake | **Done** |
 | ClickHouse HTTP | `clickhouseHttp` | 8123 | HTTP | ClickHouse | Planned |
+
+\*Snowflake is optional: you must set `snowflakeHttp.port` in YAML (no implicit default). `8443` is typical; some repo examples use `8445`. Wire and SQL API v2 share this listener; routing uses `snowflakeHttp` vs `snowflakeSqlApi` — see [Snowflake](snowflake.md).
 
 ## Shared architecture
 
@@ -51,7 +53,7 @@ The dispatch layer offers three execution paths:
 |------|---------|----------|
 | **`dispatch_query`** | Trino HTTP (async-capable groups) | Submit to engine, persist handle, return polling URL. Client follows `nextUri` to stream pages. Falls back to `execute_to_sink` when a sync adapter is selected from a mixed-engine group. |
 | **`execute_to_sink` — native** | MySQL wire ↔ `MysqlWire` backend; Postgres wire ↔ `PostgresWire` backend | Wait for cluster capacity, call `execute_native` on the adapter, stream `NativeResultChunk`s directly to the sink. **Zero Arrow allocation.** |
-| **`execute_to_sink` — Arrow** | All other frontend/backend combinations | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
+| **`execute_to_sink` — Arrow** | All other frontend/backend combinations (including Snowflake HTTP wire and SQL API v2) | Wait for cluster capacity, call `execute_as_arrow`, stream `RecordBatch`es through a `ResultSink` that re-encodes to the native protocol response. |
 
 #### Protocol matching (`ConnectionFormat`)
 
@@ -81,7 +83,7 @@ Each frontend builds a `SessionContext` that travels with the query through rout
 | `tags` | `QueryTags` | Query tags for routing and metrics. |
 | `extra` | `HashMap<String, String>` | Protocol-specific key-value bag (headers, session params, etc.). |
 
-Each frontend is responsible for extracting `user` and `database` from its protocol's native fields and placing remaining data into `extra`. Key conventions for `extra`: Trino/ClickHouse HTTP store lowercased header names; Postgres wire stores startup parameters; MySQL wire stores session variables.
+Each frontend is responsible for extracting `user` and `database` from its protocol's native fields and placing remaining data into `extra`. Key conventions for `extra`: Trino/ClickHouse HTTP store lowercased header names; Postgres wire stores startup parameters; MySQL wire stores session variables; Snowflake HTTP / SQL API v2 store session and account-related fields from login or request metadata.
 
 ### Authentication
 
@@ -98,6 +100,8 @@ routers:
     postgresWire: trino-default
     mysqlWire: starrocks-group
     flightSql: flight-analytics
+    snowflakeHttp: trino-default
+    snowflakeSqlApi: trino-default
 ```
 
 ### SQL dialect and translation
@@ -123,6 +127,12 @@ queryflux:
     flightSql:
       enabled: true
       port: 50051
+    snowflakeHttp:
+      enabled: true
+      port: 8443
+      sessionAffinityAcknowledged: false
 ```
 
-Omitting a frontend block or setting `enabled: false` disables that listener entirely.
+Omitting `postgresWire`, `mysqlWire`, `flightSql`, or `snowflakeHttp` disables that listener. For any frontend block, `enabled: false` turns the listener off while keeping other settings. When `trinoHttp` is omitted from YAML, serde defaults apply (`enabled: true`, port `8080`).
+
+See **[Snowflake](snowflake.md)** for session affinity, TTL fields, and SQL API v2 behavior.

--- a/website/versioned_docs/version-0.1.2/intro.md
+++ b/website/versioned_docs/version-0.1.2/intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 sidebar_label: Overview
 description:
-  QueryFlux documentation — universal SQL proxy for Trino, PostgreSQL, MySQL, and Flight;
+  QueryFlux documentation — universal SQL proxy for Trino, PostgreSQL, MySQL, Snowflake HTTP, and Flight;
   routing, dialect translation, and one place to run queries against many engines.
 keywords:
   - QueryFlux
@@ -12,7 +12,7 @@ keywords:
 
 # QueryFlux documentation
 
-QueryFlux is a **high-performance, protocol-aware SQL proxy** for analytical and operational engines. Clients connect with the drivers they already use (Trino HTTP, PostgreSQL wire, MySQL wire, Arrow Flight). QueryFlux routes each query to the right backend, translates SQL dialects when needed, and exposes a single observability surface — so you stop wiring **N clients × M engines** by hand.
+QueryFlux is a **high-performance, protocol-aware SQL proxy** for analytical and operational engines. Clients connect with the drivers they already use (Trino HTTP, PostgreSQL wire, MySQL wire, Snowflake HTTP wire and SQL API v2, Arrow Flight). QueryFlux routes each query to the right backend, translates SQL dialects when needed, and exposes a single observability surface — so you stop wiring **N clients × M engines** by hand.
 
 > **One endpoint.** Multiple engines. Native protocols.
 
@@ -57,9 +57,10 @@ QueryFlux listens on multiple frontends at once:
 | Trino HTTP | 8080 | Trino CLI, JDBC, Python |
 | PostgreSQL wire | 5432 | `psql`, Postgres drivers |
 | MySQL wire | 3306 | `mysql`, JDBC, BI tools |
+| Snowflake HTTP + SQL API v2 | configurable (e.g. 8443) | Snowflake JDBC/ODBC/Python, SnowSQL, REST v2 |
 | Arrow Flight SQL | gRPC | Flight-native clients |
 
-Details: **[Frontends](/docs/architecture/frontends/overview)**.
+Details: **[Frontends](/docs/architecture/frontends/overview)** and **[Snowflake frontend](/docs/architecture/frontends/snowflake)**.
 
 ### 2. Routing
 
@@ -72,7 +73,7 @@ Details: **[Routing and clusters](/docs/architecture/routing-and-clusters)**.
 QueryFlux picks a healthy cluster (round-robin, least-loaded, failover, weighted), optionally **rewrites SQL** for the target dialect, and runs the query. If the group is at capacity, queries **queue** at the proxy.
 
 ```
-Client (psql / Trino CLI / mysql / BI)
+Client (psql / Trino CLI / mysql / Snowflake / BI)
         │  native protocol
         ▼
 ┌──────────────────────────┐

--- a/website/versioned_sidebars/version-0.1.2-sidebars.json
+++ b/website/versioned_sidebars/version-0.1.2-sidebars.json
@@ -48,7 +48,8 @@
         "architecture/frontends/trino-http",
         "architecture/frontends/postgres-wire",
         "architecture/frontends/mysql-wire",
-        "architecture/frontends/flight-sql"
+        "architecture/frontends/flight-sql",
+        "architecture/frontends/snowflake"
       ]
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Added comprehensive documentation for Snowflake frontend support, including Snowflake HTTP wire and SQL API v2 protocols.
  * Updated project overview and architecture documentation to include Snowflake as a supported frontend alongside existing protocols (Trino, PostgreSQL, MySQL, Arrow Flight).
  * Expanded configuration examples and routing guidance for Snowflake protocol handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->