### PR TITLE
ci: skip CI and release for docs-only and GitHub template changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,20 @@ on:
     paths-ignore:
       - 'website/**'
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/DISCUSSION_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE*'
   pull_request:
     paths-ignore:
       - 'website/**'
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/DISCUSSION_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE*'
 
 # One active run per ref: new pushes cancel older in-progress runs on the same branch/PR.
 concurrency:

--- a/.github/workflows/docker-verify.yml
+++ b/.github/workflows/docker-verify.yml
@@ -8,7 +8,11 @@ on:
     paths-ignore:
       - 'website/**'
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/DISCUSSION_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'LICENSE*'
 
 jobs:
   docker-verify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,11 @@ on:
     paths-ignore:
       - "website/**"
       - "docs/**"
-      - "*.md"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/DISCUSSION_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - "LICENSE*"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
# User description
Expand paths-ignore so markdown and .github templates do not trigger full CI, Docker verify, or release builds on PRs like issue templates.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expand GitHub workflow path filters to prevent docs-only updates from triggering CI, Docker verify, and release jobs. Apply the broader ignore list across the ci, docker-verify, and release workflows to cover markdown and GitHub template edits.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
<sub><a href="https://baz.co/changes/lakeops-org/queryflux/85?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>