### PR TITLE
feat: ClickHouse backend adapter (HTTP, Arrow result path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,15 +219,16 @@ jobs:
           echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
 
       # Same stack as `make test-e2e`, but split so "Engine logs" / `compose down` still run if `cargo test` fails.
-      - name: Start e2e Docker stack (Trino + StarRocks + sentinel)
+      - name: Start e2e Docker stack (Trino + StarRocks + ClickHouse + sentinel)
         run: |
-          docker compose -f docker/docker-compose.test.yml --project-directory . up -d --wait --wait-timeout 300 trino starrocks sentinel
+          docker compose -f docker/docker-compose.test.yml --project-directory . up -d --wait --wait-timeout 300 trino starrocks clickhouse sentinel
 
       - name: E2E tests (queryflux-e2e-tests)
         env:
           TRINO_URL: http://localhost:18081
           TRINO_ADBC_URI: http://localhost:18081
           STARROCKS_URL: mysql://root@localhost:9030
+          CLICKHOUSE_URL: http://localhost:18123
           LAKEKEEPER_URL: http://localhost:18181
           MINIO_ENDPOINT: localhost:19000
         run: |
@@ -238,6 +239,7 @@ jobs:
         run: |
           docker compose -f docker/docker-compose.test.yml --project-directory . logs --no-color --tail=200 trino || true
           docker compose -f docker/docker-compose.test.yml --project-directory . logs --no-color --tail=200 starrocks || true
+          docker compose -f docker/docker-compose.test.yml --project-directory . logs --no-color --tail=200 clickhouse || true
 
       - name: Stop e2e Docker stack
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,13 @@ test-e2e:
 	trap '$(COMPOSE_TEST) down' EXIT; \
 	PYO3_PYTHON=$(shell pwd)/.venv/bin/python3 \
 	PYTHONPATH=$(PYTHONPATH_VENV) \
-	$(COMPOSE_TEST) up -d --wait trino starrocks sentinel; \
+	$(COMPOSE_TEST) up -d --wait trino starrocks clickhouse sentinel; \
 	PYO3_PYTHON=$(shell pwd)/.venv/bin/python3 \
 	PYTHONPATH=$(PYTHONPATH_VENV) \
 	TRINO_URL=http://localhost:18081 \
 	TRINO_ADBC_URI=http://localhost:18081 \
 	STARROCKS_URL=mysql://root@localhost:9030 \
+	CLICKHOUSE_URL=http://localhost:18123 \
 	LAKEKEEPER_URL=http://localhost:18181 \
 	MINIO_ENDPOINT=localhost:19000 \
 	$(CARGO) test -p queryflux-e2e-tests --manifest-path Cargo.toml -- --test-threads=1 --include-ignored --nocapture

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ routers:
 - DuckDB — embedded, in-process execution
 - StarRocks — MySQL wire protocol
 - Athena — AWS SDK, async polling
-- ClickHouse — planned
+- ClickHouse — HTTP interface, Arrow results
 
 **Routing**
 - Protocol-based (route by client connection type)

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -887,6 +887,11 @@ pub struct ClusterConfig {
     /// Default Athena catalog. Defaults to `"AwsDataCatalog"` when omitted.
     #[serde(default)]
     pub catalog: Option<String>,
+    /// Max bytes of a single query result QueryFlux buffers in memory
+    /// (`maxResultBufferBytes` in JSON/YAML). ClickHouse only; defaults to
+    /// 1 GiB when omitted. Other engines ignore this.
+    #[serde(default)]
+    pub max_result_buffer_bytes: Option<u64>,
     #[serde(default)]
     pub tls: Option<TlsConfig>,
     /// Type 1 credentials — service account used for health checks and (by default) query execution.

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -144,6 +144,7 @@ pub fn cluster_config_from_persisted_json(
         workgroup: None,
         catalog: None,
         tls: None,
+        max_result_buffer_bytes: None,
         auth,
         query_auth,
     }

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -225,6 +225,8 @@ impl TestHarness {
                         endpoint: ch_url,
                         auth: None,
                         tls_skip_verify: false,
+                        max_result_buffer_bytes:
+                            queryflux_engine_adapters::clickhouse::DEFAULT_MAX_RESULT_BUFFER_BYTES,
                     },
                 )
                 .map_err(|e| anyhow!("ClickHouse adapter: {e}"))?,

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -3,6 +3,7 @@
 /// Backends are optional and discovered via connectivity / env:
 ///   TRINO_URL         — default http://localhost:18081
 ///   STARROCKS_URL     — default mysql://root@localhost:9030 (matches docker-compose.test.yml)
+///   CLICKHOUSE_URL    — default http://localhost:18123 (ClickHouse HTTP interface)
 ///
 /// Lakekeeper / Iceberg (optional):
 ///   LAKEKEEPER_URL, MINIO_ENDPOINT — StarRocks external catalog DDL only.
@@ -29,6 +30,7 @@ use queryflux_core::{
     query::{ClusterGroupName, ClusterName, EngineType},
 };
 use queryflux_engine_adapters::{
+    clickhouse::{ClickHouseAdapter, ClickHouseConfig},
     duckdb::{DuckDbAdapter, DuckDbConfig},
     starrocks::StarRocksAdapter,
     trino::TrinoAdapter,
@@ -71,6 +73,7 @@ pub const GROUP_STARROCKS: &str = "starrocks";
 pub const GROUP_DUCKDB: &str = "duckdb";
 /// Set when Lakekeeper port is reachable (Iceberg tables seeded by e2e tests via Trino).
 pub const GROUP_LAKEKEEPER: &str = "lakekeeper";
+pub const GROUP_CLICKHOUSE: &str = "clickhouse";
 
 pub struct TestHarness {
     pub port: u16,
@@ -196,6 +199,42 @@ impl TestHarness {
 
         if let Some((cluster, sr)) = sr_adapter {
             adapters.insert(cluster.0.clone(), AdapterKind::Sync(sr));
+        }
+
+        // --- ClickHouse (HTTP interface, Arrow result path) ---
+        let ch_url = std::env::var("CLICKHOUSE_URL")
+            .unwrap_or_else(|_| "http://localhost:18123".to_string());
+        if is_clickhouse_ready(&ch_url).await {
+            let group = ClusterGroupName(GROUP_CLICKHOUSE.to_string());
+            let cluster = ClusterName("clickhouse-1".to_string());
+            let state = Arc::new(ClusterState::new(
+                cluster.clone(),
+                group.clone(),
+                None,
+                None,
+                EngineType::ClickHouse,
+                Some(ch_url.clone()),
+                8,
+                true,
+            ));
+            let adapter = Arc::new(
+                ClickHouseAdapter::new(
+                    cluster.clone(),
+                    group.clone(),
+                    ClickHouseConfig {
+                        endpoint: ch_url,
+                        auth: None,
+                        tls_skip_verify: false,
+                    },
+                )
+                .map_err(|e| anyhow!("ClickHouse adapter: {e}"))?,
+            );
+            group_states.insert(group.clone(), (vec![state], strategy_from_config(None)));
+            group_members.insert(GROUP_CLICKHOUSE.to_string(), vec![cluster.0.clone()]);
+            group_order.push(GROUP_CLICKHOUSE.to_string());
+            adapters.insert(cluster.0.clone(), AdapterKind::Sync(adapter));
+            available_groups.push(GROUP_CLICKHOUSE.to_string());
+            header_map.insert(GROUP_CLICKHOUSE.to_string(), group);
         }
 
         // --- DuckDB (always available — embedded, in-memory, no external dependency) ---
@@ -418,6 +457,15 @@ async fn is_starrocks_ready(url: &str) -> bool {
     };
     let host = parsed.host_str().unwrap_or("localhost");
     let port = parsed.port().unwrap_or(9030);
+    port_is_open(host, port).await
+}
+
+async fn is_clickhouse_ready(url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    let host = parsed.host_str().unwrap_or("localhost");
+    let port = parsed.port().unwrap_or(8123);
     port_is_open(host, port).await
 }
 

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -99,6 +99,30 @@ async fn clickhouse_syntax_error_returns_error() {
     assert!(r.error.is_some(), "expected error for invalid SQL");
 }
 
+/// A query that fails AFTER ClickHouse sent HTTP 200 (mid-stream) must
+/// surface the server's exception text — proving `find_exception_frame`
+/// parses the real server's `__exception__` framing, not just fixtures.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_mid_stream_failure_surfaces_exception_message() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on(
+            "SELECT throwIf(number = 5000000) FROM system.numbers LIMIT 10000000 \
+             SETTINGS max_block_size = 65536",
+            GROUP_CLICKHOUSE,
+        )
+        .await
+        .expect("request succeeded");
+    let err = r
+        .error
+        .expect("expected mid-stream failure to surface as an error");
+    assert!(
+        err.contains("throwIf") || err.contains("DB::Exception"),
+        "expected the ClickHouse exception text from the __exception__ frame, got: {err}"
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires ClickHouse — run with: make test-e2e"]
 async fn clickhouse_empty_result() {

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -102,13 +102,21 @@ async fn clickhouse_syntax_error_returns_error() {
 /// A query that fails AFTER ClickHouse sent HTTP 200 (mid-stream) must
 /// surface the server's exception text — proving `find_exception_frame`
 /// parses the real server's `__exception__` framing, not just fixtures.
+///
+/// The throw fires in the second output block (100_000 > one 65_536-row
+/// block), after the server has flushed the first block and committed to
+/// HTTP 200 — verified against 26.3.17.56 (the CI image) and 26.8. The
+/// `mid-stream` assertion keeps the row count honest: if the failure ever
+/// arrives before streaming starts it degrades to a plain HTTP error and
+/// this test fails, instead of silently passing without exercising the
+/// framing parser.
 #[tokio::test]
 #[ignore = "requires ClickHouse — run with: make test-e2e"]
 async fn clickhouse_mid_stream_failure_surfaces_exception_message() {
     require_group!(GROUP_CLICKHOUSE);
     let r = client()
         .execute_on(
-            "SELECT throwIf(number = 5000000) FROM system.numbers LIMIT 10000000 \
+            "SELECT throwIf(number = 100000) FROM system.numbers LIMIT 200000 \
              SETTINGS max_block_size = 65536",
             GROUP_CLICKHOUSE,
         )
@@ -117,6 +125,10 @@ async fn clickhouse_mid_stream_failure_surfaces_exception_message() {
     let err = r
         .error
         .expect("expected mid-stream failure to surface as an error");
+    assert!(
+        err.contains("mid-stream"),
+        "expected the exception-frame path (adapter says 'failed mid-stream'), got: {err}"
+    );
     assert!(
         err.contains("throwIf") || err.contains("DB::Exception"),
         "expected the ClickHouse exception text from the __exception__ frame, got: {err}"

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -147,6 +147,12 @@ async fn exec_ok(c: &TrinoClient, sql: &str) -> queryflux_e2e_tests::trino_clien
 
 /// DDL and INSERT return an empty ArrowStream body; a full create → insert →
 /// select → drop cycle proves those paths and data round-tripping.
+///
+/// NOTE: the harness runs `TranslationService::disabled()`, so this SQL is
+/// native ClickHouse dialect (`UInt32`, `ENGINE = Memory`) sent as-is — the
+/// Trino→ClickHouse sqlglot translation path is NOT exercised here. Real
+/// clients go through translation, whose DDL coverage is a known limitation
+/// (see the PR #105 description).
 #[tokio::test]
 #[ignore = "requires ClickHouse — run with: make test-e2e"]
 async fn clickhouse_ddl_insert_select_roundtrip() {

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -1,0 +1,274 @@
+/// ClickHouse tests — require a running ClickHouse instance.
+///
+/// All tests are marked `#[ignore]` and run with: make test-e2e
+/// or: cargo test -p queryflux-e2e-tests --test clickhouse_tests -- --include-ignored
+use std::sync::OnceLock;
+
+use queryflux_e2e_tests::{
+    harness::{TestHarness, GROUP_CLICKHOUSE, GROUP_TRINO},
+    trino_client::TrinoClient,
+};
+use serde_json::json;
+
+static HARNESS: OnceLock<TestHarness> = OnceLock::new();
+
+fn harness() -> &'static TestHarness {
+    HARNESS.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("runtime");
+            let h = rt.block_on(TestHarness::new()).expect("TestHarness::new");
+            tx.send(h).expect("send harness");
+            rt.block_on(std::future::pending::<()>());
+        });
+        rx.recv().expect("recv harness")
+    })
+}
+
+fn client() -> TrinoClient {
+    TrinoClient::new(&harness().base_url())
+}
+
+macro_rules! require_group {
+    ($group:expr) => {
+        if !harness().has_group($group) {
+            eprintln!("SKIP: engine group '{}' not available", $group);
+            return;
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Basic ClickHouse
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_select_literal() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on("SELECT 1 + 1 AS result", GROUP_CLICKHOUSE)
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+    assert_eq!(r.rows.len(), 1);
+    assert_eq!(r.rows[0][0], json!(2));
+}
+
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_select_multi_row() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on(
+            "SELECT 1 AS v UNION ALL SELECT 2 UNION ALL SELECT 3",
+            GROUP_CLICKHOUSE,
+        )
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+    assert_eq!(r.rows.len(), 3);
+}
+
+/// `system.numbers` exists only in ClickHouse — proves the query really ran there.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_system_numbers() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on(
+            "SELECT number FROM system.numbers LIMIT 5",
+            GROUP_CLICKHOUSE,
+        )
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+    assert_eq!(r.rows.len(), 5);
+    assert_eq!(r.rows[0][0], json!(0));
+    assert_eq!(r.rows[4][0], json!(4));
+}
+
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_syntax_error_returns_error() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on("THIS IS NOT VALID SQL FOR CLICKHOUSE", GROUP_CLICKHOUSE)
+        .await
+        .expect("query");
+    assert!(r.error.is_some(), "expected error for invalid SQL");
+}
+
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_empty_result() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute_on("SELECT 1 AS n WHERE 1 = 0", GROUP_CLICKHOUSE)
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+    assert_eq!(r.rows.len(), 0);
+}
+
+/// Run a statement on the ClickHouse group and assert it succeeded.
+async fn exec_ok(c: &TrinoClient, sql: &str) -> queryflux_e2e_tests::trino_client::QueryResult {
+    let r = c
+        .execute_on(sql, GROUP_CLICKHOUSE)
+        .await
+        .expect("request succeeded");
+    assert!(r.error.is_none(), "'{sql}' failed: {:?}", r.error);
+    r
+}
+
+/// DDL and INSERT return an empty ArrowStream body; a full create → insert →
+/// select → drop cycle proves those paths and data round-tripping.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_ddl_insert_select_roundtrip() {
+    require_group!(GROUP_CLICKHOUSE);
+    let c = client();
+
+    c.execute_on("DROP TABLE IF EXISTS qf_e2e_ch_roundtrip", GROUP_CLICKHOUSE)
+        .await
+        .expect("drop if exists");
+    exec_ok(
+        &c,
+        "CREATE TABLE qf_e2e_ch_roundtrip (id UInt32, name String) ENGINE = Memory",
+    )
+    .await;
+    exec_ok(
+        &c,
+        "INSERT INTO qf_e2e_ch_roundtrip VALUES (1, 'alpha'), (2, 'beta')",
+    )
+    .await;
+
+    let r = exec_ok(&c, "SELECT id, name FROM qf_e2e_ch_roundtrip ORDER BY id").await;
+    assert_eq!(r.rows.len(), 2);
+    assert_eq!(r.rows[0][1], json!("alpha"));
+    assert_eq!(r.rows[1][1], json!("beta"));
+
+    exec_ok(&c, "DROP TABLE qf_e2e_ch_roundtrip").await;
+}
+
+// ---------------------------------------------------------------------------
+// Session context propagation
+// ---------------------------------------------------------------------------
+
+/// `X-Trino-User` from the Trino HTTP frontend must end up in the QueryRecord.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_session_user_recorded_in_metrics() {
+    require_group!(GROUP_CLICKHOUSE);
+    harness().clear_records();
+    let r = client()
+        .execute(
+            "SELECT 1",
+            &[("x-trino-user", "alice"), ("x-qf-group", GROUP_CLICKHOUSE)],
+        )
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+
+    let record = harness()
+        .wait_for_record(|r| {
+            r.user.as_deref() == Some("alice") && r.cluster_group.0 == GROUP_CLICKHOUSE
+        })
+        .await;
+    assert!(
+        record.is_some(),
+        "expected QueryRecord with user=alice on clickhouse"
+    );
+}
+
+/// The ClickHouse adapter passes `session.database()` as the HTTP `database`
+/// parameter. `one` resolves only inside the `system` database, so success
+/// here proves the parameter was applied.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_database_hint_scopes_queries() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute(
+            "SELECT dummy FROM one",
+            &[
+                ("x-trino-user", "test"),
+                ("x-trino-catalog", "system"),
+                ("x-qf-group", GROUP_CLICKHOUSE),
+            ],
+        )
+        .await
+        .expect("query");
+    assert!(
+        r.error.is_none(),
+        "expected database=system to scope the query, got: {:?}",
+        r.error
+    );
+    assert_eq!(r.rows.len(), 1, "system.one always contains one row");
+}
+
+/// An invalid database hint must bubble up as a query error (ClickHouse
+/// rejects an unknown `database` parameter), not a panic or silent mismatch.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_invalid_database_hint_returns_error() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute(
+            "SELECT 1",
+            &[
+                ("x-trino-user", "test"),
+                ("x-trino-catalog", "nonexistent_db_xyz_qf_test"),
+                ("x-qf-group", GROUP_CLICKHOUSE),
+            ],
+        )
+        .await
+        .expect("request succeeded");
+    assert!(
+        r.error.is_some(),
+        "expected an error for an unknown database, got rows: {:?}",
+        r.rows
+    );
+}
+
+/// Omitting the catalog header must not break queries — no `database`
+/// parameter is sent and ClickHouse uses the connection default.
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_no_database_hint_still_executes() {
+    require_group!(GROUP_CLICKHOUSE);
+    let r = client()
+        .execute(
+            "SELECT 42 AS n",
+            &[("x-trino-user", "test"), ("x-qf-group", GROUP_CLICKHOUSE)],
+        )
+        .await
+        .expect("query");
+    assert!(r.error.is_none(), "unexpected error: {:?}", r.error);
+    assert_eq!(r.rows[0][0], json!(42));
+}
+
+// ---------------------------------------------------------------------------
+// Cross-engine routing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires Trino + ClickHouse — run with: make test-e2e"]
+async fn routing_same_sql_trino_and_clickhouse() {
+    require_group!(GROUP_TRINO);
+    require_group!(GROUP_CLICKHOUSE);
+    let c = client();
+    let sql = "SELECT 1 + 1 AS result";
+
+    let trino = c.execute_on(sql, GROUP_TRINO).await.expect("trino");
+    let ch = c
+        .execute_on(sql, GROUP_CLICKHOUSE)
+        .await
+        .expect("clickhouse");
+
+    assert!(trino.error.is_none(), "trino error: {:?}", trino.error);
+    assert!(ch.error.is_none(), "clickhouse error: {:?}", ch.error);
+    assert_eq!(trino.rows.len(), 1);
+    assert_eq!(ch.rows.len(), 1);
+    assert_eq!(trino.rows[0][0], ch.rows[0][0]);
+}

