### PR TITLE
feat: make running QueryFlux as plain CLI binary first-class and modularize CLI crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,7 @@ rustflags = ["-L", "native=/opt/homebrew/lib"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-L", "native=/usr/local/lib"]
+
+[env]
+# Safely fall back to downloading libduckdb if not installed on the system
+DUCKDB_DOWNLOAD_LIB = { value = "1", force = false }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "opentelemetry_sdk",
  "queryflux-auth",
  "queryflux-cache",
+ "queryflux-cli",
  "queryflux-cluster-manager",
  "queryflux-config",
  "queryflux-core",
@@ -3851,6 +3852,17 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+]
+
+[[package]]
+name = "queryflux-cli"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "queryflux-config",
+ "queryflux-core",
+ "queryflux-translation",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/queryflux-metrics",
     "crates/queryflux-fingerprint",
     "crates/queryflux-guardrails",
+    "crates/queryflux-cli",
 ]
 
 [workspace.package]
@@ -88,6 +89,7 @@ queryflux-cache = { path = "crates/queryflux-cache" }
 opendal = { version = "0.53", features = ["services-fs", "services-s3", "services-gcs"] }
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 regex = "1"
+queryflux-cli = { path = "crates/queryflux-cli" }
 
 # Arrow ecosystem — version must match what duckdb uses (bundled duckdb crate pins arrow)
 arrow = { version = "58.1.0", features = ["ipc", "ipc_compression"] }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ curl -X POST http://localhost:8080/v1/statement \
   -d "SELECT 42"
 ```
 
+### CLI Quickstart (No Docker)
+
+You can run QueryFlux natively with an embedded DuckDB engine without any containers:
+
+```bash
+cargo build --release
+./target/release/queryflux --install-deps
+./target/release/queryflux --config examples/cli-quickstart/config.yaml --validate
+./target/release/queryflux --config examples/cli-quickstart/config.yaml
+```
+
 ### Kubernetes
 
 QueryFlux includes a provider-neutral Helm chart:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,20 +41,24 @@ queryflux:
   # configReloadIntervalSecs: 60
   # queryHistoryRetentionDays: 90
 
+clusters:
+  # trino-1:
+  #   engine: trino
+  #   endpoint: http://localhost:8081
+  duckdb-1:
+    engine: duckDb
+    # databasePath: /tmp/queryflux.duckdb
+
 clusterGroups:
   # trino-default:
-  #   engine: trino
   #   maxRunningQueries: 100
-  #   clusters:
-  #     - name: trino-1
-  #       endpoint: http://localhost:8081
+  #   members:
+  #     - trino-1
 
   duckdb-local:
-    engine: duckDb
     maxRunningQueries: 4
-    clusters:
-      - name: duckdb-1
-        # databasePath: /tmp/queryflux.duckdb
+    members:
+      - duckdb-1
 
 translation:
   errorOnUnsupported: false

--- a/crates/queryflux-cli/Cargo.toml
+++ b/crates/queryflux-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "queryflux-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+queryflux-core = { workspace = true }
+queryflux-config = { workspace = true }
+queryflux-translation = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+tokio = { workspace = true }

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -1,0 +1,309 @@
+use clap::Parser;
+use queryflux_config::{yaml::YamlFileConfigProvider, ConfigProvider};
+use queryflux_core::config::{ProxyConfig, EngineConfig, RouterConfig};
+use queryflux_core::query::{FrontendProtocol, SqlDialect, EngineType};
+
+#[derive(Parser, Debug)]
+#[command(name = "queryflux", about = "Multi-engine SQL query proxy", version)]
+pub struct Cli {
+    #[arg(short, long, default_value = "config.yaml")]
+    pub config: String,
+
+    /// Validate config and runtime environment (Python/sqlglot) and exit
+    #[arg(short, long)]
+    pub validate: bool,
+
+    /// Install required Python dependencies (sqlglot) in a local .venv and exit
+    #[arg(long)]
+    pub install_deps: bool,
+}
+
+impl Cli {
+    pub fn parse_args() -> Self {
+        Self::parse()
+    }
+}
+
+/// Automate Python path setup if .venv exists and PYTHONPATH/PYO3_PYTHON are unset
+pub fn setup_env() {
+    if std::env::var("PYO3_PYTHON").is_err() || std::env::var("PYTHONPATH").is_err() {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let venv_dir = cwd.join(".venv");
+        if venv_dir.exists() {
+            // Set PYO3_PYTHON
+            if std::env::var("PYO3_PYTHON").is_err() {
+                let venv_paths = vec![
+                    venv_dir.join("bin/python3"),
+                    venv_dir.join("bin/python"),
+                    venv_dir.join("Scripts/python.exe"),
+                ];
+                for path in venv_paths {
+                    if path.exists() {
+                        if let Some(path_str) = path.to_str() {
+                            std::env::set_var("PYO3_PYTHON", path_str);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Set PYTHONPATH by finding .venv/lib/python*/site-packages
+            if std::env::var("PYTHONPATH").is_err() {
+                let lib_dir = venv_dir.join("lib");
+                if lib_dir.exists() {
+                    if let Ok(entries) = std::fs::read_dir(lib_dir) {
+                        for entry in entries.flatten() {
+                            let path = entry.path();
+                            if path.is_dir() {
+                                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                                    if name.starts_with("python") {
+                                        let site_packages = path.join("site-packages");
+                                        if site_packages.exists() {
+                                            if let Some(site_str) = site_packages.to_str() {
+                                                std::env::set_var("PYTHONPATH", site_str);
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Validate config and runtime dependencies, then exit
+pub async fn handle_validation(config_path: &str) {
+    println!("Validating configuration file: {}", config_path);
+    let config_res = YamlFileConfigProvider::new(config_path).load().await;
+    let config = match config_res {
+        Ok(c) => {
+            println!("✓ Configuration file is valid YAML and matches the schema.");
+            c
+        }
+        Err(e) => {
+            eprintln!("✗ Failed to load or parse configuration file: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let requires_translation = config_requires_translation(&config);
+
+    println!("Validating Python & sqlglot environment...");
+    match queryflux_translation::TranslationService::new_sqlglot(vec![]) {
+        Ok(_) => {
+            println!("✓ Python interpreter and 'sqlglot' library are available and correctly configured.");
+        }
+        Err(e) => {
+            if requires_translation {
+                eprintln!("✗ Python/sqlglot dependency check failed: {}", e);
+                println!("\nDialect translation is required by your configuration.");
+                
+                use std::io::{self, IsTerminal, Write};
+                print!("Would you like to automatically create a virtual environment (.venv) and install 'sqlglot'? [y/N]: ");
+                let _ = io::stdout().flush();
+                let mut response = String::new();
+                let mut confirmed = false;
+                if io::stdin().is_terminal() && io::stdin().read_line(&mut response).is_ok() {
+                    let trimmed = response.trim().to_lowercase();
+                    if trimmed == "y" || trimmed == "yes" {
+                        confirmed = true;
+                    }
+                }
+
+                if confirmed {
+                    println!();
+                    handle_install_deps();
+                } else {
+                    eprintln!("\nTo run QueryFlux with SQL translation, please ensure that:");
+                    eprintln!("  1. Python 3.10+ is installed on the host.");
+                    eprintln!("  2. 'sqlglot' package is installed in your Python environment (run: pip install sqlglot).");
+                    eprintln!("  3. If using a virtual environment (venv), activate it or run 'queryflux --install-deps'.");
+                    std::process::exit(1);
+                }
+            } else {
+                println!("✓ Python/sqlglot is not available ({}), but translation is not required for this configuration.", e);
+            }
+        }
+    }
+
+    println!("\n✓ Validation successful! Configuration and runtime dependencies are correctly configured.");
+    std::process::exit(0);
+}
+
+fn config_requires_translation(config: &ProxyConfig) -> bool {
+    // 1. Gather all unique target group names from routers and the fallback group
+    let mut target_groups = vec![config.routing_fallback.clone()];
+
+    for router in &config.routers {
+        match router {
+            RouterConfig::ProtocolBased {
+                trino_http,
+                postgres_wire,
+                mysql_wire,
+                clickhouse_http,
+                flight_sql,
+                snowflake_http,
+                snowflake_sql_api,
+            } => {
+                if let Some(g) = trino_http { target_groups.push(g.clone()); }
+                if let Some(g) = postgres_wire { target_groups.push(g.clone()); }
+                if let Some(g) = mysql_wire { target_groups.push(g.clone()); }
+                if let Some(g) = clickhouse_http { target_groups.push(g.clone()); }
+                if let Some(g) = flight_sql { target_groups.push(g.clone()); }
+                if let Some(g) = snowflake_http { target_groups.push(g.clone()); }
+                if let Some(g) = snowflake_sql_api { target_groups.push(g.clone()); }
+            }
+            RouterConfig::Header { header_value_to_group, .. } => {
+                for g in header_value_to_group.values() {
+                    target_groups.push(g.clone());
+                }
+            }
+            RouterConfig::UserGroup { user_to_group, .. } => {
+                for g in user_to_group.values() {
+                    target_groups.push(g.clone());
+                }
+            }
+            RouterConfig::QueryRegex { rules } => {
+                for rule in rules {
+                    target_groups.push(rule.target_group.clone());
+                }
+            }
+            RouterConfig::Tags { rules } => {
+                for rule in rules {
+                    target_groups.push(rule.target_group.clone());
+                }
+            }
+            RouterConfig::Compound { target_group, .. } => {
+                target_groups.push(target_group.clone());
+            }
+            RouterConfig::PythonScript { .. } => {
+                // Custom Python routing implies translation/custom execution is required
+                return true;
+            }
+        }
+    }
+
+    // 2. Identify all enabled frontend dialects
+    let mut enabled_frontends = Vec::new();
+    
+    if config.queryflux.frontends.trino_http.enabled {
+        enabled_frontends.push((FrontendProtocol::TrinoHttp, SqlDialect::Trino));
+    }
+    
+    if let Some(ref f) = config.queryflux.frontends.postgres_wire {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::PostgresWire, SqlDialect::Postgres));
+        }
+    }
+    
+    if let Some(ref f) = config.queryflux.frontends.mysql_wire {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::MySqlWire, SqlDialect::MySql));
+        }
+    }
+    
+    if let Some(ref f) = config.queryflux.frontends.clickhouse_http {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::ClickHouseHttp, SqlDialect::ClickHouse));
+        }
+    }
+
+    if let Some(ref f) = config.queryflux.frontends.flight_sql {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::FlightSql, SqlDialect::Generic));
+        }
+    }
+
+    if let Some(ref f) = config.queryflux.frontends.snowflake_http {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::SnowflakeHttp, SqlDialect::Snowflake));
+        }
+    }
+
+    // If no frontends are enabled, no translation is needed
+    if enabled_frontends.is_empty() {
+        return false;
+    }
+
+    // 3. Check if any frontend dialect differs from the dialect of any backend cluster it can route to
+    for (_, proto_dialect) in enabled_frontends {
+        for group_name in &target_groups {
+            if let Some(group) = config.cluster_groups.get(group_name) {
+                for member in &group.members {
+                    if let Some(cluster) = config.clusters.get(member) {
+                        if let Some(ref engine) = cluster.engine {
+                            let engine_type = match engine {
+                                EngineConfig::Trino => EngineType::Trino,
+                                EngineConfig::DuckDb => EngineType::DuckDb,
+                                EngineConfig::DuckDbHttp => EngineType::DuckDbHttp,
+                                EngineConfig::StarRocks => EngineType::StarRocks,
+                                EngineConfig::ClickHouse => EngineType::ClickHouse,
+                                EngineConfig::Athena => EngineType::Athena,
+                                EngineConfig::Adbc => EngineType::Adbc,
+                            };
+                            if engine_type.dialect() != proto_dialect {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Create a local Python virtual environment and install dependencies
+pub fn handle_install_deps() {
+    println!("Creating Python virtual environment in .venv...");
+    let venv_status = std::process::Command::new("python3")
+        .args(&["-m", "venv", ".venv"])
+        .status();
+
+    match venv_status {
+        Ok(status) if status.success() => {
+            println!("✓ Virtual environment created successfully.");
+        }
+        _ => {
+            eprintln!("✗ Failed to create virtual environment. Ensure python3 and python3-venv are installed on the host.");
+            std::process::exit(1);
+        }
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let pip_path = if cfg!(windows) {
+        cwd.join(".venv/Scripts/pip.exe")
+    } else {
+        cwd.join(".venv/bin/pip")
+    };
+
+    let mut pip_cmd = std::process::Command::new(&pip_path);
+    pip_cmd.arg("install");
+
+    let req_path = cwd.join("requirements.txt");
+    if req_path.exists() {
+        println!("Installing Python packages from requirements.txt inside the virtual environment...");
+        pip_cmd.args(&["-r", "requirements.txt"]);
+    } else {
+        println!("Installing 'sqlglot' package inside the virtual environment...");
+        pip_cmd.arg("sqlglot");
+    }
+
+    let pip_status = pip_cmd.status();
+
+    match pip_status {
+        Ok(status) if status.success() => {
+            println!("✓ Dependencies installed successfully.");
+            println!("\n✓ Dependency installation successful! You can now run QueryFlux.");
+            std::process::exit(0);
+        }
+        _ => {
+            eprintln!("✗ Failed to install dependencies. Make sure you have internet access.");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/queryflux/Cargo.toml
+++ b/crates/queryflux/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 queryflux-core = { workspace = true }
 queryflux-auth = { workspace = true }
+queryflux-cli = { workspace = true }
 queryflux-config = { workspace = true }
 queryflux-persistence = { workspace = true }
 queryflux-routing = { workspace = true }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use clap::Parser;
 use queryflux_auth::{
     AllowAllAuthorization, BackendIdentityResolver, LdapAuthProvider, NoneAuthProvider,
     OidcAuthProvider, OpenFgaAuthorizationClient, SimpleAuthorizationPolicy, StaticAuthProvider,
@@ -53,16 +52,19 @@ use tracing::info;
 
 mod registered_engines;
 
-#[derive(Parser)]
-#[command(name = "queryflux", about = "Multi-engine SQL query proxy")]
-struct Cli {
-    #[arg(short, long, default_value = "config.yaml")]
-    config: String,
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    queryflux_cli::setup_env();
+
+    let cli = queryflux_cli::Cli::parse_args();
+
+    if cli.install_deps {
+        queryflux_cli::handle_install_deps();
+    }
+
+    if cli.validate {
+        queryflux_cli::handle_validation(&cli.config).await;
+    }
 
     // Load config before initializing the tracing subscriber so that
     // `otlpEndpoint` from the config file can feed the OTel layer.
@@ -527,7 +529,13 @@ async fn main() -> Result<()> {
     let translation = Arc::new(
         TranslationService::new_sqlglot(config.translation.python_scripts.clone()).unwrap_or_else(
             |e| {
-                tracing::warn!("sqlglot unavailable ({e}), translation disabled");
+                tracing::warn!(
+                    "sqlglot unavailable ({e}), translation disabled. \
+                     If you need SQL dialect translation, please ensure that: \
+                     1. Python 3.10+ is installed on the host. \
+                     2. 'sqlglot' is installed in your Python environment (run: pip install sqlglot). \
+                     3. PYO3_PYTHON is set if using a virtual environment (e.g. export PYO3_PYTHON=.venv/bin/python)."
+                );
                 TranslationService::disabled()
             },
         ),

--- a/development.md
+++ b/development.md
@@ -44,14 +44,17 @@ Adjust `PYTHONPATH` if your venv’s `lib/pythonX.Y` differs.
 `make dev` brings up dependencies via `docker compose` (see `Makefile` for the exact services). After containers are healthy, run the binary from the repo root with your config, for example:
 
 ```bash
