### PR TITLE
feat: improve query lifecycle queueing and admin configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,6 @@ dependencies = [
  "async-trait",
  "polyglot-sql 0.3.2",
  "queryflux-core",
- "queryflux-persistence",
  "regex",
  "serde",
  "serde_json",

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -555,6 +555,12 @@ pub struct ClusterGroupConfig {
     pub max_running_queries: u64,
     #[serde(default)]
     pub max_queued_queries: Option<u64>,
+    /// Maximum time (ms) a wire-protocol query will wait for a free cluster slot before
+    /// returning an error. `None` → wait indefinitely (legacy behavior).
+    /// Only affects MySQL wire, Postgres wire, FlightSQL, and Snowflake HTTP.
+    /// Trino HTTP uses its own persistent queue with client-driven polling.
+    #[serde(default)]
+    pub queue_timeout_ms: Option<u64>,
     /// Simple authorization policy (used when `authorization.provider: none`).
     /// If both lists are empty/absent, all authenticated users are allowed.
     #[serde(default)]

--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 use bytes::Bytes;
@@ -373,4 +374,19 @@ pub enum QueryStatus {
     Success,
     Failed,
     Cancelled,
+}
+
+// --- Guard actions ---
+
+/// A single guard evaluation result — stored as JSONB in `query_history.guard_actions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardAction {
+    pub guard: String,
+    pub action: String,
+    pub reason: Option<String>,
+    pub code: Option<String>,
+    /// Free-form key/value metadata returned by the guard (e.g. matched rule name,
+    /// estimated row count). Omitted from JSON when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
 }

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -286,6 +286,7 @@ impl TestHarness {
             group_order,
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_queue_timeouts: HashMap::new(),
         };
         let records = Arc::new(Mutex::new(Vec::<QueryRecord>::new()));
         let state = Arc::new(AppState {

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -16,17 +16,18 @@ use queryflux_core::{
     error::{QueryFluxError, Result},
     query::{
         ClusterGroupName, ClusterName, EngineType, ExecutingQuery, FrontendProtocol, ProxyQueryId,
-        QueryEngineStats, QueryExecution, QueryStats, QueryStatus, QueuedQuery,
+        QueryEngineStats, QueryExecution, QueryStats, QueryStatus, QueuedQuery, SqlDialect,
     },
     session::SessionContext,
 };
-use queryflux_engine_adapters::trino::api::TrinoResponse;
 use queryflux_engine_adapters::{AdapterKind, AsyncAdapter, ConnectionFormat, SyncAdapter};
-use queryflux_guardrails::{GuardContext, GuardLayer};
+use queryflux_guardrails::{GuardChain, GuardContext, GuardLayer};
 use queryflux_metrics::MetricsStore;
 use queryflux_translation::SchemaContext;
 
 use tracing::{debug, info, warn};
+
+use queryflux_routing::chain::RoutingTrace;
 
 use crate::state::{AppState, QueryContext, QueryOutcome};
 
@@ -74,12 +75,6 @@ pub enum DispatchOutcome {
     },
 }
 
-/// Rewrite a Trino-origin URL to point to QueryFlux instead, keeping the full path.
-/// `http://trino:8080/v1/statement/executing/{id}/{token}` →
-/// `http://queryflux:9000/v1/statement/executing/{id}/{token}`
-///
-/// Any instance can then reconstruct the Trino URL by looking up the stored
-/// `trino_endpoint` and re-joining it with the path.
 async fn cluster_db_ids(
     mgr: &std::sync::Arc<dyn ClusterGroupManager>,
     group: &ClusterGroupName,
@@ -91,17 +86,162 @@ async fn cluster_db_ids(
     }
 }
 
-pub fn rewrite_trino_uri(trino_uri: &str, external_address: &str) -> String {
-    // Find the path portion starting at /v1/
-    if let Some(path_start) = trino_uri.find("/v1/") {
-        format!(
-            "{}{}",
-            external_address.trim_end_matches('/'),
-            &trino_uri[path_start..]
+// ---------------------------------------------------------------------------
+// Shared query preparation helpers (used by both async and sync paths)
+// ---------------------------------------------------------------------------
+
+/// Snapshot of per-group live config needed for query preparation.
+struct GroupLiveConfig {
+    cluster_manager: Arc<dyn ClusterGroupManager>,
+    group_fixups: Vec<String>,
+    group_default_tags: QueryTags,
+    guard_chain: Option<Arc<GuardChain>>,
+    group_guard_chain: Option<Arc<GuardChain>>,
+    /// Max time (ms) a sync/wire query waits for a cluster slot. `None` → no limit.
+    queue_timeout_ms: Option<u64>,
+}
+
+/// Read the per-group live config snapshot from `AppState`.
+async fn read_group_live_config(state: &AppState, group: &str) -> GroupLiveConfig {
+    let live = state.live.read().await;
+    GroupLiveConfig {
+        cluster_manager: live.cluster_manager.clone(),
+        group_fixups: live
+            .group_translation_scripts
+            .get(group)
+            .cloned()
+            .unwrap_or_default(),
+        group_default_tags: live
+            .group_default_tags
+            .get(group)
+            .cloned()
+            .unwrap_or_default(),
+        guard_chain: live.guard_chain.clone(),
+        group_guard_chain: live.group_guard_chains.get(group).cloned(),
+        queue_timeout_ms: live.group_queue_timeouts.get(group).copied().flatten(),
+    }
+}
+
+/// Translate SQL and optionally interpolate parameters.
+///
+/// Shared by both the async (`dispatch_query`) and sync (`setup_sync_query`) paths.
+/// Returns `(translated_sql, was_translated, effective_params)`.
+async fn translate_and_prepare(
+    state: &AppState,
+    sql: &str,
+    params: QueryParams,
+    src_dialect: &SqlDialect,
+    tgt_dialect: &SqlDialect,
+    group_fixups: &[String],
+    supports_native_params: bool,
+) -> Result<(String, bool, QueryParams)> {
+    let translated = state
+        .translation
+        .maybe_translate(
+            sql,
+            src_dialect,
+            tgt_dialect,
+            &SchemaContext::default(),
+            group_fixups,
+        )
+        .await?;
+
+    let was_translated = translated != sql;
+
+    let (translated, effective_params) = if !params.is_empty() && !supports_native_params {
+        (
+            interpolate_params(&translated, &params, tgt_dialect)?,
+            vec![],
         )
     } else {
-        trino_uri.to_string()
+        (translated, params)
+    };
+
+    Ok((translated, was_translated, effective_params))
+}
+
+/// Centralized routing: resolve the target cluster group for a query.
+///
+/// Evaluates the router chain, applies authorization-aware fallback resolution, and returns
+/// the final group name along with the routing trace. All frontends should use this (or
+/// [`route_and_execute`]) instead of calling `router_chain.route_with_trace` directly.
+pub async fn resolve_route(
+    state: &Arc<AppState>,
+    sql: &str,
+    session: &SessionContext,
+    protocol: &FrontendProtocol,
+    auth_ctx: &AuthContext,
+) -> Result<(ClusterGroupName, RoutingTrace)> {
+    let routing_result = {
+        let live = state.live.read().await;
+        live.router_chain
+            .route_with_trace(sql, session, protocol, Some(auth_ctx))
+            .await
+    };
+    let (group, trace) = routing_result?;
+
+    // When the router chain fell back to the static default, honour it if the user is
+    // authorized. Otherwise find the first group the user can access (restrictive ACLs).
+    let group = if trace.used_fallback {
+        resolve_group_for_user(state, auth_ctx, group).await
+    } else {
+        group
+    };
+    Ok((group, trace))
+}
+
+/// Authorization-aware fallback resolution: if the user is authorized for the configured
+/// fallback group, use it. Otherwise scan groups in config order for the first allowed one.
+async fn resolve_group_for_user(
+    state: &AppState,
+    auth_ctx: &AuthContext,
+    fallback: ClusterGroupName,
+) -> ClusterGroupName {
+    if state.authorization.check(auth_ctx, &fallback.0).await {
+        return fallback;
     }
+    let group_order = state.live.read().await.group_order.clone();
+    for group_name in &group_order {
+        if state.authorization.check(auth_ctx, group_name).await {
+            return ClusterGroupName(group_name.clone());
+        }
+    }
+    fallback
+}
+
+/// Route a query and execute it to a sink in one call.
+///
+/// Combines [`resolve_route`] + [`execute_to_sink`] — the standard entry point for
+/// frontends that use the sink-based (sync/Arrow) execution path (MySQL wire, Postgres wire,
+/// FlightSQL). Trino HTTP uses [`resolve_route`] directly because it branches on async vs sync.
+///
+/// Routing errors are reported to the sink via [`ResultSink::on_error`] so the client always
+/// receives a protocol-native error message regardless of where the failure occurred.
+pub async fn route_and_execute(
+    state: &Arc<AppState>,
+    sql: String,
+    params: QueryParams,
+    session: SessionContext,
+    protocol: FrontendProtocol,
+    sink: &mut impl ResultSink,
+    auth_ctx: &AuthContext,
+) -> Result<()> {
+    let (group, trace) = match resolve_route(state, &sql, &session, &protocol, auth_ctx).await {
+        Ok(r) => r,
+        Err(e) => return sink.on_error(&e.to_string()).await,
+    };
+    execute_to_sink(
+        state,
+        sql,
+        params,
+        session,
+        protocol,
+        group,
+        Some(trace),
+        sink,
+        auth_ctx,
+    )
+    .await
 }
 
 /// Core dispatch logic shared across all frontend protocol implementations.
@@ -117,6 +257,7 @@ pub async fn dispatch_query(
     already_queued: bool,
     sequence: u64,
     auth_ctx: &AuthContext,
+    routing_trace: Option<RoutingTrace>,
 ) -> Result<DispatchOutcome> {
     // Authorization check — first gate before any resource acquisition.
     // Phase 1: AllowAllAuthorization always returns true (no behavior change).
@@ -127,24 +268,12 @@ pub async fn dispatch_query(
         )));
     }
 
-    // Clone the manager, group translation fixups, default tags, and guard chains in one snapshot.
-    let (cluster_manager, group_fixups, group_default_tags, guard_chain, group_guard_chain) = {
-        let live = state.live.read().await;
-        (
-            live.cluster_manager.clone(),
-            live.group_translation_scripts
-                .get(&group.0)
-                .cloned()
-                .unwrap_or_default(),
-            live.group_default_tags
-                .get(&group.0)
-                .cloned()
-                .unwrap_or_default(),
-            live.guard_chain.clone(),
-            live.group_guard_chains.get(&group.0).cloned(),
-        )
-    };
-    let effective_tags = merge_tags(&group_default_tags, &session.tags().clone());
+    let glc = read_group_live_config(state, &group.0).await;
+    let cluster_manager = &glc.cluster_manager;
+    let group_fixups = &glc.group_fixups;
+    let guard_chain = &glc.guard_chain;
+    let group_guard_chain = &glc.group_guard_chain;
+    let effective_tags = merge_tags(&glc.group_default_tags, &session.tags().clone());
 
     let cluster_name = match cluster_manager.acquire_cluster(&group).await? {
         Some(c) => c,
@@ -167,7 +296,7 @@ pub async fn dispatch_query(
     };
 
     let (cluster_group_config_id, cluster_config_id) =
-        cluster_db_ids(&cluster_manager, &group, &cluster_name).await;
+        cluster_db_ids(cluster_manager, &group, &cluster_name).await;
 
     state.metrics.on_query_started(&group.0, &cluster_name.0);
 
@@ -192,18 +321,20 @@ pub async fn dispatch_query(
     let tgt_dialect = adapter_kind.translation_target_dialect();
     let engine_type = adapter_kind.engine_type();
     let original_sql = sql.clone();
-    let sql = match state
-        .translation
-        .maybe_translate(
-            &sql,
-            &src_dialect,
-            &tgt_dialect,
-            &SchemaContext::default(),
-            &group_fixups,
-        )
-        .await
+
+    // Async adapters never support native params — always interpolate.
+    let (sql, was_translated, effective_params) = match translate_and_prepare(
+        state,
+        &sql,
+        params,
+        &src_dialect,
+        &tgt_dialect,
+        group_fixups,
+        false,
+    )
+    .await
     {
-        Ok(t) => t,
+        Ok(r) => r,
         Err(e) => {
             warn!(id = %query_id, "Translation error: {e}");
             state.metrics.on_query_finished(&group.0, &cluster_name.0);
@@ -211,22 +342,14 @@ pub async fn dispatch_query(
             return Err(e);
         }
     };
-    let was_translated = sql != original_sql;
     if was_translated {
         info!(id = %query_id, src = ?src_dialect, tgt = ?tgt_dialect, "SQL translated");
     }
 
-    // Fallback interpolation for async adapters that don't support native params.
-    let (sql, effective_params) = if !params.is_empty() {
-        (interpolate_params(&sql, &params, &tgt_dialect)?, vec![])
-    } else {
-        (sql, params)
-    };
-
     // Guard chain: runs after translation (SQL is final), before engine submission.
     // Global guards run first; per-group guards are appended after.
     let resolved_agent_ctx = session.resolved_agent_context();
-    let mut all_guard_actions: Vec<queryflux_persistence::GuardAction> = Vec::new();
+    let mut all_guard_actions: Vec<queryflux_core::query::GuardAction> = Vec::new();
 
     let guard_ctx = GuardContext {
         sql: &original_sql,
@@ -272,10 +395,11 @@ pub async fn dispatch_query(
                 QueryOutcome {
                     backend_query_id: None,
                     status: QueryStatus::Failed,
+                    queue_duration_ms: 0,
                     execution_ms: 0,
                     rows: None,
                     error: Some(deny_reason.clone()),
-                    routing_trace: None,
+                    routing_trace: routing_trace.clone(),
                     engine_stats: None,
                     guard_actions: $actions,
                     was_guard_blocked: true,
@@ -367,9 +491,9 @@ pub async fn dispatch_query(
             if next_uri.is_none() {
                 if let Some(ref ib) = initial_body {
                     if engine_type == EngineType::Trino {
-                        finalize_trino_async_terminal_on_submit(
+                        crate::trino_http::trino_dispatch::finalize_trino_async_terminal_on_submit(
                             state,
-                            &cluster_manager,
+                            cluster_manager,
                             &executing,
                             &adapter,
                             &session,
@@ -381,9 +505,9 @@ pub async fn dispatch_query(
                 }
             }
 
-            let proxy_next_uri = next_uri
-                .as_deref()
-                .map(|uri| rewrite_trino_uri(uri, &state.external_address));
+            let proxy_next_uri = next_uri.as_deref().map(|uri| {
+                crate::trino_http::trino_dispatch::rewrite_trino_uri(uri, &state.external_address)
+            });
             Ok(DispatchOutcome::Async {
                 initial_body,
                 proxy_next_uri,
@@ -393,6 +517,18 @@ pub async fn dispatch_query(
             if already_queued {
                 let _ = state.persistence.delete_queued(&query_id).await;
             }
+
+            // Wrap the already-acquired slot so Drop releases it on future cancellation
+            // (e.g. the Trino HTTP client times out and axum drops this request future).
+            // Without this guard, the running_queries counter for the sync cluster leaks
+            // upward on every client timeout until the cluster appears at-capacity and is
+            // excluded from round-robin selection.
+            let mut slot = ClusterSlotGuard::new(
+                cluster_manager.clone(),
+                group.clone(),
+                cluster_name.clone(),
+                state.metrics.clone(),
+            );
 
             info!(id = %query_id, cluster = %cluster_name, "Query executing (sync via dispatch)");
             let start = Instant::now();
@@ -493,18 +629,18 @@ pub async fn dispatch_query(
                 QueryOutcome {
                     backend_query_id: None,
                     status,
+                    queue_duration_ms: 0,
                     execution_ms: elapsed_ms,
                     rows,
                     error,
-                    routing_trace: None,
+                    routing_trace: routing_trace.clone(),
                     engine_stats: None,
                     guard_actions: all_guard_actions,
                     was_guard_blocked: false,
                 },
             );
 
-            state.metrics.on_query_finished(&group.0, &cluster_name.0);
-            let _ = cluster_manager.release_cluster(&group, &cluster_name).await;
+            slot.release().await;
 
             debug!(id = %ctx.query_id, "sync dispatch: calling into_bytes");
             let body_bytes = sink.into_bytes();
@@ -515,171 +651,6 @@ pub async fn dispatch_query(
             })
         }
     }
-}
-
-/// Determine the terminal `QueryOutcome` from a Trino submit response body.
-///
-/// Parses the body to determine success vs failure. `engine_stats` is passed in
-/// from `adapter.terminal_stats_from_body()` — Trino-specific stats parsing lives
-/// in the adapter, not here.
-///
-/// Returns `(outcome, Option<warn_log_message>)`.
-fn trino_submit_terminal_outcome(
-    body: &Bytes,
-    elapsed_ms: u64,
-    backend_id: String,
-    engine_stats: Option<QueryEngineStats>,
-) -> (QueryOutcome, Option<String>) {
-    let trino_resp: TrinoResponse = match serde_json::from_slice(body.as_ref()) {
-        Ok(r) => r,
-        Err(e) => {
-            let warn_msg = format!(
-                "trino submit terminal body JSON parse failed: {e}; releasing cluster + clearing persistence"
-            );
-            return (
-                QueryOutcome {
-                    backend_query_id: Some(backend_id),
-                    status: QueryStatus::Failed,
-                    execution_ms: elapsed_ms,
-                    rows: None,
-                    error: Some(format!("failed to parse Trino response: {e}")),
-                    routing_trace: None,
-                    engine_stats,
-                    guard_actions: vec![],
-                    was_guard_blocked: false,
-                },
-                Some(warn_msg),
-            );
-        }
-    };
-
-    let backend_id = Some(backend_id);
-
-    if let Some(err) = &trino_resp.error {
-        (
-            QueryOutcome {
-                backend_query_id: backend_id,
-                status: QueryStatus::Failed,
-                execution_ms: elapsed_ms,
-                rows: None,
-                error: Some(err.message.clone()),
-                routing_trace: None,
-                engine_stats,
-                guard_actions: vec![],
-                was_guard_blocked: false,
-            },
-            None,
-        )
-    } else if trino_resp.stats.state == "FAILED" {
-        (
-            QueryOutcome {
-                backend_query_id: backend_id,
-                status: QueryStatus::Failed,
-                execution_ms: elapsed_ms,
-                rows: None,
-                error: Some("Trino query FAILED".to_string()),
-                routing_trace: None,
-                engine_stats,
-                guard_actions: vec![],
-                was_guard_blocked: false,
-            },
-            None,
-        )
-    } else {
-        (
-            QueryOutcome {
-                backend_query_id: backend_id,
-                status: QueryStatus::Success,
-                execution_ms: elapsed_ms,
-                rows: None,
-                error: None,
-                routing_trace: None,
-                engine_stats,
-                guard_actions: vec![],
-                was_guard_blocked: false,
-            },
-            None,
-        )
-    }
-}
-
-/// Trino may return `FINISHED` with no `nextUri` on the initial POST `/v1/statement` response.
-/// Clients then never call GET `/v1/statement/...`, so `get_executing_statement` never runs —
-/// mirror its metrics, `record_query`, and persistence cleanup here.
-///
-/// Collapsed from 4 branches (including JSON parse error) to a single `record_query` call.
-async fn finalize_trino_async_terminal_on_submit(
-    state: &Arc<AppState>,
-    cluster_manager: &Arc<dyn ClusterGroupManager>,
-    executing: &ExecutingQuery,
-    adapter: &Arc<dyn AsyncAdapter>,
-    session: &SessionContext,
-    protocol: FrontendProtocol,
-    body: &Bytes,
-) {
-    let elapsed_ms = (Utc::now() - executing.creation_time)
-        .num_milliseconds()
-        .max(0) as u64;
-
-    let was_translated = executing.translated_sql.is_some();
-    let src_dialect = protocol.default_dialect();
-    let ctx = QueryContext {
-        query_id: executing.id.clone(),
-        sql: executing
-            .translated_sql
-            .as_deref()
-            .unwrap_or(&executing.sql)
-            .to_string(),
-        session: session.clone(),
-        protocol,
-        group: executing.cluster_group.clone(),
-        cluster: executing.cluster_name.clone(),
-        cluster_group_config_id: executing.cluster_group_config_id,
-        cluster_config_id: executing.cluster_config_id,
-        engine_type: adapter.engine_type(),
-        src_dialect,
-        tgt_dialect: adapter.translation_target_dialect(),
-        was_translated,
-        translated_sql: if was_translated {
-            Some(executing.sql.clone())
-        } else {
-            None
-        },
-        query_tags: executing.query_tags.clone(),
-        query_params: vec![],
-        agent_context: executing.agent_context.clone(),
-    };
-
-    let engine_stats = adapter.terminal_stats_from_body(body);
-    let (mut outcome, warn_msg) = trino_submit_terminal_outcome(
-        body,
-        elapsed_ms,
-        executing.backend_query_id.0.clone(),
-        engine_stats,
-    );
-
-    // Inject guard actions captured at submit time into the final audit record.
-    let stored_actions: Vec<queryflux_persistence::GuardAction> = serde_json::from_value(
-        serde_json::Value::Array(executing.submitted_guard_actions.clone()),
-    )
-    .unwrap_or_default();
-    if !stored_actions.is_empty() {
-        outcome.guard_actions = stored_actions;
-        outcome.was_guard_blocked = executing.was_guard_blocked;
-    }
-
-    if let Some(msg) = warn_msg {
-        warn!(proxy_id = %executing.id, "{msg}");
-    }
-
-    state
-        .metrics
-        .on_query_finished(&executing.cluster_group.0, &executing.cluster_name.0);
-    state.record_query(&ctx, outcome);
-    let _ = cluster_manager
-        .release_cluster(&executing.cluster_group, &executing.cluster_name)
-        .await;
-    let _ = state.persistence.delete(&executing.backend_query_id).await;
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -788,6 +759,59 @@ impl Drop for ClusterSlotGuard {
 }
 
 // ---------------------------------------------------------------------------
+// CancellationGuard — records a Cancelled query when a sync future is dropped
+// ---------------------------------------------------------------------------
+
+/// RAII guard that records a `Cancelled` query when the sync execution future is
+/// dropped (e.g. client disconnects). On the normal path the caller calls `disarm()`
+/// after `record_query` so the guard becomes a no-op on drop.
+struct CancellationGuard {
+    state: Arc<AppState>,
+    ctx: Option<QueryContext>,
+    start: Instant,
+}
+
+impl CancellationGuard {
+    fn new(state: Arc<AppState>, ctx: QueryContext, start: Instant) -> Self {
+        Self {
+            state,
+            ctx: Some(ctx),
+            start,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.ctx = None;
+    }
+}
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        if let Some(ctx) = self.ctx.take() {
+            let state = self.state.clone();
+            let elapsed = self.start.elapsed().as_millis() as u64;
+            tokio::spawn(async move {
+                state.record_query(
+                    &ctx,
+                    QueryOutcome {
+                        backend_query_id: None,
+                        status: QueryStatus::Cancelled,
+                        queue_duration_ms: 0,
+                        execution_ms: elapsed,
+                        rows: None,
+                        error: Some("Client disconnected".to_string()),
+                        routing_trace: None,
+                        engine_stats: None,
+                        guard_actions: vec![],
+                        was_guard_blocked: false,
+                    },
+                );
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Sync execution path — shared by MySQL wire, Postgres wire, Flight SQL
 // ---------------------------------------------------------------------------
 
@@ -867,7 +891,9 @@ struct SyncQuerySetup {
     /// Typed parameters — empty when the adapter interpolated them into `translated`.
     params: QueryParams,
     /// Guard actions collected by the guard chain (allow/warn). Merged into QueryOutcome.
-    guard_actions: Vec<queryflux_persistence::GuardAction>,
+    guard_actions: Vec<queryflux_core::query::GuardAction>,
+    /// Time spent waiting for a cluster slot (wire-protocol queueing).
+    queue_duration_ms: u64,
 }
 
 /// The outcome of executing a sync query — everything record_query needs.
@@ -886,6 +912,7 @@ impl From<SyncOutcome> for QueryOutcome {
         QueryOutcome {
             backend_query_id: None,
             status: o.status,
+            queue_duration_ms: 0,
             execution_ms: o.elapsed_ms,
             rows: o.rows,
             error: o.error,
@@ -917,52 +944,72 @@ async fn setup_sync_query(
 ) -> Result<SyncQuerySetup> {
     let query_id = ProxyQueryId::new();
 
-    let (cluster_manager, group_fixups, group_default_tags) = {
-        let live = state.live.read().await;
-        (
-            live.cluster_manager.clone(),
-            live.group_translation_scripts
-                .get(&group.0)
-                .cloned()
-                .unwrap_or_default(),
-            live.group_default_tags
-                .get(&group.0)
-                .cloned()
-                .unwrap_or_default(),
-        )
-    };
-    let effective_tags: QueryTags = merge_tags(&group_default_tags, &session.tags().clone());
+    let glc = read_group_live_config(state, &group.0).await;
+    let effective_tags: QueryTags = merge_tags(&glc.group_default_tags, &session.tags().clone());
 
-    // Queue loop: spin until a cluster slot is available.
+    // Queue loop: wait for a cluster slot with optional timeout.
+    let queue_start = Instant::now();
+    let timeout = glc.queue_timeout_ms.map(std::time::Duration::from_millis);
     let mut seq: u64 = 0;
+    let mut queued_metric_emitted = false;
+
     let (cluster_name, adapter) = loop {
-        match cluster_manager.acquire_cluster(&group).await? {
+        match glc.cluster_manager.acquire_cluster(&group).await? {
             Some(name) => match state.adapter(&name.0).await {
                 Some(AdapterKind::Sync(a)) => break (name, DispatchAdapter::Sync(a)),
                 Some(AdapterKind::Async(a)) => break (name, DispatchAdapter::Async(a)),
                 None => {
-                    let _ = cluster_manager.release_cluster(&group, &name).await;
+                    let _ = glc.cluster_manager.release_cluster(&group, &name).await;
                     return Err(QueryFluxError::Engine(format!(
                         "No adapter for {group}/{name}"
                     )));
                 }
             },
             None => {
+                if !queued_metric_emitted {
+                    info!(id = %query_id, group = %group, "Query queued — waiting for cluster slot");
+                    queued_metric_emitted = true;
+                }
+
+                if let Some(max_wait) = timeout {
+                    if queue_start.elapsed() >= max_wait {
+                        warn!(
+                            id = %query_id, group = %group,
+                            waited_ms = queue_start.elapsed().as_millis() as u64,
+                            "Queue timeout — no cluster slot available"
+                        );
+                        return Err(QueryFluxError::Engine(format!(
+                            "query timed out waiting for a free cluster slot in group '{}' \
+                             (waited {}ms, limit {}ms)",
+                            group.0,
+                            queue_start.elapsed().as_millis(),
+                            max_wait.as_millis()
+                        )));
+                    }
+                }
+
                 queued_backoff_delay(seq).await;
                 seq += 1;
             }
         }
     };
+    let queue_duration_ms = queue_start.elapsed().as_millis() as u64;
+    if queued_metric_emitted {
+        info!(
+            id = %query_id, group = %group,
+            queue_ms = queue_duration_ms,
+            "Query dequeued — cluster slot acquired"
+        );
+    }
 
     let (cluster_group_config_id, cluster_config_id) =
-        cluster_db_ids(&cluster_manager, &group, &cluster_name).await;
+        cluster_db_ids(&glc.cluster_manager, &group, &cluster_name).await;
 
-    // Fix Bug A: on_query_started was missing from the sync path.
     state.metrics.on_query_started(&group.0, &cluster_name.0);
     info!(id = %query_id, group = %group, cluster = %cluster_name, "Query executing (sync)");
 
     let mut slot = ClusterSlotGuard::new(
-        cluster_manager.clone(),
+        glc.cluster_manager.clone(),
         group.clone(),
         cluster_name.clone(),
         state.metrics.clone(),
@@ -973,20 +1020,18 @@ async fn setup_sync_query(
     let engine_type = adapter.engine_type();
     let start = Instant::now();
 
-    // Translate SQL. On failure: record the query, release the slot, propagate the error.
-    // The caller (execute_to_sink) will notify the sink via on_error.
-    let translated = match state
-        .translation
-        .maybe_translate(
-            &sql,
-            &src_dialect,
-            &tgt_dialect,
-            &SchemaContext::default(),
-            &group_fixups,
-        )
-        .await
+    let (translated, was_translated, effective_params) = match translate_and_prepare(
+        state,
+        &sql,
+        params.clone(),
+        &src_dialect,
+        &tgt_dialect,
+        &glc.group_fixups,
+        adapter.supports_native_params(),
+    )
+    .await
     {
-        Ok(t) => t,
+        Ok(r) => r,
         Err(e) => {
             let err_msg = e.to_string();
             warn!(id = %query_id, "Translation error: {err_msg}");
@@ -1013,6 +1058,7 @@ async fn setup_sync_query(
                 QueryOutcome {
                     backend_query_id: None,
                     status: QueryStatus::Failed,
+                    queue_duration_ms: 0,
                     execution_ms: start.elapsed().as_millis() as u64,
                     rows: None,
                     error: Some(err_msg),
@@ -1027,26 +1073,11 @@ async fn setup_sync_query(
         }
     };
 
-    let was_translated = translated != sql;
-
     let cluster_cfg = state.cluster_config_cloned(&cluster_name.0).await;
     let credentials = state
         .identity_resolver
         .resolve(auth_ctx, cluster_cfg.as_ref())
         .await;
-
-    // Fallback interpolation: when the adapter does not support native params,
-    // substitute `?` placeholders with typed literals now so the adapter receives
-    // a fully-resolved SQL string and empty params.
-    let (translated, effective_params) = if !params.is_empty() && !adapter.supports_native_params()
-    {
-        (
-            interpolate_params(&translated, &params, &tgt_dialect)?,
-            vec![],
-        )
-    } else {
-        (translated, params)
-    };
 
     let agent_context = session.resolved_agent_context();
     let ctx = QueryContext {
@@ -1081,6 +1112,7 @@ async fn setup_sync_query(
         credentials,
         params: effective_params,
         guard_actions: vec![],
+        queue_duration_ms,
     })
 }
 
@@ -1350,6 +1382,7 @@ pub async fn execute_to_sink(
     session: SessionContext,
     protocol: FrontendProtocol,
     group: ClusterGroupName,
+    routing_trace: Option<RoutingTrace>,
     sink: &mut impl ResultSink,
     auth_ctx: &AuthContext,
 ) -> Result<()> {
@@ -1400,7 +1433,7 @@ pub async fn execute_to_sink(
             query_tags: &ctx.query_tags,
         };
 
-        let mut all_actions: Vec<queryflux_persistence::GuardAction> = Vec::new();
+        let mut all_actions: Vec<queryflux_core::query::GuardAction> = Vec::new();
 
         for chain in [guard_chain.as_ref(), group_guard_chain.as_ref()]
             .into_iter()
@@ -1420,10 +1453,11 @@ pub async fn execute_to_sink(
                     QueryOutcome {
                         backend_query_id: None,
                         status: QueryStatus::Failed,
+                        queue_duration_ms: setup.queue_duration_ms,
                         execution_ms: setup.start.elapsed().as_millis() as u64,
                         rows: None,
                         error: Some(deny_reason.clone()),
-                        routing_trace: None,
+                        routing_trace: routing_trace.clone(),
                         engine_stats: None,
                         guard_actions: all_actions,
                         was_guard_blocked: true,
@@ -1437,6 +1471,11 @@ pub async fn execute_to_sink(
         // flow into record_query at the normal exit point below.
         setup.guard_actions = all_actions;
     }
+
+    // Cancellation safety: if the future is dropped from here on (client disconnect),
+    // the guard records the query as Cancelled so it appears in query history.
+    // Disarmed below after the normal-path record_query call.
+    let mut cancel_guard = CancellationGuard::new(state.clone(), setup.ctx.clone(), setup.start);
 
     // Native path: skip Arrow when backend connection format matches frontend protocol.
     // All other guarantees (slot release, record_query) are upheld by this function's
@@ -1455,12 +1494,15 @@ pub async fn execute_to_sink(
     // slot.release() is idempotent and sets released=true so Drop is a no-op.
     setup.slot.release().await;
     let mut final_outcome: QueryOutcome = outcome.into();
+    final_outcome.routing_trace = routing_trace;
+    final_outcome.queue_duration_ms = setup.queue_duration_ms;
     // Prepend guard actions (allow/warn) collected before execution.
     if !setup.guard_actions.is_empty() {
         setup.guard_actions.extend(final_outcome.guard_actions);
         final_outcome.guard_actions = setup.guard_actions;
     }
     state.record_query(&setup.ctx, final_outcome);
+    cancel_guard.disarm();
 
     sink_result
 }

--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -41,7 +41,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::{route_and_execute, ResultSink};
 use crate::state::AppState;
 use crate::FrontendListenerTrait;
 
@@ -190,14 +190,6 @@ impl FlightSqlService for QueryFluxFlightSql {
             .await
             .map_err(|e| Status::unauthenticated(e.to_string()))?;
 
-        let routing_result = {
-            let live = self.state.live.read().await;
-            live.router_chain
-                .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
-                .await
-        };
-        let (group, _trace) = routing_result.map_err(|e| Status::internal(e.to_string()))?;
-
         // Channel: sink sends RecordBatches; FlightDataEncoderBuilder encodes them.
         let (tx, rx) =
             tokio::sync::mpsc::unbounded_channel::<std::result::Result<RecordBatch, FlightError>>();
@@ -207,13 +199,12 @@ impl FlightSqlService for QueryFluxFlightSql {
         let sql2 = sql.clone();
 
         tokio::spawn(async move {
-            let _ = execute_to_sink(
+            let _ = route_and_execute(
                 &state2,
                 sql2,
                 vec![],
                 session,
                 protocol,
-                group,
                 &mut sink,
                 &auth_ctx,
             )

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -39,7 +39,7 @@ use queryflux_core::{
     tags::{parse_query_tags, QueryTags},
 };
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::{route_and_execute, ResultSink};
 use crate::state::AppState;
 use crate::FrontendListenerTrait;
 
@@ -333,20 +333,6 @@ async fn handle_com_query<W: AsyncWriteExt + Unpin>(
         }
     };
 
-    let routing_result = {
-        let live = state.live.read().await;
-        live.router_chain
-            .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
-            .await
-    };
-    let (group, _trace) = match routing_result {
-        Ok(r) => r,
-        Err(e) => {
-            write_packet(writer, start_seq, &build_err(1105, &e.to_string())).await?;
-            return Ok(());
-        }
-    };
-
     // Channel: sink encodes MySQL packets and sends them; we write them to TCP.
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
     let mut sink = MysqlResultSink::new(tx, start_seq);
@@ -356,13 +342,12 @@ async fn handle_com_query<W: AsyncWriteExt + Unpin>(
     let sql2 = sql.to_string();
 
     let exec_task = tokio::spawn(async move {
-        execute_to_sink(
+        route_and_execute(
             &state2,
             sql2,
             vec![],
             session2,
             protocol,
-            group,
             &mut sink,
             &auth_ctx,
         )

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -31,7 +31,7 @@ use queryflux_core::{
     tags::parse_query_tags,
 };
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::{route_and_execute, ResultSink};
 use crate::state::AppState;
 use crate::FrontendListenerTrait;
 
@@ -294,21 +294,6 @@ async fn handle_simple_query<W: AsyncWriteExt + Unpin>(
         }
     };
 
-    let routing_result = {
-        let live = state.live.read().await;
-        live.router_chain
-            .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
-            .await
-    };
-    let (group, _trace) = match routing_result {
-        Ok(r) => r,
-        Err(e) => {
-            write_error_response(writer, "42000", &e.to_string()).await?;
-            write_msg(writer, b'Z', b"I").await?;
-            return Ok(());
-        }
-    };
-
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
     let mut sink = PostgresResultSink::new(tx);
 
@@ -317,13 +302,12 @@ async fn handle_simple_query<W: AsyncWriteExt + Unpin>(
     let sql2 = sql.to_string();
 
     let exec_task = tokio::spawn(async move {
-        execute_to_sink(
+        route_and_execute(
             &state2,
             sql2,
             vec![],
             session2,
             protocol,
-            group,
             &mut sink,
             &auth_ctx,
         )

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
@@ -213,6 +213,7 @@ pub async fn query_request(
         session_ctx,
         FrontendProtocol::SnowflakeHttp,
         group,
+        None,
         &mut sink,
         &auth_ctx,
     )

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use tracing::{info, warn};
 use uuid::Uuid;
 
+use crate::dispatch::resolve_route;
 use crate::snowflake::http::session_store::SnowflakeSession;
 use crate::state::AppState;
 
@@ -76,19 +77,16 @@ pub async fn login_request(
         extra: HashMap::new(),
         agent_context: None,
     };
-    let group = {
-        let live = state.live.read().await;
-        live.router_chain
-            .route(
-                "",
-                &session_ctx,
-                &FrontendProtocol::SnowflakeHttp,
-                Some(&auth_ctx),
-            )
-            .await
-    };
-    let group = match group {
-        Ok(g) => g,
+    let (group, _routing_trace) = match resolve_route(
+        &state,
+        "",
+        &session_ctx,
+        &FrontendProtocol::SnowflakeHttp,
+        &auth_ctx,
+    )
+    .await
+    {
+        Ok(r) => r,
         Err(e) => {
             warn!(user = %username, "Snowflake HTTP routing failed at login: {e}");
             return sf_error(

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -21,7 +21,7 @@ use serde_json::{json, Value};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::{route_and_execute, ResultSink};
 use crate::snowflake::http::format::schema_to_rowtype;
 use crate::snowflake::http::handlers::bindings::bindings_to_params;
 use crate::snowflake::http::handlers::common::parse_snowflake_json_body;
@@ -218,38 +218,21 @@ pub async fn submit_statement(
         extra,
         agent_context: None,
     };
-    let group = {
-        let live = state.live.read().await;
-        live.router_chain
-            .route(
-                &sql,
-                &session_ctx,
-                &FrontendProtocol::SnowflakeSqlApi,
-                Some(&auth_ctx),
-            )
-            .await
-    };
-    let group = match group {
-        Ok(g) => g,
-        Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
-    };
-
     let handle = Uuid::new_v4().to_string();
     let mut sink = SqlApiSink::new();
 
-    if let Err(e) = execute_to_sink(
+    if let Err(e) = route_and_execute(
         &state,
         sql,
         params,
         session_ctx,
         FrontendProtocol::SnowflakeSqlApi,
-        group,
         &mut sink,
         &auth_ctx,
     )
     .await
     {
-        warn!(handle = %handle, "SQL API execute_to_sink error: {e}");
+        warn!(handle = %handle, "SQL API route_and_execute error: {e}");
         sink.error = Some(e.to_string());
     }
 

--- a/crates/queryflux-frontend/src/snowflake/tests.rs
+++ b/crates/queryflux-frontend/src/snowflake/tests.rs
@@ -204,6 +204,7 @@ mod snowflake_frontend {
             group_order: vec!["mock".to_string()],
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_queue_timeouts: HashMap::new(),
         };
 
         let app_state = Arc::new(AppState {

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -56,6 +56,9 @@ pub struct LiveConfig {
     /// group_name → default tags configured on the group.
     /// Merged with session tags at dispatch time; session tags win on key conflicts.
     pub group_default_tags: HashMap<String, QueryTags>,
+    /// group_name → max time (ms) a sync/wire query waits for a cluster slot.
+    /// `None` → wait indefinitely. Populated from `ClusterGroupConfig.queue_timeout_ms`.
+    pub group_queue_timeouts: HashMap<String, Option<u64>>,
 }
 
 /// Shared application state — passed to every handler via `axum::extract::State`.
@@ -83,6 +86,7 @@ pub struct AppState {
 /// Stable per-query metadata that does not change across the query's lifecycle.
 /// Built once (after cluster selection and SQL translation) and passed to every
 /// `record_query` call within the same dispatch function.
+#[derive(Clone)]
 pub struct QueryContext {
     pub query_id: ProxyQueryId,
     pub sql: String,
@@ -110,6 +114,7 @@ pub struct QueryOutcome {
     /// Backend engine query ID (Trino query ID, Athena execution ID, etc.).
     pub backend_query_id: Option<String>,
     pub status: QueryStatus,
+    pub queue_duration_ms: u64,
     pub execution_ms: u64,
     pub rows: Option<u64>,
     pub error: Option<String>,
@@ -193,7 +198,7 @@ impl AppState {
                 .routing_trace
                 .as_ref()
                 .and_then(|t| serde_json::to_value(t).ok()),
-            queue_duration_ms: 0,
+            queue_duration_ms: outcome.queue_duration_ms,
             execution_duration_ms: outcome.execution_ms,
             rows_returned: outcome.rows,
             error_message: outcome.error,

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use bytes::Bytes;
 use chrono::Utc;
-use queryflux_auth::{AuthContext, Credentials};
+use queryflux_auth::Credentials;
 use queryflux_core::{
     error::QueryFluxError,
     query::{BackendQueryId, FrontendProtocol, ProxyQueryId, QueryPollResult, QueryStatus},
@@ -23,7 +23,8 @@ use serde_json::{json, Value};
 use tracing::{info, warn};
 
 use super::result_sink::TrinoHttpResultSink;
-use crate::dispatch::{dispatch_query, execute_to_sink, rewrite_trino_uri, DispatchOutcome};
+use super::trino_dispatch::rewrite_trino_uri;
+use crate::dispatch::{dispatch_query, execute_to_sink, resolve_route, DispatchOutcome};
 use crate::state::{AppState, QueryContext, QueryOutcome};
 
 fn trino_error_response(query_id: &str, message: &str) -> Response<Body> {
@@ -400,30 +401,16 @@ pub async fn post_statement(
         }
     };
 
-    // 2. Route — first matching router wins.
-    // `route_with_trace` is CPU-bound (regex match, header lookup); holding the read lock
-    // across this call is fine since it's brief and read-locks don't block each other.
-    let routing_result = {
-        let live = state.live.read().await;
-        live.router_chain
-            .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
-            .await
-    };
-    let (group, trace) = match routing_result {
+    // 2. Route — centralized routing + authorization-aware fallback resolution.
+    let (group, routing_trace) = match resolve_route(&state, &sql, &session, &protocol, &auth_ctx)
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             warn!("Routing error: {e}");
             let tmp_id = ProxyQueryId::new();
             return trino_error_response(&tmp_id.0, &format!("Routing error: {e}")).into_response();
         }
-    };
-
-    // 3. Authorization-aware first-fit when router chain fell back to static default.
-    // If the user is authorized for a more specific group, use it instead.
-    let group = if trace.used_fallback {
-        resolve_group_for_user(&state, &auth_ctx, group).await
-    } else {
-        group
     };
 
     let query_id = ProxyQueryId::new();
@@ -447,6 +434,7 @@ pub async fn post_statement(
             false,
             0,
             &auth_ctx,
+            Some(routing_trace.clone()),
         )
         .await
         {
@@ -460,6 +448,7 @@ pub async fn post_statement(
                     session,
                     protocol,
                     group,
+                    Some(routing_trace),
                     &mut sink,
                     &auth_ctx,
                 )
@@ -487,6 +476,7 @@ pub async fn post_statement(
             session,
             protocol,
             group,
+            Some(routing_trace),
             &mut sink,
             &auth_ctx,
         )
@@ -589,26 +579,6 @@ fn base64_decode(encoded: &str) -> Result<String, ()> {
     String::from_utf8(out).map_err(|_| ())
 }
 
-/// When the router chain fell back to the static default, check if the authenticated user
-/// is authorized for any specific group and return the first match.
-/// Falls back to the static `routingFallback` group if no authorized group found.
-async fn resolve_group_for_user(
-    state: &AppState,
-    auth_ctx: &AuthContext,
-    fallback: queryflux_core::query::ClusterGroupName,
-) -> queryflux_core::query::ClusterGroupName {
-    // Snapshot the group order under the read lock, then drop the lock before
-    // calling authorization.check (which may do async I/O, e.g. OpenFGA).
-    let group_order = state.live.read().await.group_order.clone();
-    for group_name in &group_order {
-        let group = queryflux_core::query::ClusterGroupName(group_name.clone());
-        if state.authorization.check(auth_ctx, group_name).await {
-            return group;
-        }
-    }
-    fallback
-}
-
 /// GET /v1/statement/qf/queued/{id}/{seq} — poll a query queued in QueryFlux.
 pub async fn get_queued_statement(
     State(state): State<Arc<AppState>>,
@@ -657,6 +627,7 @@ pub async fn get_queued_statement(
             true,
             seq,
             &auth_ctx,
+            None,
         )
         .await
         {
@@ -671,6 +642,7 @@ pub async fn get_queued_statement(
                     session,
                     protocol,
                     group,
+                    None,
                     &mut sink,
                     &auth_ctx,
                 )
@@ -695,6 +667,7 @@ pub async fn get_queued_statement(
             session,
             protocol,
             group,
+            None,
             &mut sink,
             &auth_ctx,
         )
@@ -836,7 +809,7 @@ pub async fn get_executing_statement(
     };
 
     // Guard actions captured at submit time — injected into the final record_query call.
-    let submit_guard_actions: Vec<queryflux_persistence::GuardAction> = serde_json::from_value(
+    let submit_guard_actions: Vec<queryflux_core::query::GuardAction> = serde_json::from_value(
         serde_json::Value::Array(executing.submitted_guard_actions.clone()),
     )
     .unwrap_or_default();
@@ -855,6 +828,7 @@ pub async fn get_executing_statement(
                     QueryOutcome {
                         backend_query_id: Some(backend_id.0.clone()),
                         status: QueryStatus::Success,
+                        queue_duration_ms: 0,
                         execution_ms: elapsed_ms,
                         rows: None,
                         error: None,
@@ -890,6 +864,7 @@ pub async fn get_executing_statement(
                 QueryOutcome {
                     backend_query_id: Some(backend_id.0.clone()),
                     status: QueryStatus::Failed,
+                    queue_duration_ms: 0,
                     execution_ms: elapsed_ms,
                     rows: None,
                     error: Some(message.clone()),

--- a/crates/queryflux-frontend/src/trino_http/mod.rs
+++ b/crates/queryflux-frontend/src/trino_http/mod.rs
@@ -1,6 +1,7 @@
 pub mod handlers;
 pub mod result_sink;
 pub mod state;
+pub mod trino_dispatch;
 
 use std::sync::Arc;
 

--- a/crates/queryflux-frontend/src/trino_http/trino_dispatch.rs
+++ b/crates/queryflux-frontend/src/trino_http/trino_dispatch.rs
@@ -1,0 +1,198 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use chrono::Utc;
+use queryflux_cluster_manager::ClusterGroupManager;
+use queryflux_core::query::{ExecutingQuery, FrontendProtocol, QueryEngineStats, QueryStatus};
+use queryflux_core::session::SessionContext;
+use queryflux_engine_adapters::trino::api::TrinoResponse;
+use queryflux_engine_adapters::AsyncAdapter;
+use tracing::warn;
+
+use crate::state::{AppState, QueryContext, QueryOutcome};
+
+/// Rewrite a Trino-origin URL to point to QueryFlux instead, keeping the full path.
+/// `http://trino:8080/v1/statement/executing/{id}/{token}` →
+/// `http://queryflux:9000/v1/statement/executing/{id}/{token}`
+///
+/// Any instance can then reconstruct the Trino URL by looking up the stored
+/// `trino_endpoint` and re-joining it with the path.
+pub(crate) fn rewrite_trino_uri(trino_uri: &str, external_address: &str) -> String {
+    if let Some(path_start) = trino_uri.find("/v1/") {
+        format!(
+            "{}{}",
+            external_address.trim_end_matches('/'),
+            &trino_uri[path_start..]
+        )
+    } else {
+        trino_uri.to_string()
+    }
+}
+
+/// Determine the terminal `QueryOutcome` from a Trino submit response body.
+///
+/// Parses the body to determine success vs failure. `engine_stats` is passed in
+/// from `adapter.terminal_stats_from_body()` — Trino-specific stats parsing lives
+/// in the adapter, not here.
+///
+/// Returns `(outcome, Option<warn_log_message>)`.
+pub(crate) fn trino_submit_terminal_outcome(
+    body: &Bytes,
+    elapsed_ms: u64,
+    backend_id: String,
+    engine_stats: Option<QueryEngineStats>,
+) -> (QueryOutcome, Option<String>) {
+    let trino_resp: TrinoResponse = match serde_json::from_slice(body.as_ref()) {
+        Ok(r) => r,
+        Err(e) => {
+            let warn_msg = format!(
+                "trino submit terminal body JSON parse failed: {e}; releasing cluster + clearing persistence"
+            );
+            return (
+                QueryOutcome {
+                    backend_query_id: Some(backend_id),
+                    status: QueryStatus::Failed,
+                    queue_duration_ms: 0,
+                    execution_ms: elapsed_ms,
+                    rows: None,
+                    error: Some(format!("failed to parse Trino response: {e}")),
+                    routing_trace: None,
+                    engine_stats,
+                    guard_actions: vec![],
+                    was_guard_blocked: false,
+                },
+                Some(warn_msg),
+            );
+        }
+    };
+
+    let backend_id = Some(backend_id);
+
+    if let Some(err) = &trino_resp.error {
+        (
+            QueryOutcome {
+                backend_query_id: backend_id,
+                status: QueryStatus::Failed,
+                queue_duration_ms: 0,
+                execution_ms: elapsed_ms,
+                rows: None,
+                error: Some(err.message.clone()),
+                routing_trace: None,
+                engine_stats,
+                guard_actions: vec![],
+                was_guard_blocked: false,
+            },
+            None,
+        )
+    } else if trino_resp.stats.state == "FAILED" {
+        (
+            QueryOutcome {
+                backend_query_id: backend_id,
+                status: QueryStatus::Failed,
+                queue_duration_ms: 0,
+                execution_ms: elapsed_ms,
+                rows: None,
+                error: Some("Trino query FAILED".to_string()),
+                routing_trace: None,
+                engine_stats,
+                guard_actions: vec![],
+                was_guard_blocked: false,
+            },
+            None,
+        )
+    } else {
+        (
+            QueryOutcome {
+                backend_query_id: backend_id,
+                status: QueryStatus::Success,
+                queue_duration_ms: 0,
+                execution_ms: elapsed_ms,
+                rows: None,
+                error: None,
+                routing_trace: None,
+                engine_stats,
+                guard_actions: vec![],
+                was_guard_blocked: false,
+            },
+            None,
+        )
+    }
+}
+
+/// Trino may return `FINISHED` with no `nextUri` on the initial POST `/v1/statement` response.
+/// Clients then never call GET `/v1/statement/...`, so `get_executing_statement` never runs —
+/// mirror its metrics, `record_query`, and persistence cleanup here.
+///
+/// Collapsed from 4 branches (including JSON parse error) to a single `record_query` call.
+pub(crate) async fn finalize_trino_async_terminal_on_submit(
+    state: &Arc<AppState>,
+    cluster_manager: &Arc<dyn ClusterGroupManager>,
+    executing: &ExecutingQuery,
+    adapter: &Arc<dyn AsyncAdapter>,
+    session: &SessionContext,
+    protocol: FrontendProtocol,
+    body: &Bytes,
+) {
+    let elapsed_ms = (Utc::now() - executing.creation_time)
+        .num_milliseconds()
+        .max(0) as u64;
+
+    let was_translated = executing.translated_sql.is_some();
+    let src_dialect = protocol.default_dialect();
+    let ctx = QueryContext {
+        query_id: executing.id.clone(),
+        sql: executing
+            .translated_sql
+            .as_deref()
+            .unwrap_or(&executing.sql)
+            .to_string(),
+        session: session.clone(),
+        protocol,
+        group: executing.cluster_group.clone(),
+        cluster: executing.cluster_name.clone(),
+        cluster_group_config_id: executing.cluster_group_config_id,
+        cluster_config_id: executing.cluster_config_id,
+        engine_type: adapter.engine_type(),
+        src_dialect,
+        tgt_dialect: adapter.translation_target_dialect(),
+        was_translated,
+        translated_sql: if was_translated {
+            Some(executing.sql.clone())
+        } else {
+            None
+        },
+        query_tags: executing.query_tags.clone(),
+        query_params: vec![],
+        agent_context: executing.agent_context.clone(),
+    };
+
+    let engine_stats = adapter.terminal_stats_from_body(body);
+    let (mut outcome, warn_msg) = trino_submit_terminal_outcome(
+        body,
+        elapsed_ms,
+        executing.backend_query_id.0.clone(),
+        engine_stats,
+    );
+
+    let stored_actions: Vec<queryflux_core::query::GuardAction> = serde_json::from_value(
+        serde_json::Value::Array(executing.submitted_guard_actions.clone()),
+    )
+    .unwrap_or_default();
+    if !stored_actions.is_empty() {
+        outcome.guard_actions = stored_actions;
+        outcome.was_guard_blocked = executing.was_guard_blocked;
+    }
+
+    if let Some(msg) = warn_msg {
+        warn!(proxy_id = %executing.id, "{msg}");
+    }
+
+    state
+        .metrics
+        .on_query_finished(&executing.cluster_group.0, &executing.cluster_name.0);
+    state.record_query(&ctx, outcome);
+    let _ = cluster_manager
+        .release_cluster(&executing.cluster_group, &executing.cluster_name)
+        .await;
+    let _ = state.persistence.delete(&executing.backend_query_id).await;
+}

--- a/crates/queryflux-guardrails/Cargo.toml
+++ b/crates/queryflux-guardrails/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 queryflux-core = { workspace = true }
-queryflux-persistence = { workspace = true }
 async-trait = { workspace = true }
 polyglot-sql = { workspace = true }
 serde = { workspace = true }

--- a/crates/queryflux-guardrails/src/chain.rs
+++ b/crates/queryflux-guardrails/src/chain.rs
@@ -3,7 +3,7 @@ use crate::{
     context::{GuardContext, GuardLayer},
     result_to_action,
 };
-use queryflux_persistence::GuardAction;
+use queryflux_core::query::GuardAction;
 
 /// Ordered chain of guards for a single layer.
 pub struct GuardChain {

--- a/crates/queryflux-guardrails/src/lib.rs
+++ b/crates/queryflux-guardrails/src/lib.rs
@@ -7,7 +7,7 @@ pub use chain::GuardChain;
 pub use config::{GuardChainConfig, GuardGroupConfig, GuardKind, GuardLayerConfig};
 pub use context::{GuardContext, GuardLayer, GuardResult};
 
-use queryflux_persistence::GuardAction;
+use queryflux_core::query::GuardAction;
 
 /// Convert a `GuardResult` into a `GuardAction` for audit recording.
 pub fn result_to_action(guard_name: &str, result: &GuardResult) -> GuardAction {

--- a/crates/queryflux-metrics/src/lib.rs
+++ b/crates/queryflux-metrics/src/lib.rs
@@ -12,7 +12,8 @@ use queryflux_core::error::Result;
 // to depend on one crate.  Re-export them here so all existing call sites
 // (`use queryflux_metrics::{MetricsStore, QueryRecord, ...}`) continue to
 // compile without any changes.
-pub use queryflux_persistence::{ClusterSnapshot, GuardAction, MetricsStore, QueryRecord};
+pub use queryflux_core::query::GuardAction;
+pub use queryflux_persistence::{ClusterSnapshot, MetricsStore, QueryRecord};
 
 /// Fans out to multiple stores. Useful for combining Prometheus (real-time)
 /// with Postgres (historical) without changing callers.

--- a/crates/queryflux-persistence/src/cluster_config.rs
+++ b/crates/queryflux-persistence/src/cluster_config.rs
@@ -75,6 +75,9 @@ pub struct ClusterGroupConfigRecord {
     pub members: Vec<String>,
     pub max_running_queries: i64,
     pub max_queued_queries: Option<i64>,
+    /// Max time (ms) a wire-protocol query waits for a free cluster slot.
+    /// `null` means wait indefinitely.
+    pub queue_timeout_ms: Option<i64>,
     /// Serialised `StrategyConfig`. `null` means RoundRobin (the default).
     #[schema(value_type = Option<Object>)]
     pub strategy: Option<serde_json::Value>,
@@ -101,6 +104,10 @@ pub struct UpsertClusterGroupConfig {
     pub members: Vec<String>,
     pub max_running_queries: i64,
     pub max_queued_queries: Option<i64>,
+    /// Max time (ms) a wire-protocol query waits for a free cluster slot.
+    /// `null` means wait indefinitely (default).
+    #[serde(default)]
+    pub queue_timeout_ms: Option<i64>,
     /// `null` = RoundRobin. Set to `{"type":"leastLoaded"}` etc. for other strategies.
     pub strategy: Option<serde_json::Value>,
     #[serde(default)]
@@ -234,6 +241,7 @@ impl UpsertClusterGroupConfig {
             members: cfg.members.clone(),
             max_running_queries: cfg.max_running_queries as i64,
             max_queued_queries: cfg.max_queued_queries.map(|v| v as i64),
+            queue_timeout_ms: cfg.queue_timeout_ms.map(|v| v as i64),
             strategy,
             allow_groups: cfg.authorization.allow_groups.clone(),
             allow_users: cfg.authorization.allow_users.clone(),
@@ -279,6 +287,7 @@ impl ClusterGroupConfigRecord {
             strategy,
             max_running_queries: self.max_running_queries as u64,
             max_queued_queries: self.max_queued_queries.map(|v| v as u64),
+            queue_timeout_ms: self.queue_timeout_ms.map(|v| v as u64),
             authorization: queryflux_core::config::ClusterGroupAuthorizationConfig {
                 allow_groups: self.allow_groups.clone(),
                 allow_users: self.allow_users.clone(),
@@ -310,6 +319,7 @@ mod tests {
             members: vec!["c1".to_string()],
             max_running_queries: 10,
             max_queued_queries: None,
+            queue_timeout_ms: None,
             strategy: None,
             allow_groups: vec![],
             allow_users: vec![],
@@ -327,6 +337,7 @@ mod tests {
             strategy: None,
             max_running_queries: 10,
             max_queued_queries: None,
+            queue_timeout_ms: None,
             authorization: queryflux_core::config::ClusterGroupAuthorizationConfig {
                 allow_groups: vec![],
                 allow_users: vec![],
@@ -402,6 +413,26 @@ mod tests {
         let upsert = UpsertClusterGroupConfig::from_core(&make_core_group(QueryTags::new()));
         assert!(upsert.default_tags.is_object());
         assert_eq!(upsert.default_tags.as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn from_core_preserves_queue_timeout() {
+        let mut group = make_core_group(QueryTags::new());
+        group.queue_timeout_ms = Some(30_000);
+
+        let upsert = UpsertClusterGroupConfig::from_core(&group);
+
+        assert_eq!(upsert.queue_timeout_ms, Some(30_000));
+    }
+
+    #[test]
+    fn to_core_preserves_queue_timeout() {
+        let mut record = make_record(serde_json::json!({}));
+        record.queue_timeout_ms = Some(45_000);
+
+        let core = record.to_core();
+
+        assert_eq!(core.queue_timeout_ms, Some(45_000));
     }
 
     // --- roundtrip: core → upsert → record → core ---

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -450,6 +450,7 @@ impl ClusterConfigStore for InMemoryPersistence {
             members: cfg.members.clone(),
             max_running_queries: cfg.max_running_queries,
             max_queued_queries: cfg.max_queued_queries,
+            queue_timeout_ms: cfg.queue_timeout_ms,
             strategy: cfg.strategy.clone(),
             allow_groups: cfg.allow_groups.clone(),
             allow_users: cfg.allow_users.clone(),
@@ -781,6 +782,7 @@ mod tests {
             members: vec!["c1".to_string()],
             max_running_queries: 10,
             max_queued_queries: None,
+            queue_timeout_ms: None,
             strategy: None,
             allow_groups: vec![],
             allow_users: vec![],
@@ -820,6 +822,19 @@ mod tests {
             .await
             .unwrap();
         assert!(record.default_tags.as_object().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn upsert_group_stores_queue_timeout() {
+        let store = store_with_cluster().await;
+        let mut group = group_upsert(serde_json::json!({}));
+        group.queue_timeout_ms = Some(30_000);
+
+        let record = store.upsert_group_config("g1", &group).await.unwrap();
+
+        assert_eq!(record.queue_timeout_ms, Some(30_000));
+        let fetched = store.get_group_config("g1").await.unwrap().unwrap();
+        assert_eq!(fetched.queue_timeout_ms, Some(30_000));
     }
 
     #[tokio::test]

--- a/crates/queryflux-persistence/src/lib.rs
+++ b/crates/queryflux-persistence/src/lib.rs
@@ -23,8 +23,10 @@ use crate::{
 };
 
 // Re-export so callers can do `queryflux_persistence::MetricsStore` etc.
-pub use metrics_store::{ClusterSnapshot, GuardAction, MetricsStore, QueryRecord};
+pub use metrics_store::{ClusterSnapshot, MetricsStore, QueryRecord};
+// GuardAction now lives in queryflux-core; re-export for backward compatibility.
 pub use query_history::{AgentSummary, ConversationSummary, QuerySummary};
+pub use queryflux_core::query::GuardAction;
 pub use script_library::{
     is_valid_script_kind, UpsertUserScript, UserScriptRecord, KIND_GUARD, KIND_ROUTING,
     KIND_TRANSLATION_FIXUP,

--- a/crates/queryflux-persistence/src/metrics_store.rs
+++ b/crates/queryflux-persistence/src/metrics_store.rs
@@ -1,29 +1,15 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use queryflux_core::{
     error::Result,
     query::{
-        ClusterGroupName, ClusterName, EngineType, FrontendProtocol, QueryEngineStats, QueryStatus,
-        SqlDialect,
+        ClusterGroupName, ClusterName, EngineType, FrontendProtocol, GuardAction, QueryEngineStats,
+        QueryStatus, SqlDialect,
     },
     tags::QueryTags,
 };
-
-/// A single guard evaluation result — stored as JSONB in `query_history.guard_actions`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GuardAction {
-    pub guard: String,
-    pub action: String,
-    pub reason: Option<String>,
-    pub code: Option<String>,
-    /// Free-form key/value metadata returned by the guard (e.g. matched rule name,
-    /// estimated row count). Omitted from JSON when `None`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<std::collections::HashMap<String, String>>,
-}
 
 /// A record of one completed (or failed/cancelled) query execution.
 /// Written to the metrics store at the end of every query, regardless of outcome.

--- a/crates/queryflux-persistence/src/postgres/migrations/20260610000001_group_queue_timeout.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260610000001_group_queue_timeout.sql
@@ -1,0 +1,4 @@
+-- Add configurable queue timeout for wire-protocol queries per cluster group.
+-- NULL means wait indefinitely (legacy/default behavior).
+ALTER TABLE cluster_group_configs
+    ADD COLUMN queue_timeout_ms BIGINT;

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -44,6 +44,7 @@ SELECT
     ) AS members,
     g.max_running_queries,
     g.max_queued_queries,
+    g.queue_timeout_ms,
     g.strategy,
     g.allow_groups,
     g.allow_users,
@@ -579,13 +580,14 @@ impl ClusterConfigStore for PostgresStore {
 
         sqlx::query(
             r#"INSERT INTO cluster_group_configs
-                   (name, enabled, members, max_running_queries, max_queued_queries, strategy, allow_groups, allow_users, translation_script_ids, default_tags)
-               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                   (name, enabled, members, max_running_queries, max_queued_queries, queue_timeout_ms, strategy, allow_groups, allow_users, translation_script_ids, default_tags)
+               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
                ON CONFLICT (name) DO UPDATE SET
                    enabled                = EXCLUDED.enabled,
                    members                = EXCLUDED.members,
                    max_running_queries    = EXCLUDED.max_running_queries,
                    max_queued_queries     = EXCLUDED.max_queued_queries,
+                   queue_timeout_ms       = EXCLUDED.queue_timeout_ms,
                    strategy               = EXCLUDED.strategy,
                    allow_groups           = EXCLUDED.allow_groups,
                    allow_users            = EXCLUDED.allow_users,
@@ -598,6 +600,7 @@ impl ClusterConfigStore for PostgresStore {
         .bind(&member_ids)
         .bind(cfg.max_running_queries)
         .bind(cfg.max_queued_queries)
+        .bind(cfg.queue_timeout_ms)
         .bind(&cfg.strategy)
         .bind(&cfg.allow_groups)
         .bind(&cfg.allow_users)

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -724,6 +724,12 @@ async fn main() -> Result<()> {
         .filter(|(_, g)| !g.default_tags.is_empty())
         .map(|(name, g)| (name.clone(), g.default_tags.clone()))
         .collect();
+    let group_queue_timeouts: HashMap<String, Option<u64>> = config
+        .cluster_groups
+        .iter()
+        .filter(|(_, g)| g.queue_timeout_ms.is_some())
+        .map(|(name, g)| (name.clone(), g.queue_timeout_ms))
+        .collect();
     let live_config = LiveConfig {
         router_chain,
         guard_chain,
@@ -736,6 +742,7 @@ async fn main() -> Result<()> {
         group_order,
         group_translation_scripts,
         group_default_tags,
+        group_queue_timeouts,
     };
     // Seed the reload cache. When Postgres is active, fingerprint `engine_key` + JSONB config
     // (same format as `build_live_config` on reload) so an engine change rebuilds adapters even
@@ -1602,6 +1609,12 @@ async fn build_live_config(
         .map(|(name, g)| (name.clone(), g.default_tags.clone()))
         .collect();
 
+    let group_queue_timeouts: HashMap<String, Option<u64>> = cluster_groups
+        .iter()
+        .filter(|(_, g)| g.queue_timeout_ms.is_some())
+        .map(|(name, g)| (name.clone(), g.queue_timeout_ms))
+        .collect();
+
     Ok(LiveConfig {
         router_chain,
         guard_chain: None,
@@ -1614,6 +1627,7 @@ async fn build_live_config(
         group_order,
         group_translation_scripts,
         group_default_tags,
+        group_queue_timeouts,
     })
 }
 

--- a/queryflux-studio/components/group-form-dialog.tsx
+++ b/queryflux-studio/components/group-form-dialog.tsx
@@ -46,6 +46,7 @@ export function GroupFormDialog({
   const [memberOrder, setMemberOrder] = useState<string[]>([]);
   const [maxRunning, setMaxRunning] = useState("10");
   const [maxQueued, setMaxQueued] = useState("");
+  const [queueTimeout, setQueueTimeout] = useState("");
   const [strategyKind, setStrategyKind] = useState<StrategyKind>("default");
   const [enginePreferenceCsv, setEnginePreferenceCsv] = useState("");
   const [weightedJson, setWeightedJson] = useState("{}");
@@ -67,6 +68,7 @@ export function GroupFormDialog({
     setMemberOrder([]);
     setMaxRunning("10");
     setMaxQueued("");
+    setQueueTimeout("");
     setStrategyKind("default");
     setEnginePreferenceCsv("");
     setWeightedJson("{}");
@@ -91,6 +93,9 @@ export function GroupFormDialog({
       setMaxRunning(String(initial.maxRunningQueries));
       setMaxQueued(
         initial.maxQueuedQueries != null ? String(initial.maxQueuedQueries) : "",
+      );
+      setQueueTimeout(
+        initial.queueTimeoutMs != null ? String(initial.queueTimeoutMs) : "",
       );
       setTranslationScriptIds([...initial.translationScriptIds]);
       setTagRows(
@@ -204,6 +209,17 @@ export function GroupFormDialog({
       maxQ = n;
     }
 
+    let qTimeout: number | null = null;
+    const qt = queueTimeout.trim();
+    if (qt !== "") {
+      const n = parseInt(qt, 10);
+      if (!Number.isFinite(n) || n < 1) {
+        setError("Queue timeout must be empty or a positive integer (ms).");
+        return;
+      }
+      qTimeout = n;
+    }
+
     let strategy: Record<string, unknown> | null;
     try {
       strategy = buildStrategyPayload(
@@ -237,6 +253,7 @@ export function GroupFormDialog({
       members,
       maxRunningQueries: maxR,
       maxQueuedQueries: maxQ,
+      queueTimeoutMs: qTimeout,
       strategy,
       // Group allow-lists are driven by routing / security config, not edited here.
       allowGroups: mode === "edit" && initial ? [...initial.allowGroups] : [],
@@ -383,7 +400,7 @@ export function GroupFormDialog({
             </button>
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             <div>
               <label className="block text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-1.5">
                 Max running queries <span className="text-red-500">*</span>
@@ -405,9 +422,25 @@ export function GroupFormDialog({
                 min={0}
                 value={maxQueued}
                 onChange={(e) => setMaxQueued(e.target.value)}
-                placeholder="optional"
+                placeholder="unlimited"
                 className="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
               />
+            </div>
+            <div>
+              <label className="block text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-1.5">
+                Queue timeout (ms)
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={queueTimeout}
+                onChange={(e) => setQueueTimeout(e.target.value)}
+                placeholder="unlimited"
+                className="w-full text-sm border border-slate-200 rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              />
+              <p className="text-[10px] text-slate-400 mt-1">
+                Wire-protocol wait limit
+              </p>
             </div>
           </div>
 

--- a/queryflux-studio/components/groups-config-panel.tsx
+++ b/queryflux-studio/components/groups-config-panel.tsx
@@ -109,6 +109,7 @@ export function GroupsConfigPanel({ groups, clusterNames }: Props) {
                 <th className="px-4 py-3 min-w-[140px]">Strategy</th>
                 <th className="px-4 py-3 w-24">Max run</th>
                 <th className="px-4 py-3 w-28">Max queue</th>
+                <th className="px-4 py-3 w-28">Queue timeout</th>
                 <th className="px-6 py-3 text-right w-40">Actions</th>
               </tr>
             </thead>
@@ -147,6 +148,9 @@ export function GroupsConfigPanel({ groups, clusterNames }: Props) {
                   </td>
                   <td className="px-4 py-3 font-mono text-xs text-slate-600">
                     {g.maxQueuedQueries ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-600">
+                    {g.queueTimeoutMs != null ? `${g.queueTimeoutMs}ms` : "—"}
                   </td>
                   <td className="px-6 py-3 text-right">
                     <div className="flex items-center justify-end gap-1">

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -236,6 +236,8 @@ export interface ClusterGroupConfigRecord {
   members: string[];
   maxRunningQueries: number;
   maxQueuedQueries: number | null;
+  /** Max time (ms) a wire-protocol query waits for a free cluster slot. `null` = unlimited. */
+  queueTimeoutMs: number | null;
   strategy: Record<string, unknown> | null;
   allowGroups: string[];
   allowUsers: string[];
@@ -253,6 +255,8 @@ export interface UpsertClusterGroupConfig {
   members: string[];
   maxRunningQueries: number;
   maxQueuedQueries?: number | null;
+  /** Max time (ms) a wire-protocol query waits for a free cluster slot. `null` = unlimited. */
+  queueTimeoutMs?: number | null;
   strategy?: Record<string, unknown> | null;
   allowGroups?: string[];
   allowUsers?: string[];

--- a/queryflux-studio/lib/group-config-helpers.ts
+++ b/queryflux-studio/lib/group-config-helpers.ts
@@ -75,6 +75,7 @@ export function normalizeClusterGroupRecord(raw: unknown): ClusterGroupConfigRec
     members,
     maxRunningQueries: num("maxRunningQueries", "max_running_queries", 10),
     maxQueuedQueries: maybeNullNum("maxQueuedQueries", "max_queued_queries"),
+    queueTimeoutMs: maybeNullNum("queueTimeoutMs", "queue_timeout_ms"),
     strategy,
     allowGroups: strArr("allowGroups", "allow_groups"),
     allowUsers: strArr("allowUsers", "allow_users"),
@@ -97,6 +98,10 @@ export function clusterGroupRecordToUpsert(
       overrides.maxQueuedQueries !== undefined
         ? overrides.maxQueuedQueries
         : r.maxQueuedQueries,
+    queueTimeoutMs:
+      overrides.queueTimeoutMs !== undefined
+        ? overrides.queueTimeoutMs
+        : r.queueTimeoutMs,
     strategy:
       overrides.strategy !== undefined ? overrides.strategy : r.strategy,
     allowGroups: overrides.allowGroups ?? [...r.allowGroups],


### PR DESCRIPTION
# User description
## Summary

- Track query queue duration through persisted query outcomes and history.
- Add configurable wire-protocol queue timeouts, including admin API, DB migration, and Studio UI support.
- Refactor Trino dispatch/query lifecycle handling and document follow-up tasks for distributed queueing and custom group routing.

## Test plan

- `cargo test --workspace --exclude queryflux-translation`
- `cargo clippy --workspace --exclude queryflux-translation --all-targets -- -D warnings`
- `cargo test -p queryflux-persistence queue_timeout`
- `npm --prefix queryflux-studio exec -- tsc -p queryflux-studio/tsconfig.json --noEmit`
- `npm run lint` in `queryflux-studio`

Note: `queryflux-translation` tests are excluded because they require a local Python/sqlglot environment.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Track wire-protocol queue lifecycles by centralizing routing/translation helpers (<code>resolve_route</code>, <code>route_and_execute</code>) so every frontend flow records <code>queue_duration_ms</code>, guard actions, and cancellation metadata on <code>QueryOutcome</code>. Harmonize per-group <code>queue_timeout_ms</code> from config through persistence, live state, and Studio forms so admins can limit how long sync protocols wait for cluster slots.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lakeops-org/queryflux/80?tool=ast&topic=Queue+timeout+config>Queue timeout config</a>
        </td><td>Expose per-group <code>queue_timeout_ms</code> from cluster config through persistence stores, live state, and Studio admin UI so wire protocols can cap how long they wait for cluster slots while tests and harnesses carry the new metadata.<details><summary>Modified files (13)</summary><ul><li>crates/queryflux-core/src/config.rs</li>
<li>crates/queryflux-e2e-tests/src/harness.rs</li>
<li>crates/queryflux-frontend/src/snowflake/tests.rs</li>
<li>crates/queryflux-frontend/src/state.rs</li>
<li>crates/queryflux-persistence/src/cluster_config.rs</li>
<li>crates/queryflux-persistence/src/in_memory.rs</li>
<li>crates/queryflux-persistence/src/postgres/migrations/20260610000001_group_queue_timeout.sql</li>
<li>crates/queryflux-persistence/src/postgres/mod.rs</li>
<li>crates/queryflux/src/main.rs</li>
<li>queryflux-studio/components/group-form-dialog.tsx</li>
<li>queryflux-studio/components/groups-config-panel.tsx</li>
<li>queryflux-studio/lib/api-types.ts</li>
<li>queryflux-studio/lib/group-config-helpers.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lakeops-org/queryflux/80?tool=ast&topic=Dispatch+lifecycle>Dispatch lifecycle</a>
        </td><td>Unify dispatch helpers so all frontends reuse <code>translate_and_prepare</code>, <code>resolve_route</code>, and <code>route_and_execute</code>, carry <code>routing_trace</code>/<code>queue_duration_ms</code>, reuse the shared <code>GuardAction</code>, and guard against client cancellation before recording query outcomes.<details><summary>Modified files (12)</summary><ul><li>crates/queryflux-frontend/src/dispatch.rs</li>
<li>crates/queryflux-frontend/src/flight_sql/mod.rs</li>
<li>crates/queryflux-frontend/src/mysql_wire/mod.rs</li>
<li>crates/queryflux-frontend/src/postgres_wire/mod.rs</li>
<li>crates/queryflux-frontend/src/snowflake/http/handlers/query.rs</li>
<li>crates/queryflux-frontend/src/snowflake/http/handlers/session.rs</li>
<li>crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs</li>
<li>crates/queryflux-frontend/src/snowflake/tests.rs</li>
<li>crates/queryflux-frontend/src/state.rs</li>
<li>crates/queryflux-frontend/src/trino_http/handlers.rs</li>
<li>crates/queryflux-frontend/src/trino_http/mod.rs</li>
<li>crates/queryflux-frontend/src/trino_http/trino_dispatch.rs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lakeops-org/queryflux/80?tool=ast&topic=Guard+action+model>Guard action model</a>
        </td><td>Move <code>GuardAction</code> ownership into <code>queryflux-core</code>, re-export it via metrics/persistence, and update guardrails so telemetry/metrics layers no longer depend on <code>queryflux-persistence</code>.<details><summary>Modified files (8)</summary><ul><li>Cargo.lock</li>
<li>crates/queryflux-core/src/query.rs</li>
<li>crates/queryflux-guardrails/Cargo.toml</li>
<li>crates/queryflux-guardrails/src/chain.rs</li>
<li>crates/queryflux-guardrails/src/lib.rs</li>
<li>crates/queryflux-metrics/src/lib.rs</li>
<li>crates/queryflux-persistence/src/lib.rs</li>
<li>crates/queryflux-persistence/src/metrics_store.rs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lakeops-org/queryflux/80?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable queue timeout per cluster group to limit how long wire-protocol queries wait for available cluster slots; `null` means unlimited.
  * Introduced queue duration tracking to measure how long queries wait for cluster resources.

* **User Interface**
  * Studio now supports viewing and configuring queue timeout settings for each cluster group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->