--- a/crates/queryflux-engine-adapters/Cargo.toml
+++ b/crates/queryflux-engine-adapters/Cargo.toml
@@ -25,6 +25,7 @@ aws-config = { version = "1", default-features = false, features = ["rustls"] }
 aws-credential-types = "1"
 aws-types = "1"
 url = "2"
+uuid = { version = "1", features = ["v4"] }
 adbc_core = "0.23"
 adbc_driver_manager = "0.23"
 r2d2 = "0.8"

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -46,6 +46,14 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Cap on error-body text included in error messages.
 const MAX_ERROR_BODY: usize = 2000;
 
+/// Cap on error-response bodies read off the wire — exception text is small.
+const MAX_ERROR_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// The exception frame is appended at the tail of the body (≤16 KiB per the
+/// ClickHouse docs) — bound the reverse scan so large successful results do
+/// not pay a full-buffer scan looking for a frame that isn't there.
+const EXCEPTION_SCAN_WINDOW: usize = 64 * 1024;
+
 /// Default cap on the buffered result body (`maxResultBufferBytes` config).
 /// ClickHouse has infinite virtual tables (`system.numbers`,
 /// `generateRandom()`, …) — without a cap, one unbounded SELECT would grow
@@ -267,9 +275,10 @@ impl ClickHouseAdapter {
 
     /// Run a control-plane query (catalog listing, process counts) and return
     /// the response body as non-empty TSV lines. Values are NOT unescaped —
-    /// callers that surface identifiers apply [`tsv_unescape`].
+    /// callers that surface identifiers apply [`tsv_unescape`]. Hardened like
+    /// the Arrow path: capped read, exception-frame scan, aborts propagate.
     async fn run_query_lines(&self, sql: &str) -> Result<Vec<String>> {
-        let resp = self
+        let mut resp = self
             .query_request(sql, "TSV")
             .timeout(CONTROL_TIMEOUT)
             .send()
@@ -277,16 +286,74 @@ impl ClickHouseAdapter {
             .map_err(|e| QueryFluxError::Engine(format!("ClickHouse request failed: {e}")))?;
         let status = resp.status();
         let exception_code = header_string(&resp, "x-clickhouse-exception-code");
-        let body = resp.text().await.unwrap_or_default();
+        let exception_tag = header_string(&resp, "x-clickhouse-exception-tag");
         if !status.is_success() {
+            let body = read_error_body(&mut resp).await;
             return Err(clickhouse_http_error(status, exception_code, &body));
         }
-        Ok(body
+        let (body, transfer_error) =
+            read_body_capped(&mut resp, self.max_result_buffer_bytes).await?;
+        if let Some(tag) = &exception_tag {
+            if let Some(msg) = find_exception_frame(&body, tag) {
+                return Err(QueryFluxError::Engine(format!(
+                    "ClickHouse query failed mid-stream: {}",
+                    msg.trim()
+                )));
+            }
+        }
+        if let Some(e) = transfer_error {
+            return Err(QueryFluxError::Engine(format!(
+                "ClickHouse response aborted mid-stream: {e}"
+            )));
+        }
+        Ok(String::from_utf8_lossy(&body)
             .lines()
             .filter(|l| !l.is_empty())
             .map(String::from)
             .collect())
     }
+}
+
+/// Read a response body up to `cap` bytes. A mid-stream transfer error is
+/// returned alongside the bytes received so far — ClickHouse aborts the
+/// chunked encoding on post-200 failures, and callers must scan those bytes
+/// for the exception frame before treating the abort as a transport error.
+async fn read_body_capped(
+    resp: &mut reqwest::Response,
+    cap: usize,
+) -> Result<(Vec<u8>, Option<reqwest::Error>)> {
+    let mut body: Vec<u8> = Vec::new();
+    loop {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                if body.len() + chunk.len() > cap {
+                    return Err(QueryFluxError::Engine(format!(
+                        "ClickHouse result exceeded the {cap}-byte buffered-result cap; \
+                         add a LIMIT, narrow the query, or raise maxResultBufferBytes"
+                    )));
+                }
+                body.extend_from_slice(&chunk);
+            }
+            Ok(None) => return Ok((body, None)),
+            Err(e) => return Ok((body, Some(e))),
+        }
+    }
+}
+
+/// Read an error-response body, capped — exception text is small, and an
+/// unbounded read would bypass the buffered-result protection.
+async fn read_error_body(resp: &mut reqwest::Response) -> String {
+    let mut body: Vec<u8> = Vec::new();
+    while body.len() < MAX_ERROR_RESPONSE_BYTES {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                let room = MAX_ERROR_RESPONSE_BYTES - body.len();
+                body.extend_from_slice(&chunk[..chunk.len().min(room)]);
+            }
+            _ => break,
+        }
+    }
+    String::from_utf8_lossy(&body).into_owned()
 }
 
 /// Decode ClickHouse TSV escape sequences (`\\`, `\t`, `\n`, `\r`, `\b`,