-export PYO3_PYTHON="$(pwd)/.venv/bin/python3"
-export PYTHONPATH="$(pwd)/.venv/lib/python3.13/site-packages"  # version may vary
+# PYO3_PYTHON and PYTHONPATH are automatically detected if a `.venv` directory exists in the workspace.
+# You can manually export them to override this behavior:
+# export PYO3_PYTHON="$(pwd)/.venv/bin/python3"
+# export PYTHONPATH="$(pwd)/.venv/lib/python3.13/site-packages"
+
 cargo run --bin queryflux -- --config config.local.yaml
 ```
 
 Use `config.local.yaml` for the compose-oriented stack, or copy and edit `config.example.yaml` for your own layout.
 
-**Note:** If `sqlglot` is not importable, the process starts but **translation is disabled** and logs a warning; dialect mismatches may then fail on the backend.
+**Note:** If `sqlglot` is not importable (and auto-detection fails), the process starts but **translation is disabled** and logs a warning; dialect mismatches may then fail on the backend. You can run validation with `cargo run --bin queryflux -- --config config.local.yaml --validate` to verify your environment setup.
 
 ## Workspace layout
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,13 +6,14 @@ Several stacks for **QueryFlux** + **Trino** (and optional add-ons). Run command
 
 | Example | Postgres | Best for |
 |--------|----------|----------|
+| [`cli-quickstart/`](cli-quickstart/) | No | Running QueryFlux as a plain CLI binary with embedded DuckDB; no Docker/containers required |
 | [`minimal/`](minimal-trino/) | Yes | Full Studio (query history, persisted clusters/groups/routing via API), production-like persistence |
 | [`minimal-inmemory/`](minimal-inmemory/) | No | Fastest local tryout; config only in `config.yaml`; no shared query history |
 | [`with-prometheus-grafana/`](with-prometheus-grafana/) | Yes | Same workload as minimal + **Prometheus** + **Grafana** (repo [`grafana/`](../grafana/), local scrape config); **no Studio** |
 | [`full-stack/`](full-stack/) | Yes (host **5433**) | Trino + StarRocks + Iceberg/Lakekeeper + MinIO + TPCH loader |
 | [`full-stack-with-prometheus-grafana/`](full-stack-with-prometheus-grafana/) | Yes (host **5433**) | **`full-stack`** + **Prometheus** + **Grafana**; Grafana on **3001** |
 
-`minimal/` and `minimal-inmemory/` use the **same host ports** (8080, 8081, 3000, 9000); **`minimal/`** also maps Postgres to **`localhost:5433`**. **`with-prometheus-grafana`** also uses **3000 for Grafana** (not Studio) — run it alone or change the published Grafana port.
+`cli-quickstart/` runs entirely on the host machine without container dependencies. `minimal/` and `minimal-inmemory/` use the **same host ports** (8080, 8081, 3000, 9000); **`minimal/`** also maps Postgres to **`localhost:5433`**. **`with-prometheus-grafana`** also uses **3000 for Grafana** (not Studio) — run it alone or change the published Grafana port.
 
 ---
 
@@ -121,6 +122,25 @@ docker compose --profile loader run --rm -T starrocks-catalog-setup
 | Grafana | http://localhost:3001 |
 | MinIO console | http://localhost:19001 |
 | Lakekeeper REST | http://localhost:8181 |
+
+---
+
+## CLI Quickstart (`cli-quickstart/`)
+
+Run QueryFlux entirely on your host machine as a plain CLI binary with an embedded in-memory **DuckDB** backend. No Docker/compose environment is required.
+
+```bash
+# Build the binary
+cargo build --release
+
+# Validate environment and configuration
+./target/release/queryflux --config examples/cli-quickstart/config.yaml --validate
+
+# Run QueryFlux
+./target/release/queryflux --config examples/cli-quickstart/config.yaml
+```
+
+See **[`cli-quickstart/README.md`](cli-quickstart/README.md)** for full details.
 
 ---
 

--- a/examples/cli-quickstart/README.md
+++ b/examples/cli-quickstart/README.md
@@ -1,0 +1,88 @@
+# CLI Quickstart (No Docker)
+
+This example demonstrates how to run QueryFlux as a plain CLI binary on your host machine, using an embedded in-memory **DuckDB** engine. No Docker or container runtime is required.
+
+## Prerequisites
+
+1. **Rust** (stable toolchain installed).
+2. **Python 3.10+** (if you need SQL dialect translation via `sqlglot`).
+
+## Step 1: Install Python Dependencies (Optional but recommended)
+
+If you plan to use SQL dialect translation, install `sqlglot` in a virtual environment:
+
+```bash
+# From the repository root
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Tell PyO3 where your Python interpreter is located:
+
+```bash
+export PYO3_PYTHON="$(pwd)/.venv/bin/python3"
+```
+
+## Step 2: Build the QueryFlux Binary
+
+Build the binary from the repository root:
+
+```bash
+cargo build --release
+```
+
+The compiled binary will be placed at `./target/release/queryflux`.
+
+## Step 3: Validate the Configuration and Environment
+
+Run the validator flag to ensure your configuration file and dependencies (Python/sqlglot) are correctly set up:
+
+```bash
+./target/release/queryflux --config examples/cli-quickstart/config.yaml --validate
+```
+
+You should see:
+```
+Validating configuration file: examples/cli-quickstart/config.yaml
+✓ Configuration file is valid YAML and matches the schema.
+Validating Python & sqlglot environment...
+✓ Python interpreter and 'sqlglot' library are available and correctly configured.
+
+✓ Validation successful! Configuration and runtime dependencies are correctly configured.
+```
+
+## Step 4: Run QueryFlux
+
+Start the proxy server pointing to the quickstart configuration:
+
+```bash
+./target/release/queryflux --config examples/cli-quickstart/config.yaml
+```
+
+The proxy is now running:
+* **Trino HTTP Frontend**: `http://localhost:8080`
+* **Admin REST API**: `http://localhost:9000`
+
+## Step 5: Test it
+
+Send a query using `curl` against the Trino HTTP port:
+
+```bash
+curl -X POST http://localhost:8080/v1/statement \
+  -H "X-Trino-User: dev" \
+  -d "SELECT 42"
+```
+
+You will receive a standard Trino response containing the data returned by the local embedded DuckDB:
+
+```json
+{
+  "id": "...",
+  "infoUri": "...",
+  "nextUri": "...",
+  "stats": { ... },
+  "data": [[42]],
+  ...
+}
+```

