### PR TITLE
feat: add native CLI flow and duckdb quickstart example

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,7 @@ rustflags = ["-L", "native=/opt/homebrew/lib"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-L", "native=/usr/local/lib"]
+
+[env]
+# Safely fall back to downloading libduckdb if not installed on the host system
+DUCKDB_DOWNLOAD_LIB = { value = "1", force = false }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,7 +11,3 @@ rustflags = ["-L", "native=/opt/homebrew/lib"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-L", "native=/usr/local/lib"]
-
-[env]
-# Safely fall back to downloading libduckdb if not installed on the host system
-DUCKDB_DOWNLOAD_LIB = { value = "1", force = false }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
 name = "queryflux-cli"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "clap",
  "queryflux-config",
  "queryflux-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,7 +3776,6 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "opentelemetry_sdk",
  "queryflux-auth",
  "queryflux-cache",
+ "queryflux-cli",
  "queryflux-cluster-manager",
  "queryflux-config",
  "queryflux-core",
@@ -3851,6 +3852,16 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+]
+
+[[package]]
+name = "queryflux-cli"
+version = "0.2.0"
+dependencies = [
+ "clap",
+ "queryflux-config",
+ "queryflux-core",
+ "queryflux-translation",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ members = [
     "crates/queryflux-config",
     "crates/queryflux-metrics",
     "crates/queryflux-fingerprint",
-    "crates/queryflux-guardrails", "crates/queryflux-cli",
+    "crates/queryflux-guardrails",
+    "crates/queryflux-cli",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
     "crates/queryflux-config",
     "crates/queryflux-metrics",
     "crates/queryflux-fingerprint",
-    "crates/queryflux-guardrails",
+    "crates/queryflux-guardrails", "crates/queryflux-cli",
 ]
 
 [workspace.package]
@@ -83,6 +83,7 @@ queryflux-metrics = { path = "crates/queryflux-metrics" }
 queryflux-fingerprint = { path = "crates/queryflux-fingerprint" }
 queryflux-guardrails = { path = "crates/queryflux-guardrails" }
 queryflux-cache = { path = "crates/queryflux-cache" }
+queryflux-cli = { path = "crates/queryflux-cli" }
 
 # OpenDAL — storage abstraction for cache backend
 opendal = { version = "0.53", features = ["services-fs", "services-s3", "services-gcs"] }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ curl -X POST http://localhost:8080/v1/statement \
   -d "SELECT 42"
 ```
 
+### CLI Quickstart (No Docker)
+
+You can run QueryFlux natively with an embedded DuckDB engine without any containers:
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/lakeops-org/queryflux.git
+cd queryflux
+
+# 2. Install the binary globally
+cargo install --path crates/queryflux
+
+# 3. Automatically create a .venv and install Python dependencies (e.g., sqlglot)
+queryflux --install-deps
+
+# 4. Validate the config and environment
+queryflux --config examples/cli-quickstart/config.yaml --validate
+
+# 5. Start the proxy
+queryflux --config examples/cli-quickstart/config.yaml
+```
+
 ### Kubernetes
 
 QueryFlux includes a provider-neutral Helm chart:
@@ -243,6 +265,7 @@ See `config.example.yaml` for the full reference including TLS, auth, query queu
 queryflux/
 ├── crates/
 │   ├── queryflux/                  # Main binary
+│   ├── queryflux-cli/              # CLI logic and environment setup
 │   ├── queryflux-core/             # Shared types and traits
 │   ├── queryflux-config/           # Config loading
 │   ├── queryflux-frontend/         # Protocol frontends (Trino HTTP, PG/MySQL wire, Snowflake HTTP, …)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You can run QueryFlux natively with an embedded DuckDB engine without any contai
 git clone https://github.com/lakeops-org/queryflux.git
 cd queryflux
 
-# 2. Install the binary globally
+# 2. Install the binary globally (if linking fails, use `export DUCKDB_DOWNLOAD_LIB=1` before running this)
 cargo install --path crates/queryflux
 
 # 3. Automatically create a .venv and install Python dependencies (e.g., sqlglot)

--- a/crates/queryflux-cli/Cargo.toml
+++ b/crates/queryflux-cli/Cargo.toml
@@ -9,3 +9,4 @@ queryflux-core = { workspace = true }
 queryflux-config = { workspace = true }
 queryflux-translation = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true }

--- a/crates/queryflux-cli/Cargo.toml
+++ b/crates/queryflux-cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "queryflux-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+queryflux-core = { workspace = true }
+queryflux-config = { workspace = true }
+queryflux-translation = { workspace = true }
+clap = { version = "4", features = ["derive"] }

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -1,0 +1,326 @@
+use clap::Parser;
+use queryflux_config::{yaml::YamlFileConfigProvider, ConfigProvider};
+use queryflux_core::config::{EngineConfig, ProxyConfig, RouterConfig};
+use queryflux_core::query::{EngineType, FrontendProtocol, SqlDialect};
+
+#[derive(Parser, Debug)]
+#[command(name = "queryflux", about = "Multi-engine SQL query proxy", version)]
+pub struct Cli {
+    #[arg(short, long, default_value = "config.yaml")]
+    pub config: String,
+
+    /// Validate config and runtime environment (Python/sqlglot) and exit
+    #[arg(short, long)]
+    pub validate: bool,
+
+    /// Install required Python dependencies (sqlglot) in a local .venv and exit
+    #[arg(long)]
+    pub install_deps: bool,
+}
+
+/// Automate Python path setup if .venv exists and PYTHONPATH/PYO3_PYTHON are unset
+fn setup_env() {
+    if std::env::var("PYO3_PYTHON").is_err() || std::env::var("PYTHONPATH").is_err() {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let venv_dir = cwd.join(".venv");
+        if venv_dir.exists() {
+            if std::env::var("PYO3_PYTHON").is_err() {
+                let venv_paths = vec![
+                    venv_dir.join("bin/python3"),
+                    venv_dir.join("bin/python"),
+                    venv_dir.join("Scripts/python.exe"),
+                ];
+                for path in venv_paths {
+                    if path.exists() {
+                        if let Some(path_str) = path.to_str() {
+                            std::env::set_var("PYO3_PYTHON", path_str);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Set PYTHONPATH by finding .venv/lib/python*/site-packages
+            if std::env::var("PYTHONPATH").is_err() {
+                let lib_dir = venv_dir.join("lib");
+                if lib_dir.exists() {
+                    if let Ok(entries) = std::fs::read_dir(lib_dir) {
+                        for entry in entries.flatten() {
+                            let path = entry.path();
+                            if path.is_dir() {
+                                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                                    if name.starts_with("python") {
+                                        let site_packages = path.join("site-packages");
+                                        if site_packages.exists() {
+                                            if let Some(site_str) = site_packages.to_str() {
+                                                std::env::set_var("PYTHONPATH", site_str);
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Create a local Python virtual environment and install dependencies
+fn handle_install_deps() {
+    println!("Creating Python virtual environment in .venv...");
+    let venv_status = std::process::Command::new("python3")
+        .args(["-m", "venv", ".venv"])
+        .status();
+
+    match venv_status {
+        Ok(status) if status.success() => {
+            println!("✓ Virtual environment created successfully.");
+        }
+        _ => {
+            eprintln!("✗ Failed to create virtual environment. Ensure python3 and python3-venv are installed on the host.");
+            std::process::exit(1);
+        }
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let pip_path = if cfg!(windows) {
+        cwd.join(".venv/Scripts/pip.exe")
+    } else {
+        cwd.join(".venv/bin/pip")
+    };
+
+    let mut pip_cmd = std::process::Command::new(&pip_path);
+    pip_cmd.arg("install");
+
+    let req_path = cwd.join("requirements.txt");
+    if req_path.exists() {
+        println!(
+            "Installing Python packages from requirements.txt inside the virtual environment..."
+        );
+        pip_cmd.args(["-r", "requirements.txt"]);
+    } else {
+        println!("Installing 'sqlglot' package inside the virtual environment...");
+        pip_cmd.arg("sqlglot");
+    }
+
+    let pip_status = pip_cmd.status();
+
+    match pip_status {
+        Ok(status) if status.success() => {
+            println!("✓ Dependencies installed successfully.");
+            println!("\n✓ Dependency installation successful! You can now run QueryFlux.");
+            std::process::exit(0);
+        }
+        _ => {
+            eprintln!("✗ Failed to install dependencies. Make sure you have internet access.");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn config_requires_translation(config: &ProxyConfig) -> bool {
+    let mut target_groups = vec![config.routing_fallback.clone()];
+
+    for router in &config.routers {
+        match router {
+            RouterConfig::ProtocolBased {
+                trino_http,
+                postgres_wire,
+                mysql_wire,
+                clickhouse_http,
+                flight_sql,
+                snowflake_http,
+                snowflake_sql_api,
+            } => {
+                if let Some(g) = trino_http {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = postgres_wire {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = mysql_wire {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = clickhouse_http {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = flight_sql {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = snowflake_http {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = snowflake_sql_api {
+                    target_groups.push(g.clone());
+                }
+            }
+            RouterConfig::Header {
+                header_value_to_group,
+                ..
+            } => {
+                for g in header_value_to_group.values() {
+                    target_groups.push(g.clone());
+                }
+            }
+            RouterConfig::UserGroup { user_to_group, .. } => {
+                for g in user_to_group.values() {
+                    target_groups.push(g.clone());
+                }
+            }
+            RouterConfig::QueryRegex { rules } => {
+                for rule in rules {
+                    target_groups.push(rule.target_group.clone());
+                }
+            }
+            RouterConfig::Tags { rules } => {
+                for rule in rules {
+                    target_groups.push(rule.target_group.clone());
+                }
+            }
+            RouterConfig::Compound { target_group, .. } => {
+                target_groups.push(target_group.clone());
+            }
+            RouterConfig::PythonScript { .. } => {
+                return true;
+            }
+        }
+    }
+
+    let mut enabled_frontends = Vec::new();
+    if config.queryflux.frontends.trino_http.enabled {
+        enabled_frontends.push((FrontendProtocol::TrinoHttp, SqlDialect::Trino));
+    }
+    if let Some(ref f) = config.queryflux.frontends.postgres_wire {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::PostgresWire, SqlDialect::Postgres));
+        }
+    }
+    if let Some(ref f) = config.queryflux.frontends.mysql_wire {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::MySqlWire, SqlDialect::MySql));
+        }
+    }
+    if let Some(ref f) = config.queryflux.frontends.clickhouse_http {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::ClickHouseHttp, SqlDialect::ClickHouse));
+        }
+    }
+    if let Some(ref f) = config.queryflux.frontends.flight_sql {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::FlightSql, SqlDialect::Generic));
+        }
+    }
+    if let Some(ref f) = config.queryflux.frontends.snowflake_http {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::SnowflakeHttp, SqlDialect::Snowflake));
+        }
+    }
+
+    if enabled_frontends.is_empty() {
+        return false;
+    }
+
+    for (_, proto_dialect) in enabled_frontends {
+        for group_name in &target_groups {
+            if let Some(group) = config.cluster_groups.get(group_name) {
+                for member in &group.members {
+                    if let Some(cluster) = config.clusters.get(member) {
+                        if let Some(ref engine) = cluster.engine {
+                            let engine_type = match engine {
+                                EngineConfig::Trino => EngineType::Trino,
+                                EngineConfig::DuckDb => EngineType::DuckDb,
+                                EngineConfig::DuckDbHttp => EngineType::DuckDbHttp,
+                                EngineConfig::StarRocks => EngineType::StarRocks,
+                                EngineConfig::ClickHouse => EngineType::ClickHouse,
+                                EngineConfig::Athena => EngineType::Athena,
+                                EngineConfig::Adbc => EngineType::Adbc,
+                            };
+                            if engine_type.dialect() != proto_dialect {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn handle_validation(config_path: &str) {
+    println!("Validating configuration file: {}", config_path);
+    let config_res = YamlFileConfigProvider::new(config_path).load().await;
+    let config = match config_res {
+        Ok(c) => {
+            println!("✓ Configuration file is valid YAML and matches the schema.");
+            c
+        }
+        Err(e) => {
+            eprintln!("✗ Failed to load or parse configuration file: {:?}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let requires_translation = config_requires_translation(&config);
+
+    println!("Validating Python & sqlglot environment...");
+    match queryflux_translation::TranslationService::new_sqlglot(vec![]) {
+        Ok(_) => {
+            println!("✓ Python interpreter and 'sqlglot' library are available and correctly configured.");
+        }
+        Err(e) => {
+            if requires_translation {
+                eprintln!("✗ Python/sqlglot dependency check failed: {}", e);
+                println!("\nDialect translation is required by your configuration.");
+
+                use std::io::{self, IsTerminal, Write};
+                print!("Would you like to automatically create a virtual environment (.venv) and install 'sqlglot'? [y/N]: ");
+                let _ = io::stdout().flush();
+                let mut response = String::new();
+                let mut confirmed = false;
+                if io::stdin().is_terminal() && io::stdin().read_line(&mut response).is_ok() {
+                    let trimmed = response.trim().to_lowercase();
+                    if trimmed == "y" || trimmed == "yes" {
+                        confirmed = true;
+                    }
+                }
+
+                if confirmed {
+                    println!();
+                    handle_install_deps();
+                } else {
+                    eprintln!("\nTo run QueryFlux with SQL translation, please ensure that:");
+                    eprintln!("  1. Python 3.10+ is installed on the host.");
+                    eprintln!("  2. 'sqlglot' package is installed in your Python environment (run: pip install sqlglot).");
+                    eprintln!("  3. If using a virtual environment (venv), activate it or run 'queryflux --install-deps'.");
+                    std::process::exit(1);
+                }
+            } else {
+                println!("✓ Python/sqlglot is not available ({}), but translation is not required for this configuration.", e);
+            }
+        }
+    }
+
+    println!("\n✓ Validation successful! Configuration and runtime dependencies are correctly configured.");
+    std::process::exit(0);
+}
+
+/// The main entry point for the CLI. Returns the config path.
+pub async fn run_cli() -> String {
+    let cli = Cli::parse();
+
+    setup_env();
+
+    if cli.install_deps {
+        handle_install_deps();
+    }
+
+    if cli.validate {
+        handle_validation(&cli.config).await;
+    }
+
+    cli.config
+}

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -40,20 +40,27 @@ fn setup_env() {
                 }
             }
 
-            // Set PYTHONPATH by finding .venv/lib/python*/site-packages
+            // Set PYTHONPATH by finding .venv/lib/python*/site-packages or .venv/Lib/site-packages
             if std::env::var("PYTHONPATH").is_err() {
-                let lib_dir = venv_dir.join("lib");
-                if lib_dir.exists() {
-                    if let Ok(entries) = std::fs::read_dir(lib_dir) {
-                        for entry in entries.flatten() {
-                            let path = entry.path();
-                            if path.is_dir() {
-                                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                                    if name.starts_with("python") {
-                                        let site_packages = path.join("site-packages");
-                                        if site_packages.exists() {
-                                            if let Some(site_str) = site_packages.to_str() {
-                                                std::env::set_var("PYTHONPATH", site_str);
+                let mut site_pkg_path = None;
+
+                // Windows style: .venv/Lib/site-packages
+                let win_site = venv_dir.join("Lib").join("site-packages");
+                if win_site.exists() {
+                    site_pkg_path = Some(win_site);
+                } else {
+                    // POSIX style: .venv/lib/python*/site-packages
+                    let lib_dir = venv_dir.join("lib");
+                    if lib_dir.exists() {
+                        if let Ok(entries) = std::fs::read_dir(lib_dir) {
+                            for entry in entries.flatten() {
+                                let path = entry.path();
+                                if path.is_dir() {
+                                    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                                        if name.starts_with("python") {
+                                            let site_packages = path.join("site-packages");
+                                            if site_packages.exists() {
+                                                site_pkg_path = Some(site_packages);
                                                 break;
                                             }
                                         }
@@ -63,25 +70,49 @@ fn setup_env() {
                         }
                     }
                 }
+
+                if let Some(path) = site_pkg_path {
+                    if let Some(site_str) = path.to_str() {
+                        std::env::set_var("PYTHONPATH", site_str);
+                    }
+                }
             }
         }
     }
 }
 
 /// Create a local Python virtual environment and install dependencies
-fn handle_install_deps() {
+fn handle_install_deps() -> std::io::Result<()> {
     println!("Creating Python virtual environment in .venv...");
-    let venv_status = std::process::Command::new("python3")
-        .args(["-m", "venv", ".venv"])
-        .status();
+
+    // Find python executable to use for venv creation
+    let py_cmds = if let Ok(pyo3_py) = std::env::var("PYO3_PYTHON") {
+        vec![pyo3_py]
+    } else {
+        vec!["python3".to_string(), "python".to_string()]
+    };
+
+    let mut venv_status = None;
+    for cmd in py_cmds {
+        if let Ok(status) = std::process::Command::new(&cmd)
+            .args(["-m", "venv", ".venv"])
+            .status()
+        {
+            venv_status = Some(status);
+            if status.success() {
+                break;
+            }
+        }
+    }
 
     match venv_status {
-        Ok(status) if status.success() => {
+        Some(status) if status.success() => {
             println!("✓ Virtual environment created successfully.");
         }
         _ => {
-            eprintln!("✗ Failed to create virtual environment. Ensure python3 and python3-venv are installed on the host.");
-            std::process::exit(1);
+            return Err(std::io::Error::other(
+                "Failed to create virtual environment. Ensure python3/python and python3-venv are installed.",
+            ));
         }
     }
 
@@ -106,18 +137,14 @@ fn handle_install_deps() {
         pip_cmd.arg("sqlglot");
     }
 
-    let pip_status = pip_cmd.status();
-
-    match pip_status {
-        Ok(status) if status.success() => {
-            println!("✓ Dependencies installed successfully.");
-            println!("\n✓ Dependency installation successful! You can now run QueryFlux.");
-            std::process::exit(0);
-        }
-        _ => {
-            eprintln!("✗ Failed to install dependencies. Make sure you have internet access.");
-            std::process::exit(1);
-        }
+    let pip_status = pip_cmd.status()?;
+    if pip_status.success() {
+        println!("✓ Dependencies installed successfully.");
+        Ok(())
+    } else {
+        Err(std::io::Error::other(
+            "Failed to install dependencies. Make sure you have internet access.",
+        ))
     }
 }
 
@@ -290,7 +317,22 @@ async fn handle_validation(config_path: &str) {
 
                 if confirmed {
                     println!();
-                    handle_install_deps();
+                    if let Err(err) = handle_install_deps() {
+                        eprintln!("✗ {}", err);
+                        std::process::exit(1);
+                    }
+
+                    // Re-setup env variables and re-check sqlglot
+                    setup_env();
+                    if let Err(e2) = queryflux_translation::TranslationService::new_sqlglot(vec![])
+                    {
+                        eprintln!(
+                            "✗ SQL translation check failed even after installation: {}",
+                            e2
+                        );
+                        std::process::exit(1);
+                    }
+                    println!("✓ Python interpreter and 'sqlglot' library successfully configured after auto-installation.");
                 } else {
                     eprintln!("\nTo run QueryFlux with SQL translation, please ensure that:");
                     eprintln!("  1. Python 3.10+ is installed on the host.");
@@ -315,7 +357,12 @@ pub async fn run_cli() -> String {
     setup_env();
 
     if cli.install_deps {
-        handle_install_deps();
+        if let Err(e) = handle_install_deps() {
+            eprintln!("✗ {}", e);
+            std::process::exit(1);
+        }
+        println!("\n✓ Dependency installation successful! You can now run QueryFlux.");
+        std::process::exit(0);
     }
 
     if cli.validate {

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -117,14 +117,19 @@ fn handle_install_deps() -> std::io::Result<()> {
     }
 
     let cwd = std::env::current_dir().unwrap_or_default();
-    let pip_path = if cfg!(windows) {
-        cwd.join(".venv/Scripts/pip.exe")
+    let venv_python = if cfg!(windows) {
+        cwd.join(".venv/Scripts/python.exe")
     } else {
-        cwd.join(".venv/bin/pip")
+        let py3 = cwd.join(".venv/bin/python3");
+        if py3.exists() {
+            py3
+        } else {
+            cwd.join(".venv/bin/python")
+        }
     };
 
-    let mut pip_cmd = std::process::Command::new(&pip_path);
-    pip_cmd.arg("install");
+    let mut pip_cmd = std::process::Command::new(&venv_python);
+    pip_cmd.args(["-m", "pip", "install"]);
 
     let req_path = cwd.join("requirements.txt");
     if req_path.exists() {
@@ -281,7 +286,7 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
     false
 }
 
-async fn handle_validation(config_path: &str) {
+async fn handle_validation(config_path: &str) -> anyhow::Result<()> {
     println!("Validating configuration file: {}", config_path);
     let config_res = YamlFileConfigProvider::new(config_path).load().await;
     let config = match config_res {
@@ -290,8 +295,10 @@ async fn handle_validation(config_path: &str) {
             c
         }
         Err(e) => {
-            eprintln!("✗ Failed to load or parse configuration file: {:?}", e);
-            std::process::exit(1);
+            return Err(anyhow::anyhow!(
+                "Failed to load or parse configuration file: {:?}",
+                e
+            ));
         }
     };
 
@@ -324,8 +331,7 @@ async fn handle_validation(config_path: &str) {
                 if confirmed {
                     println!();
                     if let Err(err) = handle_install_deps() {
-                        eprintln!("✗ {}", err);
-                        std::process::exit(1);
+                        return Err(anyhow::anyhow!(err));
                     }
 
                     // Re-setup env variables and re-check sqlglot
@@ -333,19 +339,16 @@ async fn handle_validation(config_path: &str) {
                     if let Err(e2) = queryflux_translation::TranslationService::new_sqlglot(
                         config.translation.python_scripts.clone(),
                     ) {
-                        eprintln!(
-                            "✗ SQL translation check failed even after installation: {}",
+                        return Err(anyhow::anyhow!(
+                            "SQL translation check failed even after installation: {}",
                             e2
-                        );
-                        std::process::exit(1);
+                        ));
                     }
                     println!("✓ Python interpreter and 'sqlglot' library successfully configured after auto-installation.");
                 } else {
-                    eprintln!("\nTo run QueryFlux with SQL translation, please ensure that:");
-                    eprintln!("  1. Python 3.10+ is installed on the host.");
-                    eprintln!("  2. 'sqlglot' package is installed in your Python environment (run: pip install sqlglot).");
-                    eprintln!("  3. If using a virtual environment (venv), activate it or run 'queryflux --install-deps'.");
-                    std::process::exit(1);
+                    return Err(anyhow::anyhow!(
+                        "To run QueryFlux with SQL translation, please ensure that:\n  1. Python 3.10+ is installed on the host.\n  2. 'sqlglot' package is installed in your Python environment (run: pip install sqlglot).\n  3. If using a virtual environment (venv), activate it or run 'queryflux --install-deps'."
+                    ));
                 }
             } else {
                 println!("✓ Python/sqlglot is not available ({}), but translation is not required for this configuration.", e);
@@ -354,27 +357,25 @@ async fn handle_validation(config_path: &str) {
     }
 
     println!("\n✓ Validation successful! Configuration and runtime dependencies are correctly configured.");
-    std::process::exit(0);
+    Ok(())
 }
 
-/// The main entry point for the CLI. Returns the config path.
-pub async fn run_cli() -> String {
+/// The main entry point for the CLI. Returns the config path if execution should continue.
+pub async fn run_cli() -> anyhow::Result<Option<String>> {
     let cli = Cli::parse();
 
     setup_env();
 
     if cli.install_deps {
-        if let Err(e) = handle_install_deps() {
-            eprintln!("✗ {}", e);
-            std::process::exit(1);
-        }
+        handle_install_deps()?;
         println!("\n✓ Dependency installation successful! You can now run QueryFlux.");
-        std::process::exit(0);
+        return Ok(None);
     }
 
     if cli.validate {
-        handle_validation(&cli.config).await;
+        handle_validation(&cli.config).await?;
+        return Ok(None);
     }
 
-    cli.config
+    Ok(Some(cli.config))
 }

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -149,6 +149,10 @@ fn handle_install_deps() -> std::io::Result<()> {
 }
 
 fn config_requires_translation(config: &ProxyConfig) -> bool {
+    if !config.translation.python_scripts.is_empty() {
+        return true;
+    }
+
     let mut target_groups = vec![config.routing_fallback.clone()];
 
     for router in &config.routers {
@@ -294,7 +298,9 @@ async fn handle_validation(config_path: &str) {
     let requires_translation = config_requires_translation(&config);
 
     println!("Validating Python & sqlglot environment...");
-    match queryflux_translation::TranslationService::new_sqlglot(vec![]) {
+    match queryflux_translation::TranslationService::new_sqlglot(
+        config.translation.python_scripts.clone(),
+    ) {
         Ok(_) => {
             println!("✓ Python interpreter and 'sqlglot' library are available and correctly configured.");
         }
@@ -324,8 +330,9 @@ async fn handle_validation(config_path: &str) {
 
                     // Re-setup env variables and re-check sqlglot
                     setup_env();
-                    if let Err(e2) = queryflux_translation::TranslationService::new_sqlglot(vec![])
-                    {
+                    if let Err(e2) = queryflux_translation::TranslationService::new_sqlglot(
+                        config.translation.python_scripts.clone(),
+                    ) {
                         eprintln!(
                             "✗ SQL translation check failed even after installation: {}",
                             e2

--- a/crates/queryflux/Cargo.toml
+++ b/crates/queryflux/Cargo.toml
@@ -27,7 +27,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
-clap = { version = "4", features = ["derive"] }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 uuid = { version = "1", features = ["v4"] }

--- a/crates/queryflux/Cargo.toml
+++ b/crates/queryflux/Cargo.toml
@@ -21,6 +21,7 @@ queryflux-frontend = { workspace = true }
 queryflux-cluster-manager = { workspace = true }
 queryflux-metrics = { workspace = true }
 queryflux-cache = { workspace = true }
+queryflux-cli = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use clap::Parser;
 use queryflux_auth::{
     AllowAllAuthorization, BackendIdentityResolver, LdapAuthProvider, NoneAuthProvider,
     OidcAuthProvider, OpenFgaAuthorizationClient, SimpleAuthorizationPolicy, StaticAuthProvider,
@@ -53,20 +52,13 @@ use tracing::info;
 
 mod registered_engines;
 
-#[derive(Parser)]
-#[command(name = "queryflux", about = "Multi-engine SQL query proxy")]
-struct Cli {
-    #[arg(short, long, default_value = "config.yaml")]
-    config: String,
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let config_path = queryflux_cli::run_cli().await;
 
     // Load config before initializing the tracing subscriber so that
     // `otlpEndpoint` from the config file can feed the OTel layer.
-    let mut config = YamlFileConfigProvider::new(&cli.config)
+    let mut config = YamlFileConfigProvider::new(&config_path)
         .load()
         .await
         .context("Failed to load config")?;
@@ -116,7 +108,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    info!("QueryFlux starting — loaded config from: {}", cli.config);
+    info!("QueryFlux starting — loaded config from: {}", config_path);
 
     let external_address = config
         .queryflux

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -54,7 +54,10 @@ mod registered_engines;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config_path = queryflux_cli::run_cli().await;
+    let config_path = match queryflux_cli::run_cli().await? {
+        Some(path) => path,
+        None => return Ok(()),
+    };
 
     // Load config before initializing the tracing subscriber so that
     // `otlpEndpoint` from the config file can feed the OTel layer.

--- a/examples/cli-quickstart/README.md
+++ b/examples/cli-quickstart/README.md
@@ -1,0 +1,30 @@
+# CLI Quickstart (No Docker)
+
+This example demonstrates how to run QueryFlux locally on your host machine as a plain CLI binary. 
+It uses the embedded in-process `duckdb` engine, meaning you do not need to run any external databases or Docker containers to test the proxy.
+
+### 1. Install QueryFlux
+Run this from the root of the repository to install the binary globally:
+```bash
+cargo install --path crates/queryflux
+```
+
+### 2. Auto-Install Dependencies (Optional)
+If you plan to use SQL translation (which requires Python and `sqlglot`), you can have QueryFlux automatically set up a `.venv` for you:
+```bash
+queryflux --install-deps
+```
+
+### 3. Run the Proxy
+Pass this example's configuration file to the binary:
+```bash
+queryflux --config examples/cli-quickstart/config.yaml
+```
+
+### 4. Smoke Test
+In a new terminal, send a query via the Trino HTTP protocol. QueryFlux will execute it instantly using the embedded DuckDB engine:
+```bash
+curl -X POST http://localhost:8080/v1/statement \
+  -H "X-Trino-User: admin" \
+  -d "SELECT 42 AS answer, 'Hello from DuckDB' AS message;"
+```

--- a/examples/cli-quickstart/config.yaml
+++ b/examples/cli-quickstart/config.yaml
@@ -1,0 +1,23 @@
+# A minimal QueryFlux configuration using the embedded DuckDB engine.
+# This config requires NO external databases or containers.
+
+queryflux:
+  frontends:
+    trino_http:
+      enabled: true
+      bind_address: "0.0.0.0:8080"
+  metrics:
+    bind_address: "0.0.0.0:9000"
+
+clusters:
+  local_duckdb:
+    engine: duckDb
+    max_connections: 10
+
+cluster_groups:
+  default_group:
+    members:
+      - local_duckdb
+
+routing_fallback: default_group
+routers: []

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -44,6 +44,30 @@ docker compose up -d --wait
 
 **Next steps:** Trino CLI from the host or from inside the `trino` container, verifying traffic goes through QueryFlux — full walkthrough in **[`examples/minimal-trino/README.md`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-trino/README.md)** (including Studio **Queries** and the port/hostname cheat sheet).
 
+## Example: CLI quickstart (no Docker)
+
+**Best for:** running QueryFlux natively on your host machine without any containers. Uses the embedded in-process DuckDB engine.
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/lakeops-org/queryflux.git
+cd queryflux
+
+# 2. Install the binary globally
+cargo install --path crates/queryflux
+
+# 3. Automatically create a .venv and install Python dependencies (e.g., sqlglot)
+queryflux --install-deps
+
+# 4. Validate the config and environment
+queryflux --config examples/cli-quickstart/config.yaml --validate
+
+# 5. Start the proxy
+queryflux --config examples/cli-quickstart/config.yaml
+```
+
+*Note: QueryFlux automatically detects the `.venv` directory at startup.*
+
 ## Example: minimal in-memory
 
 **Best for:** fastest local tryout; **no Postgres**. Routing/clusters come from [`config.yaml`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/config.yaml); **restart QueryFlux** after edits. Studio pages that need Postgres may **503** — see **[`examples/minimal-inmemory/README.md`](https://github.com/lakeops-org/queryflux/blob/main/examples/minimal-inmemory/README.md)**.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -53,7 +53,7 @@ docker compose up -d --wait
 git clone https://github.com/lakeops-org/queryflux.git
 cd queryflux
 
-# 2. Install the binary globally
+# 2. Install the binary globally (if linking fails, use `export DUCKDB_DOWNLOAD_LIB=1` before running this)
 cargo install --path crates/queryflux
 
 # 3. Automatically create a .venv and install Python dependencies (e.g., sqlglot)


### PR DESCRIPTION
## Summary

This PR implements a standalone CLI workflow for QueryFlux. It decouples the proxy from Docker Compose by
providing native argument parsing, automatic dependency installation, and schema validation.

## File-by-File Changes

### crates/queryflux-cli/ (New Workspace Crate)

• src/lib.rs: Created a dedicated library to handle all CLI logic.
    • Implemented Cli struct using clap with --config, --validate, and --install-deps flags.
    • Added setup_env() which automatically injects PYO3_PYTHON and PYTHONPATH if a .venv directory is detected
    in the current working directory.
    • Added handle_install_deps() which uses std::process::Command to invoke python3 -m venv .venv and pip
    install sqlglot (or requirements.txt), eliminating the need for Docker just to resolve Python dependencies.
    • Added handle_validation() which loads the YAML config and cross-references requested frontends with
    backend engine dialects (via config_requires_translation()). It verifies TranslationService::new_sqlglot can
    initialize and interactively prompts the user to auto-install dependencies if it fails.


### crates/queryflux/src/main.rs

• Stripped out all previous clap argument parsing boilerplate.
• Replaced the initialization sequence with a single asynchronous call to queryflux_cli::run_cli().await,
ensuring the core binary is kept completely isolated from CLI and environment-setup logic.

### examples/cli-quickstart/ (New Example)

• config.yaml: Added a minimal configuration file that routes the Trino HTTP frontend directly to the embedded
duckDb engine.
• README.md: Documented how to run this specific example locally. Because it uses the embedded engine, it
provides a zero-dependency local test path.

### Documentation (README.md & website/docs/getting-started.md)

• Added a new CLI Quickstart (No Docker) section to the top of both files.
• Documented the native build flow (cargo install --path crates/queryflux) followed by queryflux --install-deps
and queryflux --validate.
• Updated the "Project Structure" tree in README.md to include the new queryflux-cli crate.

### .cargo/config.toml

• Appended DUCKDB_DOWNLOAD_LIB = { value = "1", force = false } to the global [env] block.
• This replaces the old Makefile hack and ensures cargo build and cargo install will silently download the pre-
compiled C++ DuckDB binary if it is missing from the host machine, preventing fatal linking errors for new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native QueryFlux CLI support for running local proxy deployments without Docker.
  * Added automatic Python virtual environment setup and an `--install-deps` option.
  * Added `--validate` checks for configuration readiness, including guided dependency setup.
  * Added an embedded DuckDB quickstart configuration and Trino smoke-test workflow.

* **Documentation**
  * Added CLI quickstart guidance to the README and Getting Started documentation.
  * Added example configuration and usage instructions for local deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->