@@ -345,6 +412,8 @@ fn header_string(resp: &reqwest::Response, name: &str) -> Option<String> {
 /// frame is present. Older servers splice plain error text into the stream
 /// instead; those surface as an Arrow decode / transfer error.
 fn find_exception_frame(body: &[u8], tag: &str) -> Option<String> {
+    // The frame only ever lives at the tail — search a bounded window.
+    let body = &body[body.len().saturating_sub(EXCEPTION_SCAN_WINDOW)..];
     let open = format!("\r\n__exception__\r\n{tag}\r\n");
     let start = find_last(body, open.as_bytes())?;
     let rest = &body[start + open.len()..];
@@ -418,6 +487,14 @@ fn escape_ident(ident: &str) -> String {
     format!("`{}`", ident.replace('\\', "\\\\").replace('`', "``"))
 }
 
+/// True when an error carries ClickHouse's UNKNOWN_TABLE (60) or
+/// UNKNOWN_DATABASE (81) exception code — the codes `clickhouse_http_error`
+/// embeds in the message it formats.
+fn is_unknown_table_error(e: &QueryFluxError) -> bool {
+    let msg = e.to_string();
+    msg.contains("exception code 60)") || msg.contains("exception code 81)")
+}
+
 #[async_trait]
 impl crate::SyncAdapter for ClickHouseAdapter {
     async fn execute_as_arrow(
@@ -451,34 +528,15 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         let exception_tag = header_string(&resp, "x-clickhouse-exception-tag");
 
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = read_error_body(&mut resp).await;
             return Err(clickhouse_http_error(status, exception_code, &body));
         }
 
         // Buffer the body, tolerating a mid-stream abort: ClickHouse kills the
         // chunked encoding when a query fails after 200 was already sent, and
         // the exception frame is in the bytes received so far.
-        let mut body: Vec<u8> = Vec::new();
-        let mut transfer_error: Option<reqwest::Error> = None;
-        loop {
-            match resp.chunk().await {
-                Ok(Some(chunk)) => {
-                    if body.len() + chunk.len() > self.max_result_buffer_bytes {
-                        return Err(QueryFluxError::Engine(format!(
-                            "ClickHouse result exceeded the {}-byte buffered-result cap; \
-                             add a LIMIT, narrow the query, or raise maxResultBufferBytes",
-                            self.max_result_buffer_bytes
-                        )));
-                    }
-                    body.extend_from_slice(&chunk);
-                }
-                Ok(None) => break,
-                Err(e) => {
-                    transfer_error = Some(e);
-                    break;
-                }
-            }
-        }
+        let (body, transfer_error) =
+            read_body_capped(&mut resp, self.max_result_buffer_bytes).await?;
 
         // A post-200 failure appends a tag-framed exception block — check for
         // it before decoding so a failed query never yields partial batches.
@@ -567,7 +625,10 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         );
         let lines = match self.run_query_lines(&sql).await {
             Ok(l) => l,
-            Err(_) => return Ok(None),
+            // Only a genuinely missing table/database maps to `None`;
+            // connectivity, auth, and timeout errors propagate.
+            Err(e) if is_unknown_table_error(&e) => return Ok(None),
+            Err(e) => return Err(e),
         };
         let columns = lines
             .iter()
@@ -786,6 +847,32 @@ mod tests {
     #[test]
     fn body_without_frame_returns_none() {
         assert_eq!(find_exception_frame(b"plain arrow bytes", TAG), None);
+    }
+
+    /// The tail-window bound must not lose a frame at the end of a large body.
+    #[test]
+    fn frame_is_found_behind_a_large_body() {
+        let mut body = vec![b'x'; EXCEPTION_SCAN_WINDOW * 4];
+        body.extend_from_slice(&framed("boom")[b"some arrow bytes".len()..]);
+        assert_eq!(find_exception_frame(&body, TAG).as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn unknown_table_codes_map_to_none_others_propagate() {
+        let unknown_table = QueryFluxError::Engine(
+            "ClickHouse query failed (HTTP 404 Not Found, exception code 60): Code: 60.".into(),
+        );
+        let unknown_db = QueryFluxError::Engine(
+            "ClickHouse query failed (HTTP 404 Not Found, exception code 81): Code: 81.".into(),
+        );
+        let timeout = QueryFluxError::Engine(
+            "ClickHouse query failed (HTTP 408 Request Timeout, exception code 159): ...".into(),
+        );
+        let transport = QueryFluxError::Engine("ClickHouse request failed: connect error".into());
+        assert!(is_unknown_table_error(&unknown_table));
+        assert!(is_unknown_table_error(&unknown_db));
+        assert!(!is_unknown_table_error(&timeout));
+        assert!(!is_unknown_table_error(&transport));
     }
 
     #[test]

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -257,7 +257,9 @@ impl ClickHouseAdapter {
     /// Build a query request: SQL as the POST body, everything else as URL params.
     ///
     /// `query_id` is always set (one UUID per request) so queries are traceable
-    /// in `system.query_log` and killable via `KILL QUERY WHERE query_id = …`.
+    /// in `system.query_log`. Cancellation is NOT wired up: the sync adapter
+    /// path has no cancel hook, so a client disconnect does not `KILL QUERY`
+    /// on the ClickHouse side (tracked in #111).
     fn query_request(&self, sql: &str, format: &str) -> reqwest::RequestBuilder {
         let mut req = self
             .client

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -46,16 +46,38 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Cap on error-body text included in error messages.
 const MAX_ERROR_BODY: usize = 2000;
 
-/// Cap on the buffered result body. ClickHouse has infinite virtual tables
-/// (`system.numbers`, `generateRandom()`, …) — without a cap, one unbounded
-/// SELECT would grow the buffer until the process is OOM-killed.
-const MAX_RESULT_BODY_BYTES: usize = 1 << 30; // 1 GiB
+/// Default cap on the buffered result body (`maxResultBufferBytes` config).
+/// ClickHouse has infinite virtual tables (`system.numbers`,
+/// `generateRandom()`, …) — without a cap, one unbounded SELECT would grow
+/// the buffer until the process is OOM-killed.
+pub const DEFAULT_MAX_RESULT_BUFFER_BYTES: usize = 1 << 30; // 1 GiB
 
 /// Parsed and validated configuration for a ClickHouse cluster.
 pub struct ClickHouseConfig {
     pub endpoint: String,
     pub auth: Option<ClusterAuth>,
     pub tls_skip_verify: bool,
+    /// Per-query buffered-result cap in bytes.
+    pub max_result_buffer_bytes: usize,
+}
+
+/// Parse the optional `maxResultBufferBytes` JSON field (positive integer).
+fn parse_max_result_buffer_from_json(
+    json: &serde_json::Value,
+    cluster_name: &str,
+) -> Result<usize> {
+    match json.get("maxResultBufferBytes") {
+        None => Ok(DEFAULT_MAX_RESULT_BUFFER_BYTES),
+        Some(v) => v
+            .as_u64()
+            .filter(|&n| n >= 1)
+            .and_then(|n| usize::try_from(n).ok())
+            .ok_or_else(|| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': maxResultBufferBytes must be a positive integer"
+                ))
+            }),
+    }
 }
 
 impl ClickHouseConfig {
@@ -87,6 +109,7 @@ impl crate::EngineConfigParseable for ClickHouseConfig {
             endpoint,
             auth,
             tls_skip_verify: json_tls_insecure_skip_verify(json),
+            max_result_buffer_bytes: parse_max_result_buffer_from_json(json, cluster_name)?,
         })
     }
 
@@ -95,10 +118,20 @@ impl crate::EngineConfigParseable for ClickHouseConfig {
             QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
         })?;
         Self::reject_non_basic_auth(&cfg.auth, cluster_name)?;
+        let max_result_buffer_bytes = match cfg.max_result_buffer_bytes {
+            None => DEFAULT_MAX_RESULT_BUFFER_BYTES,
+            Some(0) => {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': maxResultBufferBytes must be a positive integer"
+                )))
+            }
+            Some(n) => usize::try_from(n).unwrap_or(usize::MAX),
+        };
         Ok(Self {
             endpoint,
             auth: cfg.auth.clone(),
             tls_skip_verify: cfg.tls.as_ref().is_some_and(|t| t.insecure_skip_verify),
+            max_result_buffer_bytes,
         })
     }
 }
@@ -113,6 +146,8 @@ pub struct ClickHouseAdapter {
     endpoint: String,
     /// Basic-auth credentials (username, password) when configured.
     basic_auth: Option<(String, String)>,
+    /// Per-query buffered-result cap in bytes (`maxResultBufferBytes`).
+    max_result_buffer_bytes: usize,
     client: reqwest::Client,
 }
 
@@ -141,6 +176,7 @@ impl ClickHouseAdapter {
             group_name,
             endpoint: config.endpoint.trim_end_matches('/').to_string(),
             basic_auth,
+            max_result_buffer_bytes: config.max_result_buffer_bytes,
             client,
         })
     }