--- a/website/docs/development.md
+++ b/website/docs/development.md
@@ -52,14 +52,17 @@ Adjust `PYTHONPATH` if your venv’s `lib/pythonX.Y` differs.
 `make env` brings up dependencies via `docker compose` (see `Makefile` for the exact services). After containers are healthy, run the binary from the repo root with your config (or use `make server`), for example:
 
 ```bash
-export PYO3_PYTHON="$(pwd)/.venv/bin/python3"
-export PYTHONPATH="$(pwd)/.venv/lib/python3.13/site-packages"  # version may vary
+# PYO3_PYTHON and PYTHONPATH are automatically detected if a `.venv` directory exists in the workspace.
+# You can manually export them to override this behavior:
+# export PYO3_PYTHON="$(pwd)/.venv/bin/python3"
+# export PYTHONPATH="$(pwd)/.venv/lib/python3.13/site-packages"
+
 cargo run --bin queryflux -- --config config.local.yaml
 ```
 
 Use `config.local.yaml` for the compose-oriented stack, or copy and edit `config.example.yaml` for your own layout.
 
-**Note:** If `sqlglot` is not importable, the process starts but **translation is disabled** and logs a warning; dialect mismatches may then fail on the backend.
+**Note:** If `sqlglot` is not importable (and auto-detection fails), the process starts but **translation is disabled** and logs a warning; dialect mismatches may then fail on the backend. You can run validation with `cargo run --bin queryflux -- --config config.local.yaml --validate` to verify your environment setup.
 
 ## Workspace layout
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -44,9 +44,29 @@ docker compose up -d --wait
 
 **Next steps:** Trino CLI from the host or from inside the `trino` container, verifying traffic goes through QueryFlux — full walkthrough in **[`examples/minimal-trino/README.md`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-trino/README.md)** (including Studio **Queries** and the port/hostname cheat sheet).
 
