### PR TITLE
docs: add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,23 @@
+---
+name: Documentation
+about: Report missing, confusing, or incorrect documentation
+title: ''
+labels: 'documentation, docs'
+assignees: ''
+
+---
+
+**Documentation area**
+Which page, README section, example, or command needs an update?
+
+**What is unclear or incorrect?**
+Describe the missing, outdated, or confusing documentation.
+
+**Expected documentation**
+Describe what the documentation should say or link to instead.
+
+**Checked version**
+Add the commit, release, docs URL, or local command you checked.
+
+**Additional context**
+Add any related issue, error output, or screenshot that would help explain the documentation problem.


### PR DESCRIPTION
## Summary
- add a dedicated documentation issue template
- prefill the documentation/docs labels
- ask reporters for the affected page, expected update, and checked version

## Context
Closes #46.

## Testing
- Not run; GitHub issue template only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new GitHub issue template for documentation issues, enabling users to report documentation problems with structured guidance for consistent issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->