@@ -188,6 +224,15 @@ impl ClickHouseAdapter {
                     field_type: FieldType::Secret,
                     required: false,
                     example: None,
+                },
+                ConfigField {
+                    key: "maxResultBufferBytes",
+                    label: "Max result buffer (bytes)",
+                    description: "Per-query cap on the result bytes QueryFlux buffers in memory. \
+                                  Defaults to 1 GiB when omitted.",
+                    field_type: FieldType::Number,
+                    required: false,
+                    example: Some("1073741824"),
                 },
                 ConfigField {
                     key: "tls.insecureSkipVerify",
@@ -418,10 +463,11 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         loop {
             match resp.chunk().await {
                 Ok(Some(chunk)) => {
-                    if body.len() + chunk.len() > MAX_RESULT_BODY_BYTES {
+                    if body.len() + chunk.len() > self.max_result_buffer_bytes {
                         return Err(QueryFluxError::Engine(format!(
-                            "ClickHouse result exceeded the {MAX_RESULT_BODY_BYTES}-byte \
-                             buffered-result cap; add a LIMIT or narrow the query"
+                            "ClickHouse result exceeded the {}-byte buffered-result cap; \
+                             add a LIMIT, narrow the query, or raise maxResultBufferBytes",
+                            self.max_result_buffer_bytes
                         )));
                     }
                     body.extend_from_slice(&chunk);
@@ -603,6 +649,31 @@ mod tests {
     }
 
     #[test]
+    fn result_buffer_cap_defaults_and_overrides() {
+        // Omitted → 1 GiB default.
+        let cfg =
+            ClickHouseConfig::from_json(&json!({"endpoint": "http://ch:8123"}), "ch-1").unwrap();
+        assert_eq!(cfg.max_result_buffer_bytes, DEFAULT_MAX_RESULT_BUFFER_BYTES);
+        // Explicit value wins.
+        let cfg = ClickHouseConfig::from_json(
+            &json!({"endpoint": "http://ch:8123", "maxResultBufferBytes": 65536}),
+            "ch-1",
+        )
+        .unwrap();
+        assert_eq!(cfg.max_result_buffer_bytes, 65536);
+        // Zero and non-integers are rejected.
+        for bad in [json!(0), json!("big"), json!(-1)] {
+            let err = ClickHouseConfig::from_json(
+                &json!({"endpoint": "http://ch:8123", "maxResultBufferBytes": bad}),
+                "ch-1",
+            )
+            .map(|_| ())
+            .unwrap_err();
+            assert!(err.to_string().contains("maxResultBufferBytes"));
+        }
+    }
+
+    #[test]
     fn from_json_rejects_bearer_auth() {
         let err = ClickHouseConfig::from_json(
             &json!({
@@ -631,6 +702,7 @@ mod tests {
             workgroup: None,
             catalog: None,
             tls: None,
+            max_result_buffer_bytes: None,
             auth: None,
             query_auth: None,
         };

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -306,15 +306,21 @@ fn find_exception_frame(body: &[u8], tag: &str) -> Option<String> {
     // The frame closes with `\r\n<message_length> <TAG>\r\n__exception__\r\n`.
     let close_suffix = format!(" {tag}\r\n__exception__\r\n");
     let close_at = find_last(rest, close_suffix.as_bytes())?;
-    // Walk back over the message-length digits and the `\r\n` preceding them.
+    // Walk back over the message-length digits and the newline preceding them.
+    // Observed on 26.7 the separator is a bare `\n` (the docs say `\r\n`) —
+    // accept either.
     let mut msg_end = close_at;
     while msg_end > 0 && rest[msg_end - 1].is_ascii_digit() {
         msg_end -= 1;
     }
-    let msg_end = msg_end
-        .checked_sub(2)
-        .filter(|_| rest.get(msg_end.wrapping_sub(2)..msg_end) == Some(b"\r\n".as_slice()))?;
-    Some(String::from_utf8_lossy(&rest[..msg_end]).into_owned())
+    let sep_len = if msg_end >= 2 && &rest[msg_end - 2..msg_end] == b"\r\n" {
+        2
+    } else if msg_end >= 1 && rest[msg_end - 1] == b'\n' {
+        1
+    } else {
+        return None;
+    };
+    Some(String::from_utf8_lossy(&rest[..msg_end - sep_len]).into_owned())
 }
 
 fn find_last(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -650,7 +656,23 @@ mod tests {
 
     const TAG: &str = "yqftqimeegydpouu";
 
+    /// Byte-exact real-server framing (verified against ClickHouse 26.7):
+    /// bare `\n` between message and length line.
     fn framed(message: &str) -> Vec<u8> {
+        let mut body = b"some arrow bytes".to_vec();
+        body.extend_from_slice(
+            format!(
+                "\r\n__exception__\r\n{TAG}\r\n{message}\n{} {TAG}\r\n__exception__\r\n",
+                message.len()
+            )
+            .as_bytes(),
+        );
+        body
+    }
+
+    /// The framing the ClickHouse docs describe (`\r\n` separator) — accepted
+    /// too in case other versions emit it.
+    fn framed_crlf(message: &str) -> Vec<u8> {
         let mut body = b"some arrow bytes".to_vec();
         body.extend_from_slice(
             format!(
@@ -668,6 +690,15 @@ mod tests {
         assert_eq!(
             find_exception_frame(&body, TAG).as_deref(),
             Some("Code: 395. DB::Exception: Value passed to 'throwIf'.")
+        );
+    }
+
+    #[test]
+    fn exception_frame_with_crlf_separator_is_extracted() {
+        let body = framed_crlf("Code: 395. DB::Exception: boom.");
+        assert_eq!(
+            find_exception_frame(&body, TAG).as_deref(),
+            Some("Code: 395. DB::Exception: boom.")
         );
     }
 

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -410,18 +410,33 @@ fn header_string(resp: &reqwest::Response, name: &str) -> Option<String> {
 /// Since 25.11, a query that fails after HTTP 200 was sent appends
 /// `\r\n__exception__\r\n<TAG>\r\n<message>\r\n<len> <TAG>\r\n__exception__\r\n`
 /// to the body, where `<TAG>` is a random per-response tag pre-announced in the
-/// `X-ClickHouse-Exception-Tag` header. Returns the error message when the
-/// frame is present. Older servers splice plain error text into the stream
-/// instead; those surface as an Arrow decode / transfer error.
+/// `X-ClickHouse-Exception-Tag` header. Both `\r\n` and bare `\n` are
+/// accepted around every part of the frame (real 26.x servers already mix
+/// them: CRLF markers, LF message-length separator). Returns the error
+/// message when the frame is present. Older servers splice plain error text
+/// into the stream instead; those surface as an Arrow decode / transfer
+/// error.
 fn find_exception_frame(body: &[u8], tag: &str) -> Option<String> {
     // The frame only ever lives at the tail — search a bounded window.
     let body = &body[body.len().saturating_sub(EXCEPTION_SCAN_WINDOW)..];
-    let open = format!("\r\n__exception__\r\n{tag}\r\n");
-    let start = find_last(body, open.as_bytes())?;
-    let rest = &body[start + open.len()..];
-    // The frame closes with `\r\n<message_length> <TAG>\r\n__exception__\r\n`.
-    let close_suffix = format!(" {tag}\r\n__exception__\r\n");
-    let close_at = find_last(rest, close_suffix.as_bytes())?;
+    // Real servers put `\r\n` around the markers (verified on 26.3–26.8), yet
+    // the message-length separator is already a bare `\n` where the docs say
+    // `\r\n` — so accept both separators around the markers too, lest an
+    // LF-only server version slip a failed query past the scan.
+    let open_crlf = format!("\r\n__exception__\r\n{tag}\r\n");
+    let open_lf = format!("\n__exception__\n{tag}\n");
+    let (start, open_len) = [open_crlf, open_lf]
+        .iter()
+        .filter_map(|o| find_last(body, o.as_bytes()).map(|at| (at, o.len())))
+        .max_by_key(|&(at, _)| at)?;
+    let rest = &body[start + open_len..];
+    // The frame closes with `<sep><message_length> <TAG><sep>__exception__<sep>`.
+    let close_crlf = format!(" {tag}\r\n__exception__\r\n");
+    let close_lf = format!(" {tag}\n__exception__\n");
+    let close_at = [close_crlf, close_lf]
+        .iter()
+        .filter_map(|c| find_last(rest, c.as_bytes()))
+        .max()?;
     // Walk back over the message-length digits and the newline preceding them.
     // Observed on 26.7 the separator is a bare `\n` (the docs say `\r\n`) —
     // accept either.
@@ -835,6 +850,36 @@ mod tests {
             find_exception_frame(&body, TAG).as_deref(),
             Some("Code: 395. DB::Exception: boom.")
         );
+    }
+
+    /// Hypothetical LF-only framing (no server observed emitting it, but the
+    /// real servers already deviate from the docs on the length separator, so
+    /// the markers are parsed separator-agnostically too).
+    fn framed_lf(message: &str) -> Vec<u8> {
+        let mut body = b"some arrow bytes".to_vec();
+        body.extend_from_slice(
+            format!(
+                "\n__exception__\n{TAG}\n{message}\n{} {TAG}\n__exception__\n",
+                message.len()
+            )
+            .as_bytes(),
+        );
+        body
+    }
+
+    #[test]
+    fn exception_frame_with_lf_only_markers_is_extracted() {
+        let body = framed_lf("Code: 395. DB::Exception: boom.");
+        assert_eq!(
+            find_exception_frame(&body, TAG).as_deref(),
+            Some("Code: 395. DB::Exception: boom.")
+        );
+    }
+
+    #[test]
+    fn lf_only_frame_with_wrong_tag_returns_none() {
+        let body = framed_lf("boom");
+        assert_eq!(find_exception_frame(&body, "aaaaaaaaaaaaaaaa"), None);
     }
 
     #[test]

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -46,8 +46,12 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Cap on error-body text included in error messages.
 const MAX_ERROR_BODY: usize = 2000;
 
+/// Cap on the buffered result body. ClickHouse has infinite virtual tables
+/// (`system.numbers`, `generateRandom()`, …) — without a cap, one unbounded
+/// SELECT would grow the buffer until the process is OOM-killed.
+const MAX_RESULT_BODY_BYTES: usize = 1 << 30; // 1 GiB
+
 /// Parsed and validated configuration for a ClickHouse cluster.
-#[derive(Debug)]
 pub struct ClickHouseConfig {
     pub endpoint: String,
     pub auth: Option<ClusterAuth>,
@@ -99,6 +103,10 @@ impl crate::EngineConfigParseable for ClickHouseConfig {
     }
 }
 
+/// ClickHouse adapter — executes SQL over the HTTP interface (default port
+/// 8123) and decodes `ArrowStream` responses; sync/eager like the other sync
+/// adapters. See the module docs for exception-frame handling and catalog
+/// mapping.
 pub struct ClickHouseAdapter {
     pub cluster_name: ClusterName,
     pub group_name: ClusterGroupName,
@@ -184,8 +192,7 @@ impl ClickHouseAdapter {
                 ConfigField {
                     key: "tls.insecureSkipVerify",
                     label: "Skip TLS verification",
-                    description:
-                        "Accept invalid/self-signed TLS certificates (https endpoints only).",
+                    description: "Disable TLS certificate verification. Use only in development.",
                     field_type: FieldType::Boolean,
                     required: false,
                     example: Some("false"),
@@ -214,19 +221,15 @@ impl ClickHouseAdapter {
     }
 
     /// Run a control-plane query (catalog listing, process counts) and return
-    /// the response body as trimmed non-empty TSV lines.
+    /// the response body as non-empty TSV lines. Values are NOT unescaped —
+    /// callers that surface identifiers apply [`tsv_unescape`].
     async fn run_query_lines(&self, sql: &str) -> Result<Vec<String>> {
         let resp = self
             .query_request(sql, "TSV")
             .timeout(CONTROL_TIMEOUT)
             .send()
             .await
-            .map_err(|e| {
-                QueryFluxError::Engine(format!(
-                    "cluster '{}': ClickHouse request failed: {e}",
-                    self.cluster_name.0
-                ))
-            })?;
+            .map_err(|e| QueryFluxError::Engine(format!("ClickHouse request failed: {e}")))?;
         let status = resp.status();
         let exception_code = header_string(&resp, "x-clickhouse-exception-code");
         let body = resp.text().await.unwrap_or_default();
@@ -235,11 +238,34 @@ impl ClickHouseAdapter {
         }
         Ok(body
             .lines()
-            .map(str::trim_end)
             .filter(|l| !l.is_empty())
             .map(String::from)
             .collect())
     }
+}
+
+/// Decode ClickHouse TSV escape sequences (`\\`, `\t`, `\n`, `\r`, `\b`,
+/// `\f`, `\0`, `\'`). Unknown escapes pass the escaped character through.
+fn tsv_unescape(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('t') => out.push('\t'),
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('b') => out.push('\u{8}'),
+            Some('f') => out.push('\u{c}'),
+            Some('0') => out.push('\0'),
+            Some(other) => out.push(other),
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Format a non-200 ClickHouse response as an engine error.
@@ -318,7 +344,7 @@ fn decode_arrow_stream(body: &[u8]) -> Result<Vec<RecordBatch>> {
 /// Line shape: `name\ttype\tdefault_type\tdefault_expression\t…`.
 fn parse_describe_line(line: &str) -> Option<ColumnDef> {
     let mut fields = line.split('\t');
-    let name = fields.next()?.to_string();
+    let name = tsv_unescape(fields.next()?);
     let raw_type = fields.next().unwrap_or("String");
     let (data_type, nullable) = strip_nullable(raw_type);
     Some(ColumnDef {
@@ -335,9 +361,10 @@ fn strip_nullable(raw: &str) -> (&str, bool) {
         .map_or((raw, false), |inner| (inner, true))
 }
 
-/// Backtick-escape a ClickHouse identifier.
+/// Backtick-escape a ClickHouse identifier. Backslashes are escaped too —
+/// ClickHouse interprets backslash escapes inside back-quoted identifiers.
 fn escape_ident(ident: &str) -> String {
-    format!("`{}`", ident.replace('`', "``"))
+    format!("`{}`", ident.replace('\\', "\\\\").replace('`', "``"))
 }
 
 #[async_trait]
@@ -364,12 +391,10 @@ impl crate::SyncAdapter for ClickHouseAdapter {
             req = req.query(&[("log_comment", tag_json.as_str())]);
         }
 
-        let mut resp = req.send().await.map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{}': ClickHouse request failed: {e}",
-                self.cluster_name.0
-            ))
-        })?;
+        let mut resp = req
+            .send()
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("ClickHouse request failed: {e}")))?;
         let status = resp.status();
         let exception_code = header_string(&resp, "x-clickhouse-exception-code");
         let exception_tag = header_string(&resp, "x-clickhouse-exception-tag");
@@ -386,7 +411,15 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         let mut transfer_error: Option<reqwest::Error> = None;
         loop {
             match resp.chunk().await {
-                Ok(Some(chunk)) => body.extend_from_slice(&chunk),
+                Ok(Some(chunk)) => {
+                    if body.len() + chunk.len() > MAX_RESULT_BODY_BYTES {
+                        return Err(QueryFluxError::Engine(format!(
+                            "ClickHouse result exceeded the {MAX_RESULT_BODY_BYTES}-byte \
+                             buffered-result cap; add a LIMIT or narrow the query"
+                        )));
+                    }
+                    body.extend_from_slice(&chunk);
+                }
                 Ok(None) => break,
                 Err(e) => {
                     transfer_error = Some(e);
@@ -459,12 +492,14 @@ impl crate::SyncAdapter for ClickHouseAdapter {
     }
 
     async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
-        self.run_query_lines("SHOW DATABASES").await
+        let lines = self.run_query_lines("SHOW DATABASES").await?;
+        Ok(lines.iter().map(|l| tsv_unescape(l)).collect())
     }
 
     async fn list_tables(&self, _catalog: &str, database: &str) -> Result<Vec<String>> {
         let sql = format!("SHOW TABLES FROM {}", escape_ident(database));
-        self.run_query_lines(&sql).await
+        let lines = self.run_query_lines(&sql).await?;
+        Ok(lines.iter().map(|l| tsv_unescape(l)).collect())
     }
 
     async fn describe_table(
@@ -555,7 +590,9 @@ mod tests {
 
     #[test]
     fn from_json_missing_endpoint_errors() {
-        let err = ClickHouseConfig::from_json(&json!({}), "ch-1").unwrap_err();
+        let err = ClickHouseConfig::from_json(&json!({}), "ch-1")
+            .map(|_| ())
+            .unwrap_err();
         assert!(err.to_string().contains("missing endpoint"));
     }
 
@@ -569,6 +606,7 @@ mod tests {
             }),
             "ch-1",
         )
+        .map(|_| ())
         .unwrap_err();
         assert!(err.to_string().contains("only supports basic auth"));
     }
@@ -596,7 +634,9 @@ mod tests {
         cfg.auth = Some(ClusterAuth::Bearer {
             token: "tok".to_string(),
         });
-        let err = ClickHouseConfig::from_cluster_config(&cfg, "ch-1").unwrap_err();
+        let err = ClickHouseConfig::from_cluster_config(&cfg, "ch-1")
+            .map(|_| ())
+            .unwrap_err();
         assert!(err.to_string().contains("only supports basic auth"));
 
         cfg.auth = Some(ClusterAuth::Basic {
@@ -728,5 +768,29 @@ mod tests {
     fn idents_are_backtick_escaped() {
         assert_eq!(escape_ident("db"), "`db`");
         assert_eq!(escape_ident("we`ird"), "`we``ird`");
+        assert_eq!(escape_ident(r"back\slash"), r"`back\\slash`");
+    }
+
+    #[test]
+    fn tsv_escapes_are_decoded() {
+        assert_eq!(tsv_unescape(r"plain"), "plain");
+        assert_eq!(tsv_unescape(r"tab\there"), "tab\there");
+        assert_eq!(tsv_unescape(r"line\nbreak"), "line\nbreak");
+        assert_eq!(tsv_unescape(r"back\\slash"), r"back\slash");
+        assert_eq!(tsv_unescape(r"quote\'s"), "quote's");
+        // Unknown escape passes the escaped character through; trailing
+        // backslash is preserved.
+        assert_eq!(tsv_unescape(r"odd\z"), "oddz");
+        assert_eq!(tsv_unescape("trailing\\"), "trailing\\");
+    }
+
+    /// A TSV-escaped identifier from SHOW DATABASES round-trips through
+    /// decode + re-escape into a form ClickHouse parses back to the original.
+    #[test]
+    fn tsv_identifier_roundtrip() {
+        let listed = r"back\\slash"; // SHOW DATABASES output for `back\slash`
+        let decoded = tsv_unescape(listed);
+        assert_eq!(decoded, r"back\slash");
+        assert_eq!(escape_ident(&decoded), r"`back\\slash`");
     }
 }

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -1,0 +1,732 @@
+//! ClickHouse backend adapter — SQL over the HTTP interface, Arrow results.
+//!
+//! Queries are POSTed to the ClickHouse HTTP endpoint (default port 8123) with
+//! `default_format=ArrowStream`; the response is Arrow IPC decoded with the
+//! `arrow` crate. `default_format` is used instead of a `FORMAT` suffix so DDL
+//! and INSERT statements (where a trailing FORMAT clause would name the *input*
+//! format) pass through unchanged.
+//!
+//! Execution is eager like the other sync adapters: the whole response body is
+//! buffered before any batch is surfaced. ClickHouse can fail a query *after*
+//! sending HTTP 200 (it aborts the chunked encoding and appends an exception
+//! frame to the body), so the body is scanned for the `__exception__` frame —
+//! whose random tag is pre-announced in the `X-ClickHouse-Exception-Tag`
+//! response header — before Arrow decoding. A failed query therefore surfaces
+//! as an error, never as partial results.
+//!
+//! ClickHouse has no catalog level (its hierarchy is database → table), so a
+//! single synthetic `default` catalog is exposed. Requires ClickHouse 24.3+
+//! (String columns arrive as Arrow `Utf8` by default from that version).
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow::ipc::reader::StreamReader;
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use futures::stream;
+use queryflux_core::catalog::{ColumnDef, TableSchema};
+use queryflux_core::config::{ClusterAuth, ClusterConfig};
+use queryflux_core::engine_registry::{
+    AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
+};
+use queryflux_core::error::{QueryFluxError, Result};
+use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType};
+use queryflux_core::session::SessionContext;
+use queryflux_core::tags::QueryTags;
+
+use crate::{AdapterKind, SyncExecution};
+
+/// Timeout for control-plane requests (health checks, catalog listing).
+/// Query execution has no overall timeout — analytics queries can be long.
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cap on error-body text included in error messages.
+const MAX_ERROR_BODY: usize = 2000;
+
+/// Parsed and validated configuration for a ClickHouse cluster.
+#[derive(Debug)]
+pub struct ClickHouseConfig {
+    pub endpoint: String,
+    pub auth: Option<ClusterAuth>,
+    pub tls_skip_verify: bool,
+}
+
+impl ClickHouseConfig {
+    fn reject_non_basic_auth(auth: &Option<ClusterAuth>, cluster_name: &str) -> Result<()> {
+        if let Some(a) = auth {
+            if !matches!(a, ClusterAuth::Basic { .. }) {
+                return Err(QueryFluxError::Engine(format!(
+                    "cluster '{cluster_name}': ClickHouse only supports basic auth (username + password)"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl crate::EngineConfigParseable for ClickHouseConfig {
+    fn from_json(json: &serde_json::Value, cluster_name: &str) -> Result<Self> {
+        use queryflux_core::engine_registry::{
+            json_str, json_tls_insecure_skip_verify, parse_auth_from_config_json,
+        };
+        let endpoint = json_str(json, "endpoint").ok_or_else(|| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
+        })?;
+        let auth = parse_auth_from_config_json(json).map_err(|e| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': invalid auth ({e})"))
+        })?;
+        Self::reject_non_basic_auth(&auth, cluster_name)?;
+        Ok(Self {
+            endpoint,
+            auth,
+            tls_skip_verify: json_tls_insecure_skip_verify(json),
+        })
+    }
+
+    fn from_cluster_config(cfg: &ClusterConfig, cluster_name: &str) -> Result<Self> {
+        let endpoint = cfg.endpoint.clone().ok_or_else(|| {
+            QueryFluxError::Engine(format!("cluster '{cluster_name}': missing endpoint"))
+        })?;
+        Self::reject_non_basic_auth(&cfg.auth, cluster_name)?;
+        Ok(Self {
+            endpoint,
+            auth: cfg.auth.clone(),
+            tls_skip_verify: cfg.tls.as_ref().is_some_and(|t| t.insecure_skip_verify),
+        })
+    }
+}
+
+pub struct ClickHouseAdapter {
+    pub cluster_name: ClusterName,
+    pub group_name: ClusterGroupName,
+    endpoint: String,
+    /// Basic-auth credentials (username, password) when configured.
+    basic_auth: Option<(String, String)>,
+    client: reqwest::Client,
+}
+
+impl ClickHouseAdapter {
+    pub fn new(
+        cluster_name: ClusterName,
+        group_name: ClusterGroupName,
+        config: ClickHouseConfig,
+    ) -> Result<Self> {
+        let mut builder = reqwest::Client::builder().connect_timeout(CONNECT_TIMEOUT);
+        if config.tls_skip_verify {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+        let client = builder.build().map_err(|e| {
+            QueryFluxError::Engine(format!(
+                "cluster '{}': ClickHouse HTTP client build failed: {e}",
+                cluster_name.0
+            ))
+        })?;
+        let basic_auth = match config.auth {
+            Some(ClusterAuth::Basic { username, password }) => Some((username, password)),
+            _ => None,
+        };
+        Ok(Self {
+            cluster_name,
+            group_name,
+            endpoint: config.endpoint.trim_end_matches('/').to_string(),
+            basic_auth,
+            client,
+        })
+    }
+
+    pub fn descriptor() -> EngineDescriptor {
+        EngineDescriptor {
+            engine_key: "clickHouse",
+            display_name: "ClickHouse",
+            description: "Real-time OLAP database. Connects via the ClickHouse HTTP interface.",
+            hex: "FFCC01",
+            connection_type: ConnectionType::Http,
+            default_port: Some(8123),
+            endpoint_example: Some("http://clickhouse:8123"),
+            supported_auth: vec![AuthType::Basic],
+            implemented: true,
+            config_fields: vec![
+                ConfigField {
+                    key: "endpoint",
+                    label: "Endpoint",
+                    description: "HTTP base URL of the ClickHouse server.",
+                    field_type: FieldType::Url,
+                    required: true,
+                    example: Some("http://clickhouse:8123"),
+                },
+                ConfigField {
+                    key: "auth.type",
+                    label: "Auth type",
+                    description: "Must be 'basic' for ClickHouse (username + password).",
+                    field_type: FieldType::Text,
+                    required: false,
+                    example: Some("basic"),
+                },
+                ConfigField {
+                    key: "auth.username",
+                    label: "Username",
+                    description: "ClickHouse username.",
+                    field_type: FieldType::Text,
+                    required: false,
+                    example: Some("default"),
+                },
+                ConfigField {
+                    key: "auth.password",
+                    label: "Password",
+                    description: "ClickHouse password.",
+                    field_type: FieldType::Secret,
+                    required: false,
+                    example: None,
+                },
+                ConfigField {
+                    key: "tls.insecureSkipVerify",
+                    label: "Skip TLS verification",
+                    description:
+                        "Accept invalid/self-signed TLS certificates (https endpoints only).",
+                    field_type: FieldType::Boolean,
+                    required: false,
+                    example: Some("false"),
+                },
+            ],
+        }
+    }
+
+    /// Build a query request: SQL as the POST body, everything else as URL params.
+    ///
+    /// `query_id` is always set (one UUID per request) so queries are traceable
+    /// in `system.query_log` and killable via `KILL QUERY WHERE query_id = …`.
+    fn query_request(&self, sql: &str, format: &str) -> reqwest::RequestBuilder {
+        let mut req = self
+            .client
+            .post(format!("{}/", self.endpoint))
+            .query(&[
+                ("default_format", format),
+                ("query_id", &uuid::Uuid::new_v4().to_string()),
+            ])
+            .body(sql.to_string());
+        if let Some((user, pass)) = &self.basic_auth {
+            req = req.basic_auth(user, Some(pass));
+        }
+        req
+    }
+
+    /// Run a control-plane query (catalog listing, process counts) and return
+    /// the response body as trimmed non-empty TSV lines.
+    async fn run_query_lines(&self, sql: &str) -> Result<Vec<String>> {
+        let resp = self
+            .query_request(sql, "TSV")
+            .timeout(CONTROL_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': ClickHouse request failed: {e}",
+                    self.cluster_name.0
+                ))
+            })?;
+        let status = resp.status();
+        let exception_code = header_string(&resp, "x-clickhouse-exception-code");
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(clickhouse_http_error(status, exception_code, &body));
+        }
+        Ok(body
+            .lines()
+            .map(str::trim_end)
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect())
+    }
+}
+
+/// Format a non-200 ClickHouse response as an engine error.
+fn clickhouse_http_error(
+    status: reqwest::StatusCode,
+    exception_code: Option<String>,
+    body: &str,
+) -> QueryFluxError {
+    let code = exception_code
+        .map(|c| format!(", exception code {c}"))
+        .unwrap_or_default();
+    // Truncate on char boundaries — exception bodies can contain multi-byte text.
+    let body: String = body.trim().chars().take(MAX_ERROR_BODY).collect();
+    QueryFluxError::Engine(format!(
+        "ClickHouse query failed (HTTP {status}{code}): {body}"
+    ))
+}
+
+fn header_string(resp: &reqwest::Response, name: &str) -> Option<String> {
+    resp.headers()
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+}
+
+/// Locate a ClickHouse `__exception__` frame appended to a response body.
+///
+/// Since 25.11, a query that fails after HTTP 200 was sent appends
+/// `\r\n__exception__\r\n<TAG>\r\n<message>\r\n<len> <TAG>\r\n__exception__\r\n`
+/// to the body, where `<TAG>` is a random per-response tag pre-announced in the
+/// `X-ClickHouse-Exception-Tag` header. Returns the error message when the
+/// frame is present. Older servers splice plain error text into the stream
+/// instead; those surface as an Arrow decode / transfer error.
+fn find_exception_frame(body: &[u8], tag: &str) -> Option<String> {
+    let open = format!("\r\n__exception__\r\n{tag}\r\n");
+    let start = find_last(body, open.as_bytes())?;
+    let rest = &body[start + open.len()..];
+    // The frame closes with `\r\n<message_length> <TAG>\r\n__exception__\r\n`.
+    let close_suffix = format!(" {tag}\r\n__exception__\r\n");
+    let close_at = find_last(rest, close_suffix.as_bytes())?;
+    // Walk back over the message-length digits and the `\r\n` preceding them.
+    let mut msg_end = close_at;
+    while msg_end > 0 && rest[msg_end - 1].is_ascii_digit() {
+        msg_end -= 1;
+    }
+    let msg_end = msg_end
+        .checked_sub(2)
+        .filter(|_| rest.get(msg_end.wrapping_sub(2)..msg_end) == Some(b"\r\n".as_slice()))?;
+    Some(String::from_utf8_lossy(&rest[..msg_end]).into_owned())
+}
+
+fn find_last(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    (0..=haystack.len() - needle.len())
+        .rev()
+        .find(|&i| &haystack[i..i + needle.len()] == needle)
+}
+
+/// Decode a complete ArrowStream response body into record batches.
+/// An empty body (DDL, INSERT) decodes to no batches.
+fn decode_arrow_stream(body: &[u8]) -> Result<Vec<RecordBatch>> {
+    if body.is_empty() {
+        return Ok(Vec::new());
+    }
+    let reader = StreamReader::try_new(Cursor::new(body), None).map_err(|e| {
+        QueryFluxError::Engine(format!("ClickHouse Arrow stream schema read failed: {e}"))
+    })?;
+    reader
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| QueryFluxError::Engine(format!("ClickHouse Arrow decode failed: {e}")))
+}
+
+/// Split a `DESCRIBE TABLE` TSV line into a column definition.
+/// Line shape: `name\ttype\tdefault_type\tdefault_expression\t…`.
+fn parse_describe_line(line: &str) -> Option<ColumnDef> {
+    let mut fields = line.split('\t');
+    let name = fields.next()?.to_string();
+    let raw_type = fields.next().unwrap_or("String");
+    let (data_type, nullable) = strip_nullable(raw_type);
+    Some(ColumnDef {
+        name,
+        data_type: data_type.to_string(),
+        nullable,
+    })
+}
+
+/// `Nullable(String)` → (`String`, true); anything else passes through as not null.
+fn strip_nullable(raw: &str) -> (&str, bool) {
+    raw.strip_prefix("Nullable(")
+        .and_then(|s| s.strip_suffix(')'))
+        .map_or((raw, false), |inner| (inner, true))
+}
+
+/// Backtick-escape a ClickHouse identifier.
+fn escape_ident(ident: &str) -> String {
+    format!("`{}`", ident.replace('`', "``"))
+}
+
+#[async_trait]
+impl crate::SyncAdapter for ClickHouseAdapter {
+    async fn execute_as_arrow(
+        &self,
+        sql: &str,
+        session: &SessionContext,
+        _credentials: &queryflux_auth::QueryCredentials,
+        tags: &QueryTags,
+        // Dispatch interpolates params into the SQL before calling — this
+        // adapter reports `supports_native_params() == false` (the default).
+        _params: &queryflux_core::params::QueryParams,
+    ) -> Result<SyncExecution> {
+        let mut req = self.query_request(sql, "ArrowStream");
+        if let Some(db) = session.database() {
+            req = req.query(&[("database", db)]);
+        }
+        if !tags.is_empty() {
+            // `log_comment` surfaces the tags in system.query_log for audits.
+            // Note: rejected by servers for users with the readonly=1 profile;
+            // use readonly=2 (or a non-readonly service account) with tags.
+            let tag_json = serde_json::to_string(tags).unwrap_or_default();
+            req = req.query(&[("log_comment", tag_json.as_str())]);
+        }
+
+        let mut resp = req.send().await.map_err(|e| {
+            QueryFluxError::Engine(format!(
+                "cluster '{}': ClickHouse request failed: {e}",
+                self.cluster_name.0
+            ))
+        })?;
+        let status = resp.status();
+        let exception_code = header_string(&resp, "x-clickhouse-exception-code");
+        let exception_tag = header_string(&resp, "x-clickhouse-exception-tag");
+
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(clickhouse_http_error(status, exception_code, &body));
+        }
+
+        // Buffer the body, tolerating a mid-stream abort: ClickHouse kills the
+        // chunked encoding when a query fails after 200 was already sent, and
+        // the exception frame is in the bytes received so far.
+        let mut body: Vec<u8> = Vec::new();
+        let mut transfer_error: Option<reqwest::Error> = None;
+        loop {
+            match resp.chunk().await {
+                Ok(Some(chunk)) => body.extend_from_slice(&chunk),
+                Ok(None) => break,
+                Err(e) => {
+                    transfer_error = Some(e);
+                    break;
+                }
+            }
+        }
+
+        // A post-200 failure appends a tag-framed exception block — check for
+        // it before decoding so a failed query never yields partial batches.
+        if let Some(tag) = &exception_tag {
+            if let Some(msg) = find_exception_frame(&body, tag) {
+                return Err(QueryFluxError::Engine(format!(
+                    "ClickHouse query failed mid-stream: {}",
+                    msg.trim()
+                )));
+            }
+        }
+        if let Some(e) = transfer_error {
+            return Err(QueryFluxError::Engine(format!(
+                "ClickHouse response aborted mid-stream: {e}"
+            )));
+        }
+
+        let batches = decode_arrow_stream(&body)?;
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        // X-ClickHouse-Summary is a snapshot taken at header-flush time and
+        // undercounts in streaming mode — send None rather than wrong numbers.
+        let _ = tx.send(None);
+        Ok(SyncExecution {
+            stream: Box::pin(stream::iter(batches.into_iter().map(Ok))),
+            stats: rx,
+        })
+    }
+
+    fn engine_type(&self) -> EngineType {
+        EngineType::ClickHouse
+    }
+
+    async fn health_check(&self) -> bool {
+        // `/ping` is ClickHouse's dedicated auth-free liveness endpoint.
+        let url = format!("{}/ping", self.endpoint);
+        match self.client.get(&url).timeout(CONTROL_TIMEOUT).send().await {
+            Ok(resp) => resp.status().is_success(),
+            Err(e) => {
+                tracing::warn!(
+                    cluster = %self.cluster_name,
+                    error = %e,
+                    "ClickHouse health check ping failed"
+                );
+                false
+            }
+        }
+    }
+
+    async fn fetch_running_query_count(&self) -> Option<u64> {
+        // All actively executing queries on the server — not just those routed
+        // through QueryFlux — so the reconciler sees true engine load.
+        let lines = self
+            .run_query_lines("SELECT count() FROM system.processes")
+            .await
+            .ok()?;
+        lines.first()?.parse().ok()
+    }
+
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        // ClickHouse has no catalog level — expose one synthetic catalog.
+        Ok(vec!["default".to_string()])
+    }
+
+    async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+        self.run_query_lines("SHOW DATABASES").await
+    }
+
+    async fn list_tables(&self, _catalog: &str, database: &str) -> Result<Vec<String>> {
+        let sql = format!("SHOW TABLES FROM {}", escape_ident(database));
+        self.run_query_lines(&sql).await
+    }
+
+    async fn describe_table(
+        &self,
+        catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        let sql = format!(
+            "DESCRIBE TABLE {}.{}",
+            escape_ident(database),
+            escape_ident(table)
+        );
+        let lines = match self.run_query_lines(&sql).await {
+            Ok(l) => l,
+            Err(_) => return Ok(None),
+        };
+        let columns = lines
+            .iter()
+            .filter_map(|l| parse_describe_line(l))
+            .collect();
+        Ok(Some(TableSchema {
+            catalog: catalog.to_string(),
+            database: database.to_string(),
+            table: table.to_string(),
+            columns,
+        }))
+    }
+}
+
+pub struct ClickHouseFactory;
+
+#[async_trait]
+impl crate::EngineAdapterFactory for ClickHouseFactory {
+    fn engine_key(&self) -> &'static str {
+        "clickHouse"
+    }
+
+    fn descriptor(&self) -> EngineDescriptor {
+        ClickHouseAdapter::descriptor()
+    }
+
+    async fn build_from_config_json(
+        &self,
+        cluster_name: ClusterName,
+        group: ClusterGroupName,
+        json: &serde_json::Value,
+    ) -> Result<AdapterKind> {
+        use crate::EngineConfigParseable;
+        let name = cluster_name.0.clone();
+        let config = ClickHouseConfig::from_json(json, &name)?;
+        Ok(AdapterKind::Sync(Arc::new(ClickHouseAdapter::new(
+            cluster_name,
+            group,
+            config,
+        )?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EngineConfigParseable;
+    use arrow::array::Int64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::ipc::writer::StreamWriter;
+    use serde_json::json;
+
+    // --- config parsing ---
+
+    #[test]
+    fn from_json_parses_endpoint_auth_and_tls() {
+        let cfg = ClickHouseConfig::from_json(
+            &json!({
+                "endpoint": "http://ch:8123",
+                "authType": "basic",
+                "authUsername": "qf",
+                "authPassword": "secret",
+                "tls": { "insecureSkipVerify": true }
+            }),
+            "ch-1",
+        )
+        .expect("valid config");
+        assert_eq!(cfg.endpoint, "http://ch:8123");
+        assert!(matches!(cfg.auth, Some(ClusterAuth::Basic { .. })));
+        assert!(cfg.tls_skip_verify);
+    }
+
+    #[test]
+    fn from_json_missing_endpoint_errors() {
+        let err = ClickHouseConfig::from_json(&json!({}), "ch-1").unwrap_err();
+        assert!(err.to_string().contains("missing endpoint"));
+    }
+
+    #[test]
+    fn from_json_rejects_bearer_auth() {
+        let err = ClickHouseConfig::from_json(
+            &json!({
+                "endpoint": "http://ch:8123",
+                "authType": "bearer",
+                "authToken": "tok"
+            }),
+            "ch-1",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("only supports basic auth"));
+    }
+
+    #[test]
+    fn from_cluster_config_requires_endpoint_and_basic_auth() {
+        let mut cfg = ClusterConfig {
+            engine: Some(queryflux_core::config::EngineConfig::ClickHouse),
+            enabled: true,
+            max_running_queries: None,
+            pool_size: None,
+            endpoint: None,
+            database_path: None,
+            region: None,
+            s3_output_location: None,
+            workgroup: None,
+            catalog: None,
+            tls: None,
+            auth: None,
+            query_auth: None,
+        };
+        assert!(ClickHouseConfig::from_cluster_config(&cfg, "ch-1").is_err());
+
+        cfg.endpoint = Some("http://ch:8123".to_string());
+        cfg.auth = Some(ClusterAuth::Bearer {
+            token: "tok".to_string(),
+        });
+        let err = ClickHouseConfig::from_cluster_config(&cfg, "ch-1").unwrap_err();
+        assert!(err.to_string().contains("only supports basic auth"));
+
+        cfg.auth = Some(ClusterAuth::Basic {
+            username: "qf".to_string(),
+            password: "pw".to_string(),
+        });
+        assert!(ClickHouseConfig::from_cluster_config(&cfg, "ch-1").is_ok());
+    }
+
+    // --- exception frame scanning ---
+
+    const TAG: &str = "yqftqimeegydpouu";
+
+    fn framed(message: &str) -> Vec<u8> {
+        let mut body = b"some arrow bytes".to_vec();
+        body.extend_from_slice(
+            format!(
+                "\r\n__exception__\r\n{TAG}\r\n{message}\r\n{} {TAG}\r\n__exception__\r\n",
+                message.len()
+            )
+            .as_bytes(),
+        );
+        body
+    }
+
+    #[test]
+    fn exception_frame_is_extracted() {
+        let body = framed("Code: 395. DB::Exception: Value passed to 'throwIf'.");
+        assert_eq!(
+            find_exception_frame(&body, TAG).as_deref(),
+            Some("Code: 395. DB::Exception: Value passed to 'throwIf'.")
+        );
+    }
+
+    #[test]
+    fn multiline_exception_message_is_preserved() {
+        let body = framed("line one\r\nline two");
+        assert_eq!(
+            find_exception_frame(&body, TAG).as_deref(),
+            Some("line one\r\nline two")
+        );
+    }
+
+    #[test]
+    fn body_without_frame_returns_none() {
+        assert_eq!(find_exception_frame(b"plain arrow bytes", TAG), None);
+    }
+
+    #[test]
+    fn frame_with_wrong_tag_returns_none() {
+        let body = framed("boom");
+        assert_eq!(find_exception_frame(&body, "aaaaaaaaaaaaaaaa"), None);
+    }
+
+    #[test]
+    fn truncated_frame_returns_none() {
+        let mut body = framed("boom");
+        body.truncate(body.len() - 10);
+        assert_eq!(find_exception_frame(&body, TAG), None);
+    }
+
+    // --- arrow stream decoding ---
+
+    fn ipc_stream(batches: &[RecordBatch]) -> Vec<u8> {
+        let schema = batches[0].schema();
+        let mut buf = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
+            for b in batches {
+                writer.write(b).unwrap();
+            }
+            writer.finish().unwrap();
+        }
+        buf
+    }
+
+    #[test]
+    fn decode_roundtrips_batches() {
+        let schema = Arc::new(Schema::new(vec![Field::new("n", DataType::Int64, false)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1_i64, 2, 3]))])
+                .unwrap();
+        let decoded = decode_arrow_stream(&ipc_stream(std::slice::from_ref(&batch))).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0], batch);
+    }
+
+    #[test]
+    fn decode_empty_body_is_no_batches() {
+        assert!(decode_arrow_stream(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn decode_garbage_errors() {
+        assert!(decode_arrow_stream(b"definitely not arrow").is_err());
+    }
+
+    // --- describe parsing / identifiers ---
+
+    #[test]
+    fn describe_line_strips_nullable() {
+        let col = parse_describe_line("age\tNullable(UInt8)\t\t\t\t\t").unwrap();
+        assert_eq!(col.name, "age");
+        assert_eq!(col.data_type, "UInt8");
+        assert!(col.nullable);
+    }
+
+    #[test]
+    fn describe_line_non_nullable_passthrough() {
+        let col = parse_describe_line("name\tString\tDEFAULT\t''\t\t\t").unwrap();
+        assert_eq!(col.name, "name");
+        assert_eq!(col.data_type, "String");
+        assert!(!col.nullable);
+    }
+
+    #[test]
+    fn nested_nullable_only_strips_outer_layer() {
+        assert_eq!(
+            strip_nullable("Array(Nullable(String))"),
+            ("Array(Nullable(String))", false)
+        );
+        assert_eq!(
+            strip_nullable("Nullable(Decimal(10, 2))"),
+            ("Decimal(10, 2)", true)
+        );
+    }
+
+    #[test]
+    fn idents_are_backtick_escaped() {
+        assert_eq!(escape_ident("db"), "`db`");
+        assert_eq!(escape_ident("we`ird"), "`we``ird`");
+    }
+}

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod adbc;
 pub mod athena;
+pub mod clickhouse;
 pub mod duckdb;
 pub mod mysql_native;
 pub mod starrocks;

--- a/crates/queryflux-persistence/src/cluster_config.rs
+++ b/crates/queryflux-persistence/src/cluster_config.rs
@@ -173,6 +173,9 @@ impl UpsertClusterConfig {
         if let Some(n) = cfg.pool_size {
             config.insert("poolSize".into(), serde_json::json!(n));
         }
+        if let Some(n) = cfg.max_result_buffer_bytes {
+            config.insert("maxResultBufferBytes".into(), serde_json::json!(n));
+        }
 
         match &cfg.auth {
             Some(ClusterAuth::Basic { username, password }) => {
@@ -448,5 +451,25 @@ mod tests {
         );
         assert_eq!(core_out.default_tags.get("batch"), Some(&None));
         assert_eq!(core_out.default_tags.len(), 2);
+    }
+
+    /// The YAML→Postgres seed runs on every startup with a full-replace of the
+    /// config JSONB — any ClusterConfig field it drops silently vanishes in
+    /// Postgres mode (and wipes a Studio-set value on restart).
+    #[test]
+    fn cluster_from_core_preserves_pool_size_and_result_buffer_cap() {
+        let cfg: ClusterConfig = serde_json::from_value(serde_json::json!({
+            "engine": "clickHouse",
+            "endpoint": "http://ch:8123",
+            "poolSize": 4,
+            "maxResultBufferBytes": 65536,
+        }))
+        .unwrap();
+        let upsert = UpsertClusterConfig::from_core(&cfg).unwrap().unwrap();
+        assert_eq!(upsert.config.get("poolSize"), Some(&serde_json::json!(4)));
+        assert_eq!(
+            upsert.config.get("maxResultBufferBytes"),
+            Some(&serde_json::json!(65536))
+        );
     }
 }

--- a/crates/queryflux/src/registered_engines.rs
+++ b/crates/queryflux/src/registered_engines.rs
@@ -10,6 +10,9 @@ use queryflux_core::error::QueryFluxError;
 use queryflux_core::query::{ClusterGroupName, ClusterName};
 use queryflux_engine_adapters::adbc::AdbcFactory;
 use queryflux_engine_adapters::athena::{AthenaAdapter, AthenaConfig, AthenaFactory};
+use queryflux_engine_adapters::clickhouse::{
+    ClickHouseAdapter, ClickHouseConfig, ClickHouseFactory,
+};
 use queryflux_engine_adapters::duckdb::http::{
     DuckDbHttpAdapter, DuckDbHttpConfig, DuckDbHttpFactory,
 };
@@ -28,6 +31,7 @@ pub fn all_factories() -> Vec<Box<dyn EngineAdapterFactory>> {
         Box::new(DuckDbFactory),
         Box::new(DuckDbHttpFactory),
         Box::new(StarRocksFactory),
+        Box::new(ClickHouseFactory),
         Box::new(AthenaFactory),
         Box::new(AdbcFactory),
     ]
@@ -120,7 +124,12 @@ pub async fn build_adapter(
             ))
         }
         EngineConfig::ClickHouse => {
-            anyhow::bail!("Engine ClickHouse not yet implemented")
+            let config = ClickHouseConfig::from_cluster_config(cluster_cfg, cluster_name_str)
+                .map_err(map_qf_err)?;
+            AdapterKind::Sync(Arc::new(
+                ClickHouseAdapter::new(cluster_name, placeholder_group, config)
+                    .map_err(map_qf_err)?,
+            ))
         }
         EngineConfig::Adbc => {
             anyhow::bail!("ADBC clusters must be created via the admin API, not YAML config")

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,6 +1,6 @@
 # Lean compose file for E2E tests.
 #
-# Engines: Trino, StarRocks.
+# Engines: Trino, StarRocks, ClickHouse.
 # Iceberg stack: Postgres (Lakekeeper backend), MinIO, Lakekeeper.
 #
 # Usage:
@@ -55,6 +55,29 @@ services:
       timeout: 25s
       retries: 60
       start_period: 180s
+    networks:
+      - test_net
+
+  clickhouse:
+    # 26.3 is an LTS release (x.3 / x.8 are LTS; no `lts` tag exists on Docker Hub).
+    image: clickhouse/clickhouse-server:26.3
+    # Default user with empty password reachable from the network — tests only.
+    # Without this the image restricts the default user to localhost.
+    environment:
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+    ports:
+      - "18123:8123" # HTTP interface (adapter endpoint + /ping probe)
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    # /ping returns 200 once the server accepts queries; the image ships wget, not curl.
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8123/ping"]
+      interval: 10s
+      timeout: 25s
+      retries: 30
+      start_period: 60s
     networks:
       - test_net
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -60,13 +60,14 @@ services:
 
   clickhouse:
     # 26.3 is an LTS release (x.3 / x.8 are LTS; no `lts` tag exists on Docker Hub).
-    image: clickhouse/clickhouse-server:26.3
+    image: clickhouse/clickhouse-server:26.3.17.56
     # Default user with empty password reachable from the network — tests only.
     # Without this the image restricts the default user to localhost.
     environment:
       - CLICKHOUSE_SKIP_USER_SETUP=1
     ports:
-      - "18123:8123" # HTTP interface (adapter endpoint + /ping probe)
+      # Loopback-only: the test server has an empty-password default user.
+      - "127.0.0.1:18123:8123" # HTTP interface (adapter endpoint + /ping probe)
     ulimits:
       nofile:
         soft: 262144

--- a/queryflux-studio/app/clusters/clusters-grid.tsx
+++ b/queryflux-studio/app/clusters/clusters-grid.tsx
@@ -919,6 +919,7 @@ const PERSISTED_CONFIG_ROW_ORDER: Array<{ key: string; label: string }> = [
     label: "Cluster SQL dialect (Flight SQL)",
   },
   { key: "poolSize", label: "Pool size" },
+  { key: "maxResultBufferBytes", label: "Max result buffer (bytes)" },
   { key: "region", label: "AWS region" },
   { key: "s3OutputLocation", label: "S3 output location" },
   { key: "workgroup", label: "Workgroup" },

--- a/queryflux-studio/lib/cluster-persist-form.ts
+++ b/queryflux-studio/lib/cluster-persist-form.ts
@@ -35,6 +35,7 @@ export const MANAGED_CONFIG_JSON_KEYS = new Set([
   "role",
   "schema",
   "poolSize",
+  "maxResultBufferBytes",
 ]);
 
 function jsonScalarToString(v: unknown): string {
@@ -134,6 +135,7 @@ export function persistedClusterConfigToFlat(
     config.tlsInsecureSkipVerify === true ? "true" : "false";
 
   flat.poolSize = jsonScalarToString(config.poolSize);
+  flat.maxResultBufferBytes = jsonScalarToString(config.maxResultBufferBytes);
 
   if (descriptor) {
     for (const f of descriptor.configFields) {
@@ -178,6 +180,8 @@ export function flatToPersistedConfig(flat: Record<string, string>): Record<stri
   if (flat.schema?.trim()) cfg.schema = flat.schema.trim();
   const poolN = parsePositiveIntString(flat.poolSize);
   if (poolN !== undefined) cfg.poolSize = poolN;
+  const bufN = parsePositiveIntString(flat.maxResultBufferBytes);
+  if (bufN !== undefined) cfg.maxResultBufferBytes = bufN;
   return cfg;
 }
 
@@ -265,6 +269,15 @@ export function mergeClusterConfigFromFlat(
     } else delete out.poolSize;
   }
 
+  if (flat.maxResultBufferBytes !== undefined) {
+    const t = flat.maxResultBufferBytes.trim();
+    if (t) {
+      const n = parsePositiveIntString(flat.maxResultBufferBytes);
+      if (n !== undefined) out.maxResultBufferBytes = n;
+      else delete out.maxResultBufferBytes;
+    } else delete out.maxResultBufferBytes;
+  }
+
   return out;
 }
 
@@ -312,6 +325,8 @@ export function buildValidateShape(flat: Record<string, string>): Record<string,
   if (flat.schema) o.schema = flat.schema;
   const poolN = parsePositiveIntString(flat.poolSize);
   if (poolN !== undefined) o.poolSize = poolN;
+  const bufN = parsePositiveIntString(flat.maxResultBufferBytes);
+  if (bufN !== undefined) o.maxResultBufferBytes = bufN;
   const auth: Record<string, string> = {};
   if (flat["auth.type"]) auth.type = flat["auth.type"];
   if (flat["auth.username"]) auth.username = flat["auth.username"];

--- a/queryflux-studio/lib/studio-engines/engines/clickhouse.ts
+++ b/queryflux-studio/lib/studio-engines/engines/clickhouse.ts
@@ -11,7 +11,7 @@ export const clickHouseStudioEngine: StudioEngineModule = {
     defaultPort: 8123,
     endpointExample: "http://clickhouse:8123",
     supportedAuth: ["basic"],
-    implemented: false,
+    implemented: true,
     configFields: [
       {
         key: "endpoint",

--- a/queryflux-studio/lib/studio-engines/engines/clickhouse.ts
+++ b/queryflux-studio/lib/studio-engines/engines/clickhouse.ts
@@ -1,4 +1,16 @@
+import type { FlatClusterForm } from "@/lib/cluster-form/types";
 import type { StudioEngineModule } from "@/lib/studio-engines/types";
+
+function validateClickHouseClusterFlat(flat: FlatClusterForm): string[] {
+  const raw = flat.maxResultBufferBytes?.trim();
+  if (raw) {
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 1) {
+      return ["ClickHouse: max result buffer must be a positive integer (bytes)."];
+    }
+  }
+  return [];
+}
 
 export const clickHouseStudioEngine: StudioEngineModule = {
   descriptor: {
@@ -45,6 +57,15 @@ export const clickHouseStudioEngine: StudioEngineModule = {
         required: false,
       },
       {
+        key: "maxResultBufferBytes",
+        label: "Max result buffer (bytes)",
+        description:
+          "Per-query cap on the result bytes QueryFlux buffers in memory. Defaults to 1 GiB when omitted.",
+        fieldType: "number",
+        required: false,
+        example: "1073741824",
+      },
+      {
         key: "tls.insecureSkipVerify",
         label: "Skip TLS verification",
         description:
@@ -60,4 +81,5 @@ export const clickHouseStudioEngine: StudioEngineModule = {
     simpleIconSlug: "siClickhouse",
     catalogDescription: "Real-time OLAP database management system",
   },
+  validateFlat: validateClickHouseClusterFlat,
 };

--- a/website/docs/architecture/adding-support/backend.md
+++ b/website/docs/architecture/adding-support/backend.md
@@ -103,7 +103,7 @@ You normally **do not** edit `queryflux-persistence` for engine-specific JSON ke
 
 ### Unimplemented placeholder
 
-Until the adapter exists, **`EngineConfig::ClickHouse`** (or similar) may **`bail!`** inside **`build_adapter`**. Replace that with a real arm when you implement the adapter.
+Until the adapter exists, your `EngineConfig` variant may **`bail!("Engine <name> not yet implemented")`** inside **`build_adapter`** (ClickHouse used this pattern before its adapter landed). Replace that with a real arm when you implement the adapter.
 
 ---
 

--- a/website/docs/architecture/system-map.md
+++ b/website/docs/architecture/system-map.md
@@ -122,7 +122,7 @@ QueryExecution::Sync { result: QueryPollResult }
 | Trino | Async | Submit → poll `nextUri` until done |
 | DuckDB | Sync | Runs on `spawn_blocking`, result available immediately |
 | StarRocks | Sync | MySQL protocol, single round-trip |
-| ClickHouse | — | Planned |
+| ClickHouse | Sync | HTTP interface, `ArrowStream` response decoded to Arrow record batches |
 
 ### EngineAdapterTrait (`queryflux-engine-adapters`)
 
@@ -192,7 +192,7 @@ pub trait RouterTrait: Send + Sync {
 | DuckDB | **Done** | `Arrow` | Sync embedded — `spawn_blocking` + Arrow result set |
 | StarRocks | **Done** | `MysqlWire` | Sync — `mysql_async` pool; native path (zero Arrow) for MySQL wire clients |
 | Athena | **Done** | `Arrow` | Async AWS SDK — `StartQueryExecution` → poll → `GetQueryResults` |
-| ClickHouse | Planned | `MysqlWire` / `Arrow` / `ClickHouseHttp` | Depends on configured connection type |
+| ClickHouse | **Done** | `Arrow` | Sync — HTTP interface (`default_format=ArrowStream`), Arrow result set |
 
 ### Routers
 
@@ -375,4 +375,5 @@ curl -s -X POST http://localhost:8080/v1/statement \
 | P1 | Athena backend | **Done** |
 | P1 | Authentication / authorization (`queryflux-auth`) | **Done** |
 | P2 | Wire `SchemaContext` from catalog into dispatch | Planned |
-| P3 | ClickHouse HTTP backend + frontend | Planned |
+| P3 | ClickHouse backend (HTTP, Arrow) | **Done** |
+| P3 | ClickHouse HTTP frontend | Planned |


### PR DESCRIPTION
Closes #27

## What

Native ClickHouse backend adapter over the HTTP interface with the Arrow result path, following the StarRocks sync-adapter pattern. ClickHouse clusters can now be defined in YAML (`engine: clickHouse`) or created through the admin API / Studio, routed to like any other group, with SQL dialect translation (Trino -> ClickHouse via sqlglot) applied automatically.

## Implementation

- **Execution**: SQL is POSTed with `default_format=ArrowStream` (never a `FORMAT` suffix, so DDL/INSERT pass through unchanged); the response is Arrow IPC decoded with the workspace `arrow` crate. Eager/buffered like the other sync adapters, with a **configurable result cap** (`maxResultBufferBytes`, default 1 GiB) -- ClickHouse has infinite virtual tables (`system.numbers`), and an unbounded SELECT would otherwise OOM the proxy.
- **Mid-stream failures**: ClickHouse can fail a query *after* sending HTTP 200. The adapter scans the body for the `__exception__` frame announced by `X-ClickHouse-Exception-Tag` before decoding, so a failed query surfaces the real `DB::Exception` message and never yields partial batches. Note for reviewers: the real 26.7 framing uses a bare `\n` separator where the HTTP docs say `\r\n` -- the parser accepts both, and an e2e test locks the real format in (it caught exactly this divergence).
- **Everything else**: Basic auth (matching Studio's pre-staged module), `/ping` health checks, running-query counts from `system.processes` for the reconciler, catalog browsing via `SHOW DATABASES` / `SHOW TABLES` / `DESCRIBE TABLE` with TSV escape decoding, per-request `query_id` (UUID) for traceability, query tags via `log_comment`.
- **Registration**: `ClickHouseFactory` in `all_factories()` (appears in `/admin/engine-registry`, passes startup validation), the YAML `bail!` arm replaced with real construction, and Studio's `implemented` flag flipped -- the rest of Studio was already staged.

## Testing

- 22 in-module unit tests: config parsing (both JSON and YAML paths, auth rejection, cap default/override/reject), exception-frame scanning (real + documented framing, truncated/wrong-tag), Arrow IPC round-trip, TSV unescaping, identifier escaping.
- 13 e2e tests (`clickhouse_tests.rs`) run in CI against a new `clickhouse/clickhouse-server:26.3` (LTS) compose service: literals, `system.numbers`, DDL/INSERT/SELECT round-trip, syntax + mid-stream failures, database-hint semantics (positive/invalid/absent), session propagation to QueryRecords, cross-engine Trino/ClickHouse consistency. All verified green locally against ClickHouse 26.7 before CI, and the full CI pipeline (including the Dockerized e2e job) ran green on a fork dry-run before this PR was opened.
- Manual acceptance: MergeTree schema created through the proxy via translated Trino DDL, JOIN/GROUP BY results verified against hand-computed values (exact DECIMAL sums), 8-way concurrency burst over `maxRunningQueries: 4`, and the result cap verified live (unbounded query -> clean error in ~4s, server healthy).

## Known limitations / follow-ups

- **Engine-native DDL through the Trino frontend fails at translation** (by design: sqlglot parses input as the frontend's dialect, and `UInt32` / `ENGINE = MergeTree` aren't Trino syntax). Trino-dialect DDL translates and works (26.x's default table engine fills the ENGINE gap). Proposed follow-up: a per-request dialect override (e.g. `X-QueryFlux-Dialect` header) so clients can opt into backend-native SQL -- when source == target the existing passthrough translator already handles it.
- `DateTime` columns arrive as epoch-second integers (ClickHouse emits `UInt32` in Arrow; `DateTime64` gets real timestamps -- documented ClickHouse behavior, CAST as workaround).
- `X-ClickHouse-Summary` stats are a header-flush snapshot and undercount in streaming mode, so the adapter reports no engine stats rather than wrong ones.
- The result cap exists only for ClickHouse; StarRocks / DuckDB-HTTP / Athena also buffer unbounded (harder to trigger -- no infinite tables). Promoting the cap to all sync adapters would be a good shared follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ClickHouse as a supported query engine through its HTTP interface with Arrow-based results.
  - Added an optional per-cluster limit for buffered query result size, with Studio configuration and validation support.
  - Enabled ClickHouse end-to-end integration, including readiness checks, health monitoring, and database hints.

- **Tests**
  - Added ClickHouse end-to-end coverage for execution, errors, roundtrips, session and metrics propagation, and cross-engine routing.
  - Expanded test infrastructure and diagnostics to include ClickHouse.

- **Documentation**
  - Updated architecture and backend documentation to reflect ClickHouse support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->