+## Example: CLI quickstart (no Docker)
+
+**Best for:** running QueryFlux natively on your host machine without any containers. Uses the embedded in-process DuckDB engine.
+
+```bash
+# Build the binary
+cargo build --release
+
+# Automatically create a .venv and install Python dependencies (e.g., sqlglot)
+./target/release/queryflux --install-deps
+
+# Validate the config and environment
+./target/release/queryflux --config examples/cli-quickstart/config.yaml --validate
+
+# Start the proxy
+./target/release/queryflux --config examples/cli-quickstart/config.yaml
+```
+
+*Note: QueryFlux automatically detects the `.venv` directory at startup.*
+
 ## Example: minimal in-memory
 
-**Best for:** fastest local tryout; **no Postgres**. Routing/clusters come from [`config.yaml`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/config.yaml); **restart QueryFlux** after edits. Studio pages that need Postgres may **503** — see **[`examples/minimal-inmemory/README.md`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/README.md)**.
+**Best for:** fastest local Docker tryout; **no Postgres**. Routing/clusters come from [`config.yaml`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/config.yaml); **restart QueryFlux** after edits. Studio pages that need Postgres may **503** — see **[`examples/minimal-inmemory/README.md`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/README.md)**.
 
 ```bash
 cd queryflux/examples/minimal-inmemory


### PR DESCRIPTION
### What changed
This PR makes running QueryFlux as a plain standalone host binary a first-class developer and operator workflow, decoupling server execution from Docker/Compose dependencies.

Specifically, it includes:
1. **`queryflux-cli` Workspace Crate:** Modularized and extracted all CLI argument parsing, config validation, and environment setup code out of the main binary crate.
2. **Automated Virtualenv Detection:** On startup, QueryFlux automatically detects a local `.venv/` directory, resolves the path to the Python interpreter, and sets up `PYO3_PYTHON` and `PYTHONPATH` dynamically (removing manual env variable requirements).
3. **Interactive Dependency Auto-Installer:** Added a `--install-deps` flag to bootstrap a local `.venv` and install `sqlglot`/`requirements.txt` packages directly on the host (with Windows cross-platform support).
4. **Smart Config Validation:** The `--validate` flag inspects the configuration. If translation is required by the config but Python/`sqlglot` is missing, it interactively prompts the user to auto-install it. If translation is not needed (same-dialect routing), validation succeeds without blocking.
5. **DuckDB Quickstart Example:** Added `examples/cli-quickstart/` with a container-free, in-process DuckDB setup.
6. **Documentation Updates:** Overhauled `getting-started.md` and `README.md` to introduce the CLI-first path at the top.

### Why it changed
To drastically improve the onboarding experience and make it significantly easier for users to test, validate, and run QueryFlux locally without needing to spin up Docker containers (especially when utilizing the embedded DuckDB engine).

### Breaking Changes
- None. The existing Docker and containerized workflows remain fully intact and supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface for building, validating, and running QueryFlux locally.
  * Added optional dependency installation and automatic Python environment detection.
  * Added a no-Docker CLI quickstart using an embedded DuckDB backend.
  * Added named cluster configuration with cluster groups referencing cluster members.

* **Documentation**
  * Updated getting-started, development, and example guides with CLI, validation, Docker Compose, and SQL smoke-test instructions.
  * Improved guidance for SQL dialect translation setup and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->