### PR TITLE
fix: allow Snyk and Dependabot PR titles

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,11 +4,11 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|docs|chore|ui)!?(\\(.*\\))?!?:.*"
+    "regexp": "^(feat|fix|docs|chore|ui)!?(\\(.*\\))?!?:.*|^\\[Snyk\\].*|^Bump .+"
   },
   "MESSAGES": {
     "success": "PR title is valid",
     "failure": "PR title is invalid",
-    "notice": "PR title must match Conventional Commits: ^(feat|fix|docs|chore)!?(\\(.*\\))?!?:.*"
+    "notice": "PR title must match Conventional Commits (feat|fix|docs|chore|ui), or be a Snyk/Dependabot title ([Snyk]... / Bump ...)"
   }
 }


### PR DESCRIPTION
## Summary
- Extend the PR title checker regexp so Snyk (`[Snyk] ...`) and Dependabot (`Bump ...`) titles pass without needing Conventional Commits prefixes.
- Unblocks automated dependency PRs such as [#110](https://github.com/lakeops-org/queryflux/pull/110).

## Test plan
- [ ] Confirm [#110](https://github.com/lakeops-org/queryflux/pull/110) **PR title** check is green (config already pushed to that branch)
- [ ] Merge this PR so future Snyk/Dependabot branches inherit the allowlist
- [ ] Human PRs with invalid titles still fail


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request title validation to accept Snyk and “Bump…” title formats alongside Conventional Commits-style titles.
  * Revised validation guidance to clearly describe the supported title patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->