### PR TITLE
feat: cancel in-flight sync queries on client disconnect

### DIFF
--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -400,6 +400,10 @@ impl TestHarness {
         self.records.lock().expect("lock records").clear();
     }
 
+    pub fn snapshot_records(&self) -> Vec<QueryRecord> {
+        self.records.lock().expect("lock records").clone()
+    }
+
     pub async fn wait_for_record<F>(&self, predicate: F) -> Option<QueryRecord>
     where
         F: Fn(&QueryRecord) -> bool,

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -316,7 +316,7 @@ async fn routing_same_sql_trino_and_clickhouse() {
     assert_eq!(trino.rows[0][0], ch.rows[0][0]);
 }
 
-/// Client disconnect must `KILL QUERY` the in-flight ClickHouse query (#111).
+/// Client disconnect must `KILL QUERY` an in-flight ClickHouse query (#111).
 #[tokio::test]
 #[ignore = "requires ClickHouse — run with: make test-e2e"]
 async fn clickhouse_client_disconnect_kills_backend_query() {
@@ -330,7 +330,9 @@ async fn clickhouse_client_disconnect_kills_backend_query() {
             .as_nanos()
     );
     let url = format!("{}/v1/statement", harness().base_url());
-    let sql = format!("SELECT sleep(30) /* {marker} */");
+    // `sleep(N)` is capped at 3s (`function_sleep_max_microseconds_per_block`).
+    // An unbounded `system.numbers` count stays in-flight until KILL QUERY.
+    let sql = format!("SELECT count() FROM system.numbers /* {marker} */");
 
     let http = reqwest::Client::new();
     let inflight = tokio::spawn({
@@ -367,7 +369,7 @@ async fn clickhouse_client_disconnect_kills_backend_query() {
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    assert!(started, "sleep query never appeared in system.processes");
+    assert!(started, "long query never appeared in system.processes");
 
     inflight.abort();
     let _ = inflight.await;
@@ -392,7 +394,7 @@ async fn clickhouse_client_disconnect_kills_backend_query() {
     }
     assert!(
         gone,
-        "sleep query still running after client disconnect — KILL QUERY did not land"
+        "long query still running after client disconnect — KILL QUERY did not land"
     );
 
     let record = harness()
@@ -402,8 +404,19 @@ async fn clickhouse_client_disconnect_kills_backend_query() {
                 && r.status == QueryStatus::Cancelled
         })
         .await;
-    assert!(
-        record.is_some(),
-        "expected QueryRecord with status=Cancelled for the disconnected sleep query"
-    );
+    if record.is_none() {
+        let dump: Vec<String> = harness()
+            .snapshot_records()
+            .into_iter()
+            .map(|r| {
+                format!(
+                    "status={:?} group={} preview={:?} err={:?}",
+                    r.status, r.cluster_group.0, r.sql_preview, r.error_message
+                )
+            })
+            .collect();
+        panic!(
+            "expected QueryRecord with status=Cancelled for the disconnected query; records: {dump:?}"
+        );
+    }
 }

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -321,7 +321,6 @@ async fn routing_same_sql_trino_and_clickhouse() {
 #[ignore = "requires ClickHouse — run with: make test-e2e"]
 async fn clickhouse_client_disconnect_kills_backend_query() {
     require_group!(GROUP_CLICKHOUSE);
-    harness().clear_records();
     let marker = format!(
         "qf-cancel-{}",
         std::time::SystemTime::now()

--- a/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/clickhouse_tests.rs
@@ -4,6 +4,7 @@
 /// or: cargo test -p queryflux-e2e-tests --test clickhouse_tests -- --include-ignored
 use std::sync::OnceLock;
 
+use queryflux_core::query::QueryStatus;
 use queryflux_e2e_tests::{
     harness::{TestHarness, GROUP_CLICKHOUSE, GROUP_TRINO},
     trino_client::TrinoClient,
@@ -313,4 +314,96 @@ async fn routing_same_sql_trino_and_clickhouse() {
     assert_eq!(trino.rows.len(), 1);
     assert_eq!(ch.rows.len(), 1);
     assert_eq!(trino.rows[0][0], ch.rows[0][0]);
+}
+
+/// Client disconnect must `KILL QUERY` the in-flight ClickHouse query (#111).
+#[tokio::test]
+#[ignore = "requires ClickHouse — run with: make test-e2e"]
+async fn clickhouse_client_disconnect_kills_backend_query() {
+    require_group!(GROUP_CLICKHOUSE);
+    harness().clear_records();
+    let marker = format!(
+        "qf-cancel-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos()
+    );
+    let url = format!("{}/v1/statement", harness().base_url());
+    let sql = format!("SELECT sleep(30) /* {marker} */");
+
+    let http = reqwest::Client::new();
+    let inflight = tokio::spawn({
+        let http = http.clone();
+        let url = url.clone();
+        let sql = sql.clone();
+        async move {
+            let _ = http
+                .post(url)
+                .header("X-Trino-User", "test")
+                .header("X-Qf-Group", GROUP_CLICKHOUSE)
+                .body(sql)
+                .send()
+                .await;
+        }
+    });
+
+    // Wait until ClickHouse is actually running the sleep query.
+    let mut started = false;
+    for _ in 0..50 {
+        let r = client()
+            .execute_on(
+                &format!(
+                    "SELECT count() FROM system.processes \
+                     WHERE query LIKE '%/* {marker} */%' AND query NOT LIKE '%system.processes%'"
+                ),
+                GROUP_CLICKHOUSE,
+            )
+            .await
+            .expect("processlist");
+        if r.error.is_none() && r.rows.first().and_then(|row| row.first()) == Some(&json!(1)) {
+            started = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(started, "sleep query never appeared in system.processes");
+
+    inflight.abort();
+    let _ = inflight.await;
+
+    let mut gone = false;
+    for _ in 0..50 {
+        let r = client()
+            .execute_on(
+                &format!(
+                    "SELECT count() FROM system.processes \
+                     WHERE query LIKE '%/* {marker} */%' AND query NOT LIKE '%system.processes%'"
+                ),
+                GROUP_CLICKHOUSE,
+            )
+            .await
+            .expect("processlist");
+        if r.error.is_none() && r.rows.first().and_then(|row| row.first()) == Some(&json!(0)) {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(
+        gone,
+        "sleep query still running after client disconnect — KILL QUERY did not land"
+    );
+
+    let record = harness()
+        .wait_for_record(|r| {
+            r.cluster_group.0 == GROUP_CLICKHOUSE
+                && r.sql_preview.contains(&marker)
+                && r.status == QueryStatus::Cancelled
+        })
+        .await;
+    assert!(
+        record.is_some(),
+        "expected QueryRecord with status=Cancelled for the disconnected sleep query"
+    );
 }

--- a/crates/queryflux-e2e-tests/tests/trino_adbc_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/trino_adbc_tests.rs
@@ -70,7 +70,14 @@ async fn count_arrow_rows(adapter: &AdbcAdapter, sql: &str) -> usize {
     let creds = QueryCredentials::ServiceAccount;
     let tags = QueryTags::new();
     let mut exec = adapter
-        .execute_as_arrow(sql, &session, &creds, &tags, &vec![])
+        .execute_as_arrow(
+            sql,
+            &session,
+            &creds,
+            &tags,
+            &vec![],
+            &queryflux_engine_adapters::BackendQueryIdSlot::new(),
+        )
         .await
         .expect("execute_as_arrow");
     let mut total = 0usize;

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -18,7 +18,7 @@ use r2d2_adbc::AdbcConnectionManager;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::{AdapterKind, EngineAdapterFactory, SyncAdapter, SyncExecution};
+use crate::{AdapterKind, BackendQueryIdSlot, EngineAdapterFactory, SyncAdapter, SyncExecution};
 use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
@@ -491,7 +491,13 @@ impl SyncAdapter for AdbcAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
+        // ADBC `Statement::cancel` requires the live statement (`&mut self`)
+        // on the blocking thread; there is no cross-thread cancel handle.
+        // Publish a synthetic id for tracing. `cancel_query` stays the default
+        // no-op. Dropping the result stream stops *reading* batches.
+        id_slot.publish(uuid::Uuid::new_v4().to_string());
         let pool = self.pool.clone();
         let sql = sql.to_string();
         let param_batch = if params.is_empty() {

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -491,13 +491,18 @@ impl SyncAdapter for AdbcAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
-        id_slot: &BackendQueryIdSlot,
+        _id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
         // ADBC `Statement::cancel` requires the live statement (`&mut self`)
         // on the blocking thread; there is no cross-thread cancel handle.
-        // Publish a synthetic id for tracing. `cancel_query` stays the default
-        // no-op. Dropping the result stream stops *reading* batches.
-        id_slot.publish(uuid::Uuid::new_v4().to_string());
+        // Leave the slot unset so dispatch does not record a fake backend id.
+        // `cancel_query` stays the default no-op. Dropping the result stream
+        // stops *reading* batches.
+        tracing::debug!(
+            cluster = %self.cluster_name,
+            attempt_id = %uuid::Uuid::new_v4(),
+            "Executing ADBC query"
+        );
         let pool = self.pool.clone();
         let sql = sql.to_string();
         let param_batch = if params.is_empty() {

--- a/crates/queryflux-engine-adapters/src/athena/mod.rs
+++ b/crates/queryflux-engine-adapters/src/athena/mod.rs
@@ -22,7 +22,7 @@ use queryflux_core::{
 };
 use tracing::warn;
 
-use crate::{AdapterKind, AsyncAdapter};
+use crate::{AdapterKind, AsyncAdapter, BackendQueryIdSlot};
 
 /// Parsed and validated configuration for an Athena cluster.
 pub struct AthenaConfig {
@@ -393,6 +393,7 @@ impl AsyncAdapter for AthenaAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &queryflux_core::tags::QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> crate::Result<crate::SyncExecution> {
         use crate::SyncExecution;
         use futures::stream;
@@ -429,6 +430,7 @@ impl AsyncAdapter for AthenaAdapter {
             .query_execution_id()
             .ok_or_else(|| QueryFluxError::Engine("Athena returned no execution ID".to_string()))?
             .to_string();
+        id_slot.publish(execution_id.clone());
 
         self.wait_for_completion(&execution_id).await?;
 

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -32,11 +32,11 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 use queryflux_core::error::{QueryFluxError, Result};
-use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType};
+use queryflux_core::query::{BackendQueryId, ClusterGroupName, ClusterName, EngineType};
 use queryflux_core::session::SessionContext;
 use queryflux_core::tags::QueryTags;
 
-use crate::{AdapterKind, SyncExecution};
+use crate::{AdapterKind, BackendQueryIdSlot, SyncExecution};
 
 /// Timeout for control-plane requests (health checks, catalog listing).
 /// Query execution has no overall timeout — analytics queries can be long.
@@ -256,18 +256,22 @@ impl ClickHouseAdapter {
 
     /// Build a query request: SQL as the POST body, everything else as URL params.
     ///
-    /// `query_id` is always set (one UUID per request) so queries are traceable
-    /// in `system.query_log`. Cancellation is NOT wired up: the sync adapter
-    /// path has no cancel hook, so a client disconnect does not `KILL QUERY`
-    /// on the ClickHouse side (tracked in #111).
+    /// `query_id` is always set so queries are traceable in `system.query_log`
+    /// and so [`SyncAdapter::cancel_query`] can issue `KILL QUERY WHERE query_id = …`.
     fn query_request(&self, sql: &str, format: &str) -> reqwest::RequestBuilder {
+        self.query_request_with_id(sql, format, &uuid::Uuid::new_v4().to_string())
+    }
+
+    fn query_request_with_id(
+        &self,
+        sql: &str,
+        format: &str,
+        query_id: &str,
+    ) -> reqwest::RequestBuilder {
         let mut req = self
             .client
             .post(format!("{}/", self.endpoint))
-            .query(&[
-                ("default_format", format),
-                ("query_id", &uuid::Uuid::new_v4().to_string()),
-            ])
+            .query(&[("default_format", format), ("query_id", query_id)])
             .body(sql.to_string());
         if let Some((user, pass)) = &self.basic_auth {
             req = req.basic_auth(user, Some(pass));
@@ -504,6 +508,21 @@ fn escape_ident(ident: &str) -> String {
     format!("`{}`", ident.replace('\\', "\\\\").replace('`', "``"))
 }
 
+/// True when `id` is safe to interpolate into `KILL QUERY WHERE query_id = '…'`.
+/// QueryFlux mints UUIDs; this also rejects anything a confused caller might pass.
+fn is_safe_query_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// `KILL QUERY WHERE query_id = '<id>'`, or `None` if `id` is not safe.
+fn kill_query_sql(id: &str) -> Option<String> {
+    is_safe_query_id(id).then(|| format!("KILL QUERY WHERE query_id = '{id}'"))
+}
+
 /// True when an error carries ClickHouse's UNKNOWN_TABLE (60) or
 /// UNKNOWN_DATABASE (81) exception code — the codes `clickhouse_http_error`
 /// embeds in the message it formats.
@@ -523,8 +542,11 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         // Dispatch interpolates params into the SQL before calling — this
         // adapter reports `supports_native_params() == false` (the default).
         _params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
-        let mut req = self.query_request(sql, "ArrowStream");
+        let query_id = uuid::Uuid::new_v4().to_string();
+        id_slot.publish(query_id.clone());
+        let mut req = self.query_request_with_id(sql, "ArrowStream", &query_id);
         if let Some(db) = session.database() {
             req = req.query(&[("database", db)]);
         }
@@ -585,6 +607,36 @@ impl crate::SyncAdapter for ClickHouseAdapter {
 
     fn engine_type(&self) -> EngineType {
         EngineType::ClickHouse
+    }
+
+    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        let Some(sql) = kill_query_sql(&backend_id.0) else {
+            tracing::debug!(
+                cluster = %self.cluster_name,
+                query_id = %backend_id,
+                "ClickHouse cancel skipped: query_id is not a safe identifier"
+            );
+            return Ok(());
+        };
+        match self.run_query_lines(&sql).await {
+            Ok(_) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    "ClickHouse KILL QUERY issued"
+                );
+            }
+            Err(e) => {
+                // Best-effort: the query may already have finished.
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "ClickHouse KILL QUERY failed (ignored)"
+                );
+            }
+        }
+        Ok(())
     }
 
     async fn health_check(&self) -> bool {
@@ -1029,5 +1081,21 @@ mod tests {
         let decoded = tsv_unescape(listed);
         assert_eq!(decoded, r"back\slash");
         assert_eq!(escape_ident(&decoded), r"`back\\slash`");
+    }
+
+    #[test]
+    fn kill_query_sql_accepts_uuids() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(
+            kill_query_sql(id).as_deref(),
+            Some("KILL QUERY WHERE query_id = '550e8400-e29b-41d4-a716-446655440000'")
+        );
+    }
+
+    #[test]
+    fn kill_query_sql_rejects_quotes_and_empty() {
+        assert!(kill_query_sql("").is_none());
+        assert!(kill_query_sql("abc'; DROP TABLE t; --").is_none());
+        assert!(kill_query_sql("has space").is_none());
     }
 }

--- a/crates/queryflux-engine-adapters/src/duckdb/http.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/http.rs
@@ -19,7 +19,7 @@ use queryflux_core::{
 use reqwest::Client;
 use tracing::debug;
 
-use crate::{AdapterKind, SyncAdapter, SyncExecution};
+use crate::{AdapterKind, BackendQueryIdSlot, SyncAdapter, SyncExecution};
 use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
@@ -243,8 +243,13 @@ impl SyncAdapter for DuckDbHttpAdapter {
         _credentials: &QueryCredentials,
         _tags: &QueryTags,
         _params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
         debug!(cluster = %self.cluster_name, "Executing DuckDB HTTP query");
+        // Community httpserver has no cancel API. Publish a synthetic id so
+        // dispatch can still trace the attempt; `cancel_query` is a no-op.
+        // Dropping this future aborts the HTTP request (best-effort).
+        id_slot.publish(uuid::Uuid::new_v4().to_string());
         let response = self.run_query(sql).await?;
         let batch = response_to_record_batch(response)?;
         let (tx, rx) = tokio::sync::oneshot::channel();

--- a/crates/queryflux-engine-adapters/src/duckdb/http.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/http.rs
@@ -243,13 +243,16 @@ impl SyncAdapter for DuckDbHttpAdapter {
         _credentials: &QueryCredentials,
         _tags: &QueryTags,
         _params: &queryflux_core::params::QueryParams,
-        id_slot: &BackendQueryIdSlot,
+        _id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
-        debug!(cluster = %self.cluster_name, "Executing DuckDB HTTP query");
-        // Community httpserver has no cancel API. Publish a synthetic id so
-        // dispatch can still trace the attempt; `cancel_query` is a no-op.
+        // Community httpserver has no cancel API — leave the slot unset so
+        // dispatch does not record a fake backend id or spawn a no-op cancel.
         // Dropping this future aborts the HTTP request (best-effort).
-        id_slot.publish(uuid::Uuid::new_v4().to_string());
+        debug!(
+            cluster = %self.cluster_name,
+            attempt_id = %uuid::Uuid::new_v4(),
+            "Executing DuckDB HTTP query"
+        );
         let response = self.run_query(sql).await?;
         let batch = response_to_record_batch(response)?;
         let (tx, rx) = tokio::sync::oneshot::channel();

--- a/crates/queryflux-engine-adapters/src/duckdb/mod.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/mod.rs
@@ -10,13 +10,13 @@ use queryflux_core::{
     config::{ClusterAuth, ClusterConfig},
     error::{QueryFluxError, Result},
     params::{QueryParam, QueryParams},
-    query::{ClusterGroupName, ClusterName, EngineType},
+    query::{BackendQueryId, ClusterGroupName, ClusterName, EngineType},
     session::SessionContext,
     tags::QueryTags,
 };
 use tracing::debug;
 
-use crate::{AdapterKind, SyncAdapter, SyncExecution};
+use crate::{AdapterKind, BackendQueryIdSlot, SyncAdapter, SyncExecution};
 use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
@@ -78,6 +78,11 @@ pub struct DuckDbAdapter {
     /// Thread-safe DuckDB connection. Wrapped in Arc<Mutex> so it can be shared
     /// across `spawn_blocking` calls without moving out of `&self`.
     conn: Arc<Mutex<Connection>>,
+    /// Interrupt handle — `interrupt()` is safe from another thread while a
+    /// query holds the connection mutex.
+    interrupt: Arc<duckdb::InterruptHandle>,
+    /// Backend id of the query currently running on `conn`, if any.
+    inflight: Mutex<Option<BackendQueryId>>,
 }
 
 impl DuckDbAdapter {
@@ -93,10 +98,13 @@ impl DuckDbAdapter {
         }
         .map_err(|e| QueryFluxError::Engine(format!("DuckDB open failed: {e}")))?;
 
+        let interrupt = conn.interrupt_handle();
         Ok(Self {
             cluster_name,
             group_name,
             conn: Arc::new(Mutex::new(conn)),
+            interrupt,
+            inflight: Mutex::new(None),
         })
     }
 }
@@ -146,6 +154,20 @@ impl SyncAdapter for DuckDbAdapter {
         true
     }
 
+    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        let matches = self
+            .inflight
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            == Some(backend_id);
+        if matches {
+            self.interrupt.interrupt();
+            debug!(cluster = %self.cluster_name, query_id = %backend_id, "DuckDB interrupt issued");
+        }
+        Ok(())
+    }
+
     async fn execute_as_arrow(
         &self,
         sql: &str,
@@ -153,8 +175,16 @@ impl SyncAdapter for DuckDbAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &QueryTags,
         params: &QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
         debug!(cluster = %self.cluster_name, "Executing DuckDB query as Arrow");
+        let query_id = BackendQueryId(uuid::Uuid::new_v4().to_string());
+        id_slot.publish(query_id.0.clone());
+        {
+            let mut inflight = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+            *inflight = Some(query_id.clone());
+        }
+
         let conn = Arc::clone(&self.conn);
         let sql = sql.to_string();
         let duckdb_params: Vec<duckdb::types::Value> =
@@ -171,7 +201,18 @@ impl SyncAdapter for DuckDbAdapter {
             Ok::<_, QueryFluxError>(arrow.collect::<Vec<_>>())
         })
         .await
-        .map_err(|e| QueryFluxError::Engine(format!("spawn_blocking failed: {e}")))??;
+        .map_err(|e| QueryFluxError::Engine(format!("spawn_blocking failed: {e}")));
+
+        // Clear only after the blocking work returns. If this future is dropped
+        // mid-query, `inflight` stays set so `cancel_query` can still interrupt.
+        {
+            let mut inflight = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
+            if inflight.as_ref() == Some(&query_id) {
+                *inflight = None;
+            }
+        }
+
+        let batches = batches??;
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         // DuckDB does not expose structured engine stats (CPU time, bytes scanned, etc.)
@@ -529,5 +570,55 @@ mod tests {
     #[test]
     fn null_maps_to_null() {
         assert_eq!(query_param_to_duckdb(&QueryParam::Null), Value::Null);
+    }
+
+    #[tokio::test]
+    async fn interrupt_stops_a_long_query() {
+        use queryflux_auth::QueryCredentials;
+        use queryflux_core::query::{ClusterGroupName, ClusterName};
+
+        let adapter = DuckDbAdapter::new(
+            ClusterName("duck".into()),
+            ClusterGroupName("g".into()),
+            DuckDbConfig {
+                database_path: None,
+                motherduck_token: None,
+            },
+        )
+        .expect("open in-memory duckdb");
+
+        let slot = BackendQueryIdSlot::new();
+        let session = SessionContext::default();
+        let creds = QueryCredentials::ServiceAccount;
+        let tags = QueryTags::new();
+        let params: QueryParams = vec![];
+
+        let exec = adapter.execute_as_arrow(
+            "SELECT count(*) FROM range(1000000000)",
+            &session,
+            &creds,
+            &tags,
+            &params,
+            &slot,
+        );
+        let cancel = async {
+            // Wait until the adapter has published an id and the blocking
+            // query has had a chance to start, then interrupt.
+            for _ in 0..200 {
+                if slot.get().is_some() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let id = slot.get().expect("backend id published");
+            adapter.cancel_query(&id).await.expect("cancel");
+        };
+
+        let (result, _) = tokio::join!(exec, cancel);
+        assert!(
+            result.is_err(),
+            "interrupted range() query should fail, got Ok(SyncExecution)"
+        );
     }
 }

--- a/crates/queryflux-engine-adapters/src/duckdb/mod.rs
+++ b/crates/queryflux-engine-adapters/src/duckdb/mod.rs
@@ -81,8 +81,9 @@ pub struct DuckDbAdapter {
     /// Interrupt handle — `interrupt()` is safe from another thread while a
     /// query holds the connection mutex.
     interrupt: Arc<duckdb::InterruptHandle>,
-    /// Backend id of the query currently running on `conn`, if any.
-    inflight: Mutex<Option<BackendQueryId>>,
+    /// Backend id of the query that currently owns `conn`, if any.
+    /// Written only while holding the connection mutex.
+    inflight: Arc<Mutex<Option<BackendQueryId>>>,
 }
 
 impl DuckDbAdapter {
@@ -104,7 +105,7 @@ impl DuckDbAdapter {
             group_name,
             conn: Arc::new(Mutex::new(conn)),
             interrupt,
-            inflight: Mutex::new(None),
+            inflight: Arc::new(Mutex::new(None)),
         })
     }
 }
@@ -180,39 +181,40 @@ impl SyncAdapter for DuckDbAdapter {
         debug!(cluster = %self.cluster_name, "Executing DuckDB query as Arrow");
         let query_id = BackendQueryId(uuid::Uuid::new_v4().to_string());
         id_slot.publish(query_id.0.clone());
-        {
-            let mut inflight = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
-            *inflight = Some(query_id.clone());
-        }
 
         let conn = Arc::clone(&self.conn);
+        let inflight = Arc::clone(&self.inflight);
+        let id_for_task = query_id.clone();
         let sql = sql.to_string();
         let duckdb_params: Vec<duckdb::types::Value> =
             params.iter().map(query_param_to_duckdb).collect();
 
         let batches = tokio::task::spawn_blocking(move || {
             let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
-            let mut stmt = guard
-                .prepare(&sql)
-                .map_err(|e| QueryFluxError::Engine(format!("DuckDB prepare failed: {e}")))?;
-            let arrow = stmt
-                .query_arrow(duckdb::params_from_iter(duckdb_params))
-                .map_err(|e| QueryFluxError::Engine(format!("DuckDB query failed: {e}")))?;
-            Ok::<_, QueryFluxError>(arrow.collect::<Vec<_>>())
+            // Claim ownership only once this task holds the connection, so
+            // `interrupt()` targets the statement actually running on `conn`.
+            *inflight.lock().unwrap_or_else(|e| e.into_inner()) = Some(id_for_task.clone());
+            let result = (|| {
+                let mut stmt = guard
+                    .prepare(&sql)
+                    .map_err(|e| QueryFluxError::Engine(format!("DuckDB prepare failed: {e}")))?;
+                let arrow = stmt
+                    .query_arrow(duckdb::params_from_iter(duckdb_params))
+                    .map_err(|e| QueryFluxError::Engine(format!("DuckDB query failed: {e}")))?;
+                Ok::<_, QueryFluxError>(arrow.collect::<Vec<_>>())
+            })();
+            {
+                let mut slot = inflight.lock().unwrap_or_else(|e| e.into_inner());
+                if slot.as_ref() == Some(&id_for_task) {
+                    *slot = None;
+                }
+            }
+            result
         })
         .await
-        .map_err(|e| QueryFluxError::Engine(format!("spawn_blocking failed: {e}")));
+        .map_err(|e| QueryFluxError::Engine(format!("spawn_blocking failed: {e}")))?;
 
-        // Clear only after the blocking work returns. If this future is dropped
-        // mid-query, `inflight` stays set so `cancel_query` can still interrupt.
-        {
-            let mut inflight = self.inflight.lock().unwrap_or_else(|e| e.into_inner());
-            if inflight.as_ref() == Some(&query_id) {
-                *inflight = None;
-            }
-        }
-
-        let batches = batches??;
+        let batches = batches?;
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         // DuckDB does not expose structured engine stats (CPU time, bytes scanned, etc.)
@@ -619,6 +621,92 @@ mod tests {
         assert!(
             result.is_err(),
             "interrupted range() query should fail, got Ok(SyncExecution)"
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupt_targets_the_running_query() {
+        use queryflux_auth::QueryCredentials;
+        use queryflux_core::query::{ClusterGroupName, ClusterName};
+
+        let adapter = std::sync::Arc::new(
+            DuckDbAdapter::new(
+                ClusterName("duck".into()),
+                ClusterGroupName("g".into()),
+                DuckDbConfig {
+                    database_path: None,
+                    motherduck_token: None,
+                },
+            )
+            .expect("open in-memory duckdb"),
+        );
+
+        let session = SessionContext::default();
+        let creds = QueryCredentials::ServiceAccount;
+        let tags = QueryTags::new();
+        let params: QueryParams = vec![];
+
+        let slot_a = BackendQueryIdSlot::new();
+        let slot_b = BackendQueryIdSlot::new();
+
+        let exec_a = {
+            let adapter = Arc::clone(&adapter);
+            let session = session.clone();
+            let creds = creds.clone();
+            let tags = tags.clone();
+            let params = params.clone();
+            let slot_a = slot_a.clone();
+            async move {
+                adapter
+                    .execute_as_arrow(
+                        "SELECT count(*) FROM range(1000000000)",
+                        &session,
+                        &creds,
+                        &tags,
+                        &params,
+                        &slot_a,
+                    )
+                    .await
+            }
+        };
+        let exec_b = {
+            let adapter = Arc::clone(&adapter);
+            let session = session.clone();
+            let creds = creds.clone();
+            let tags = tags.clone();
+            let params = params.clone();
+            let slot_b = slot_b.clone();
+            async move {
+                // Let A acquire the connection first.
+                tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+                adapter
+                    .execute_as_arrow("SELECT 1", &session, &creds, &tags, &params, &slot_b)
+                    .await
+            }
+        };
+        let cancel_a = {
+            let adapter = Arc::clone(&adapter);
+            async move {
+                for _ in 0..200 {
+                    if slot_a.get().is_some() {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let id = slot_a.get().expect("backend id published");
+                adapter.cancel_query(&id).await.expect("cancel");
+            }
+        };
+
+        let (result_a, result_b, _) = tokio::join!(exec_a, exec_b, cancel_a);
+        assert!(
+            result_a.is_err(),
+            "canceled first query should fail, got Ok(SyncExecution)"
+        );
+        assert!(
+            result_b.is_ok(),
+            "second query should complete after the first is interrupted"
         );
     }
 }

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -54,13 +54,12 @@ impl BackendQueryIdSlot {
     /// Record the engine-side id. Safe to call from the execute task; dispatch
     /// reads it from a `Drop` guard on another task.
     pub fn publish(&self, id: impl Into<String>) {
-        if let Ok(mut guard) = self.inner.lock() {
-            *guard = Some(BackendQueryId(id.into()));
-        }
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(BackendQueryId(id.into()));
     }
 
     pub fn get(&self) -> Option<BackendQueryId> {
-        self.inner.lock().ok().and_then(|guard| guard.clone())
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 }
 

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -17,7 +17,7 @@ use queryflux_core::{
     engine_registry::EngineDescriptor,
     error::Result,
     native_result::NativeResultChunk,
-    query::{ClusterGroupName, ClusterName, FrontendProtocol},
+    query::{BackendQueryId, ClusterGroupName, ClusterName, FrontendProtocol},
 };
 
 /// Implemented by each engine's typed config struct.
@@ -34,6 +34,35 @@ pub trait EngineConfigParseable: Sized {
 
 /// A stream of Arrow RecordBatches — the universal output type for all adapters.
 pub type ArrowStream = Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>;
+
+/// Slot an adapter fills with the engine-side query id as soon as it is known
+/// — typically *before* the blocking wait — so dispatch can `cancel_query` if
+/// the client disconnects mid-flight.
+///
+/// Cheap to clone (shared mutex). Publish is last-write-wins; `get` returns
+/// the most recently published id, or `None` if the adapter never assigned one.
+#[derive(Clone, Default)]
+pub struct BackendQueryIdSlot {
+    inner: std::sync::Arc<std::sync::Mutex<Option<BackendQueryId>>>,
+}
+
+impl BackendQueryIdSlot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the engine-side id. Safe to call from the execute task; dispatch
+    /// reads it from a `Drop` guard on another task.
+    pub fn publish(&self, id: impl Into<String>) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard = Some(BackendQueryId(id.into()));
+        }
+    }
+
+    pub fn get(&self) -> Option<BackendQueryId> {
+        self.inner.lock().ok().and_then(|guard| guard.clone())
+    }
+}
 
 /// Returned by `SyncAdapter::execute_as_arrow`.
 ///
@@ -162,6 +191,32 @@ mod connection_format_tests {
     }
 }
 
+#[cfg(test)]
+mod backend_query_id_slot_tests {
+    use super::BackendQueryIdSlot;
+
+    #[test]
+    fn empty_slot_returns_none() {
+        assert!(BackendQueryIdSlot::new().get().is_none());
+    }
+
+    #[test]
+    fn publish_is_visible_on_clones() {
+        let slot = BackendQueryIdSlot::new();
+        let clone = slot.clone();
+        slot.publish("ch-query-1");
+        assert_eq!(clone.get().unwrap().0, "ch-query-1");
+    }
+
+    #[test]
+    fn last_publish_wins() {
+        let slot = BackendQueryIdSlot::new();
+        slot.publish("first");
+        slot.publish("second");
+        assert_eq!(slot.get().unwrap().0, "second");
+    }
+}
+
 /// Returned by `SyncAdapter::execute_native` — a stream of protocol-agnostic row chunks.
 pub struct NativeExecution {
     pub stream: Pin<Box<dyn Stream<Item = Result<NativeResultChunk>> + Send>>,
@@ -169,9 +224,10 @@ pub struct NativeExecution {
 }
 
 /// Sync engines: execute to completion, stream Arrow results.
-/// Used by DuckDB (embedded + HTTP) and StarRocks.
+/// Used by DuckDB (embedded + HTTP), StarRocks, ClickHouse, and ADBC.
 #[async_trait]
 pub trait SyncAdapter: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
     async fn execute_as_arrow(
         &self,
         sql: &str,
@@ -179,6 +235,7 @@ pub trait SyncAdapter: Send + Sync {
         credentials: &queryflux_auth::QueryCredentials,
         tags: &queryflux_core::tags::QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution>;
     fn engine_type(&self) -> queryflux_core::query::EngineType;
     /// Target dialect for SQL translation (may differ from `engine_type().dialect()`, e.g. Flight SQL + arbitrary sqlglot backend).
@@ -204,6 +261,7 @@ pub trait SyncAdapter: Send + Sync {
 
     /// Only called by dispatch when `connection_format().matches_frontend(protocol)` is true.
     /// Default returns `Err` — adapters that override `connection_format` must also override this.
+    #[allow(clippy::too_many_arguments)]
     async fn execute_native(
         &self,
         _protocol: &FrontendProtocol,
@@ -212,10 +270,21 @@ pub trait SyncAdapter: Send + Sync {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &queryflux_core::tags::QueryTags,
         _params: &queryflux_core::params::QueryParams,
+        _id_slot: &BackendQueryIdSlot,
     ) -> Result<NativeExecution> {
         Err(queryflux_core::error::QueryFluxError::Engine(
             "execute_native not implemented for this adapter".to_string(),
         ))
+    }
+
+    /// Best-effort: stop an in-flight engine query identified by `backend_id`.
+    ///
+    /// Dispatch calls this when the client disconnects or the request is
+    /// cancelled. The default is a no-op — override when the engine has a kill
+    /// API (ClickHouse `KILL QUERY`, StarRocks `KILL QUERY`, DuckDB interrupt).
+    /// "Query already finished" must be treated as success.
+    async fn cancel_query(&self, _backend_id: &BackendQueryId) -> Result<()> {
+        Ok(())
     }
 
     async fn health_check(&self) -> bool;
@@ -262,6 +331,7 @@ pub trait AsyncAdapter: Send + Sync {
     ///
     /// Enables MySQL/Postgres wire protocol clients to query async engines.
     /// Returns `Err(SyncEngineRequired)` by default — engines that support this path override it.
+    #[allow(clippy::too_many_arguments)]
     async fn execute_as_arrow(
         &self,
         _sql: &str,
@@ -269,6 +339,7 @@ pub trait AsyncAdapter: Send + Sync {
         _credentials: &queryflux_auth::QueryCredentials,
         _tags: &queryflux_core::tags::QueryTags,
         _params: &queryflux_core::params::QueryParams,
+        _id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
         Err(queryflux_core::error::QueryFluxError::SyncEngineRequired(
             "this engine only supports the async (HTTP submit-poll) protocol".to_string(),
@@ -350,6 +421,13 @@ impl AdapterKind {
         match self {
             Self::Async(a) => Some(a.clone()),
             Self::Sync(_) => None,
+        }
+    }
+
+    pub async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        match self {
+            Self::Sync(a) => a.cancel_query(backend_id).await,
+            Self::Async(a) => a.cancel_query(backend_id).await,
         }
     }
 }

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -10,6 +10,9 @@
 //! column metadata directly from the mysql_async driver and encodes values from their
 //! native `mysql_async::Value` representation, preserving full precision.
 
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
 use bytes::Bytes;
 use futures::stream;
 use mysql_async::{consts::ColumnType, prelude::Queryable, Pool, Row, Value};
@@ -27,6 +30,73 @@ use crate::{BackendQueryIdSlot, NativeExecution};
 /// Number of rows per `NativeResultChunk`. Balances channel overhead vs. memory.
 const BATCH_SIZE: usize = 1_000;
 
+/// Pooled MySQL connection ids that currently own an in-flight query.
+///
+/// `KILL QUERY <connection_id>` is only safe while this set contains the id.
+/// Completing an execute (success or engine error) removes the id before the
+/// connection returns to the pool. Dropping the execute future leaves the id
+/// registered so a later cancel can still kill the server-side query.
+#[derive(Clone, Default)]
+pub struct InflightConnIds {
+    inner: Arc<Mutex<HashSet<u32>>>,
+}
+
+/// Claim released by [`InflightConnGuard::finish`] when the query completes.
+pub struct InflightConnGuard {
+    ids: InflightConnIds,
+    id: u32,
+    finished: bool,
+}
+
+impl InflightConnIds {
+    pub fn claim(&self, id: u32) -> InflightConnGuard {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id);
+        InflightConnGuard {
+            ids: self.clone(),
+            id,
+            finished: false,
+        }
+    }
+
+    pub fn contains_published(&self, backend_id: &str) -> bool {
+        backend_id.trim().parse::<u32>().ok().is_some_and(|id| {
+            self.inner
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(&id)
+        })
+    }
+
+    pub fn release_published(&self, backend_id: &str) {
+        if let Ok(id) = backend_id.trim().parse::<u32>() {
+            self.inner
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .remove(&id);
+        }
+    }
+
+    fn release(&self, id: u32) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
+    }
+}
+
+impl InflightConnGuard {
+    /// Query finished; the connection may return to the pool.
+    pub fn finish(&mut self) {
+        if !self.finished {
+            self.ids.release(self.id);
+            self.finished = true;
+        }
+    }
+}
+
 /// Execute `sql` against `pool` and return a stream of `NativeResultChunk`s.
 ///
 /// The connection is acquired, session is set up (USE database, @query_tag), the query
@@ -38,6 +108,7 @@ const BATCH_SIZE: usize = 1_000;
 /// behaviour as the current Arrow path. The in-memory constraint is removed in a follow-up
 /// by switching to `query_iter` + a spawned task, which requires working around
 /// `mysql_async::QueryResult`'s borrow-based lifetime constraints.
+#[allow(clippy::too_many_arguments)]
 pub async fn execute(
     pool: &Pool,
     sql: &str,
@@ -46,13 +117,28 @@ pub async fn execute(
     tags: &QueryTags,
     params: &QueryParams,
     id_slot: &BackendQueryIdSlot,
+    inflight: &InflightConnIds,
 ) -> Result<NativeExecution> {
     let mut conn = pool
         .get_conn()
         .await
         .map_err(|e| QueryFluxError::Engine(format!("mysql_native: connection failed: {e}")))?;
-    id_slot.publish(conn.id().to_string());
+    let conn_id = conn.id();
+    id_slot.publish(conn_id.to_string());
+    let mut claim = inflight.claim(conn_id);
 
+    let result = execute_on_conn(&mut conn, sql, session, tags, params).await;
+    claim.finish();
+    result
+}
+
+async fn execute_on_conn(
+    conn: &mut mysql_async::Conn,
+    sql: &str,
+    session: &SessionContext,
+    tags: &QueryTags,
+    params: &QueryParams,
+) -> Result<NativeExecution> {
     if let Some(db) = session.database() {
         let use_sql = format!("USE `{}`", db.replace('`', "``"));
         conn.query_drop(&use_sql)

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -22,7 +22,7 @@ use queryflux_core::{
     tags::{tags_to_json, QueryTags},
 };
 
-use crate::NativeExecution;
+use crate::{BackendQueryIdSlot, NativeExecution};
 
 /// Number of rows per `NativeResultChunk`. Balances channel overhead vs. memory.
 const BATCH_SIZE: usize = 1_000;
@@ -45,11 +45,13 @@ pub async fn execute(
     _credentials: &QueryCredentials,
     tags: &QueryTags,
     params: &QueryParams,
+    id_slot: &BackendQueryIdSlot,
 ) -> Result<NativeExecution> {
     let mut conn = pool
         .get_conn()
         .await
         .map_err(|e| QueryFluxError::Engine(format!("mysql_native: connection failed: {e}")))?;
+    id_slot.publish(conn.id().to_string());
 
     if let Some(db) = session.database() {
         let use_sql = format!("USE `{}`", db.replace('`', "``"));

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -134,6 +134,9 @@ pub struct StarRocksAdapter {
     pool: Pool,
     /// Dedicated 1×1 pool for `health_check` so probes do not compete with query traffic.
     control_pool: Pool,
+    /// Connection ids that currently own an in-flight query. `cancel_query`
+    /// skips `KILL QUERY` once the id is released (connection back in the pool).
+    inflight: crate::mysql_native::InflightConnIds,
 }
 
 impl StarRocksAdapter {
@@ -187,6 +190,7 @@ impl StarRocksAdapter {
             group_name,
             pool,
             control_pool,
+            inflight: crate::mysql_native::InflightConnIds::default(),
         })
     }
 
@@ -240,129 +244,15 @@ impl StarRocksAdapter {
             })
             .collect())
     }
-}
 
-#[async_trait]
-impl SyncAdapter for StarRocksAdapter {
-    async fn health_check(&self) -> bool {
-        use mysql_async::prelude::Queryable;
-        match self.acquire_control_conn().await {
-            Ok(mut conn) => match conn.ping().await {
-                Ok(_) => true,
-                Err(e) => {
-                    tracing::warn!(
-                        cluster = %self.cluster_name,
-                        error = %e,
-                        "StarRocks health check ping failed"
-                    );
-                    false
-                }
-            },
-            Err(e) => {
-                tracing::warn!(
-                    cluster = %self.cluster_name,
-                    error = %e,
-                    "StarRocks health check: pool checkout failed"
-                );
-                false
-            }
-        }
-    }
-
-    async fn fetch_running_query_count(&self) -> Option<u64> {
-        // Query the FE's processlist for all actively executing queries — not just the ones
-        // routed through QueryFlux. This gives a true picture of StarRocks load and prevents
-        // the reconciler from overcorrecting when the engine is busy with external traffic.
-        let rows = self
-            .run_query(
-                "SELECT COUNT(*) FROM information_schema.processlist WHERE COMMAND = 'Query'",
-            )
-            .await
-            .ok()?;
-        rows.into_iter()
-            .next()
-            .and_then(|mut row| row.take::<u64, usize>(0))
-    }
-
-    fn engine_type(&self) -> EngineType {
-        EngineType::StarRocks
-    }
-
-    fn connection_format(&self) -> crate::ConnectionFormat {
-        crate::ConnectionFormat::MysqlWire
-    }
-
-    fn supports_native_params(&self) -> bool {
-        true
-    }
-
-    async fn execute_native(
+    async fn execute_as_arrow_on_conn(
         &self,
-        _protocol: &queryflux_core::query::FrontendProtocol,
+        conn: &mut Conn,
         sql: &str,
         session: &SessionContext,
-        credentials: &queryflux_auth::QueryCredentials,
         tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
-        id_slot: &BackendQueryIdSlot,
-    ) -> crate::Result<crate::NativeExecution> {
-        crate::mysql_native::execute(&self.pool, sql, session, credentials, tags, params, id_slot)
-            .await
-    }
-
-    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
-        let Some(sql) = kill_query_sql(&backend_id.0) else {
-            tracing::debug!(
-                cluster = %self.cluster_name,
-                query_id = %backend_id,
-                "StarRocks cancel skipped: connection id is not a safe integer"
-            );
-            return Ok(());
-        };
-        let mut conn = match self.acquire_control_conn().await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::debug!(
-                    cluster = %self.cluster_name,
-                    query_id = %backend_id,
-                    error = %e,
-                    "StarRocks KILL QUERY: control pool checkout failed (ignored)"
-                );
-                return Ok(());
-            }
-        };
-        match conn.query_drop(&sql).await {
-            Ok(()) => {
-                tracing::debug!(
-                    cluster = %self.cluster_name,
-                    query_id = %backend_id,
-                    "StarRocks KILL QUERY issued"
-                );
-            }
-            Err(e) => {
-                tracing::debug!(
-                    cluster = %self.cluster_name,
-                    query_id = %backend_id,
-                    error = %e,
-                    "StarRocks KILL QUERY failed (ignored)"
-                );
-            }
-        }
-        Ok(())
-    }
-
-    async fn execute_as_arrow(
-        &self,
-        sql: &str,
-        session: &SessionContext,
-        _credentials: &queryflux_auth::QueryCredentials,
-        tags: &QueryTags,
-        params: &queryflux_core::params::QueryParams,
-        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
-        let mut conn = self.acquire_conn().await?;
-        id_slot.publish(conn.id().to_string());
-
         if let Some(db) = session.database() {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
             conn.query_drop(&use_sql)
@@ -439,6 +329,154 @@ impl SyncAdapter for StarRocksAdapter {
             stream: Box::pin(stream::iter(std::iter::once(Ok(batch)))),
             stats: rx,
         })
+    }
+}
+
+#[async_trait]
+impl SyncAdapter for StarRocksAdapter {
+    async fn health_check(&self) -> bool {
+        use mysql_async::prelude::Queryable;
+        match self.acquire_control_conn().await {
+            Ok(mut conn) => match conn.ping().await {
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::warn!(
+                        cluster = %self.cluster_name,
+                        error = %e,
+                        "StarRocks health check ping failed"
+                    );
+                    false
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    cluster = %self.cluster_name,
+                    error = %e,
+                    "StarRocks health check: pool checkout failed"
+                );
+                false
+            }
+        }
+    }
+
+    async fn fetch_running_query_count(&self) -> Option<u64> {
+        // Query the FE's processlist for all actively executing queries — not just the ones
+        // routed through QueryFlux. This gives a true picture of StarRocks load and prevents
+        // the reconciler from overcorrecting when the engine is busy with external traffic.
+        let rows = self
+            .run_query(
+                "SELECT COUNT(*) FROM information_schema.processlist WHERE COMMAND = 'Query'",
+            )
+            .await
+            .ok()?;
+        rows.into_iter()
+            .next()
+            .and_then(|mut row| row.take::<u64, usize>(0))
+    }
+
+    fn engine_type(&self) -> EngineType {
+        EngineType::StarRocks
+    }
+
+    fn connection_format(&self) -> crate::ConnectionFormat {
+        crate::ConnectionFormat::MysqlWire
+    }
+
+    fn supports_native_params(&self) -> bool {
+        true
+    }
+
+    async fn execute_native(
+        &self,
+        _protocol: &queryflux_core::query::FrontendProtocol,
+        sql: &str,
+        session: &SessionContext,
+        credentials: &queryflux_auth::QueryCredentials,
+        tags: &QueryTags,
+        params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
+    ) -> crate::Result<crate::NativeExecution> {
+        crate::mysql_native::execute(
+            &self.pool,
+            sql,
+            session,
+            credentials,
+            tags,
+            params,
+            id_slot,
+            &self.inflight,
+        )
+        .await
+    }
+
+    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        let Some(sql) = kill_query_sql(&backend_id.0) else {
+            tracing::debug!(
+                cluster = %self.cluster_name,
+                query_id = %backend_id,
+                "StarRocks cancel skipped: connection id is not a safe integer"
+            );
+            return Ok(());
+        };
+        if !self.inflight.contains_published(&backend_id.0) {
+            tracing::debug!(
+                cluster = %self.cluster_name,
+                query_id = %backend_id,
+                "StarRocks cancel skipped: connection no longer owns an in-flight query"
+            );
+            return Ok(());
+        }
+        let mut conn = match self.acquire_control_conn().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "StarRocks KILL QUERY: control pool checkout failed (ignored)"
+                );
+                return Ok(());
+            }
+        };
+        match conn.query_drop(&sql).await {
+            Ok(()) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    "StarRocks KILL QUERY issued"
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "StarRocks KILL QUERY failed (ignored)"
+                );
+            }
+        }
+        self.inflight.release_published(&backend_id.0);
+        Ok(())
+    }
+
+    async fn execute_as_arrow(
+        &self,
+        sql: &str,
+        session: &SessionContext,
+        _credentials: &queryflux_auth::QueryCredentials,
+        tags: &QueryTags,
+        params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
+    ) -> Result<SyncExecution> {
+        let mut conn = self.acquire_conn().await?;
+        let conn_id = conn.id();
+        id_slot.publish(conn_id.to_string());
+        let mut claim = self.inflight.claim(conn_id);
+        let result = self
+            .execute_as_arrow_on_conn(&mut conn, sql, session, tags, params)
+            .await;
+        claim.finish();
+        result
     }
 
     // --- Catalog discovery ---

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -17,12 +17,12 @@ use queryflux_core::{
     catalog::TableSchema,
     config::{ClusterAuth, ClusterConfig},
     error::{QueryFluxError, Result},
-    query::{ClusterGroupName, ClusterName, EngineType},
+    query::{BackendQueryId, ClusterGroupName, ClusterName, EngineType},
     session::SessionContext,
     tags::{tags_to_json, QueryTags},
 };
 
-use crate::{AdapterKind, SyncAdapter, SyncExecution};
+use crate::{AdapterKind, BackendQueryIdSlot, SyncAdapter, SyncExecution};
 use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
@@ -304,8 +304,51 @@ impl SyncAdapter for StarRocksAdapter {
         credentials: &queryflux_auth::QueryCredentials,
         tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> crate::Result<crate::NativeExecution> {
-        crate::mysql_native::execute(&self.pool, sql, session, credentials, tags, params).await
+        crate::mysql_native::execute(&self.pool, sql, session, credentials, tags, params, id_slot)
+            .await
+    }
+
+    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        let Some(sql) = kill_query_sql(&backend_id.0) else {
+            tracing::debug!(
+                cluster = %self.cluster_name,
+                query_id = %backend_id,
+                "StarRocks cancel skipped: connection id is not a safe integer"
+            );
+            return Ok(());
+        };
+        let mut conn = match self.acquire_control_conn().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "StarRocks KILL QUERY: control pool checkout failed (ignored)"
+                );
+                return Ok(());
+            }
+        };
+        match conn.query_drop(&sql).await {
+            Ok(()) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    "StarRocks KILL QUERY issued"
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "StarRocks KILL QUERY failed (ignored)"
+                );
+            }
+        }
+        Ok(())
     }
 
     async fn execute_as_arrow(
@@ -315,8 +358,10 @@ impl SyncAdapter for StarRocksAdapter {
         _credentials: &queryflux_auth::QueryCredentials,
         tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<SyncExecution> {
         let mut conn = self.acquire_conn().await?;
+        id_slot.publish(conn.id().to_string());
 
         if let Some(db) = session.database() {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
@@ -474,6 +519,15 @@ impl SyncAdapter for StarRocksAdapter {
             columns,
         }))
     }
+}
+
+/// `KILL QUERY <connection_id>` — `connection_id` must be a decimal integer.
+fn kill_query_sql(id: &str) -> Option<String> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() || trimmed.len() > 20 || !trimmed.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(format!("KILL QUERY {trimmed}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -863,5 +917,19 @@ mod tests {
     #[test]
     fn null_maps_to_null() {
         assert_eq!(query_param_to_mysql_value(&QueryParam::Null), Value::NULL);
+    }
+
+    #[test]
+    fn kill_query_sql_accepts_decimal_ids() {
+        assert_eq!(kill_query_sql("42").as_deref(), Some("KILL QUERY 42"));
+        assert_eq!(kill_query_sql(" 7 ").as_deref(), Some("KILL QUERY 7"));
+    }
+
+    #[test]
+    fn kill_query_sql_rejects_non_integers() {
+        assert!(kill_query_sql("").is_none());
+        assert!(kill_query_sql("12; DROP").is_none());
+        assert!(kill_query_sql("-1").is_none());
+        assert!(kill_query_sql("1e2").is_none());
     }
 }

--- a/crates/queryflux-engine-adapters/src/trino/mod.rs
+++ b/crates/queryflux-engine-adapters/src/trino/mod.rs
@@ -25,7 +25,7 @@ use queryflux_core::{
 use reqwest::{Client, StatusCode};
 use tracing::debug;
 
-use crate::{AdapterKind, AsyncAdapter};
+use crate::{AdapterKind, AsyncAdapter, BackendQueryIdSlot};
 use api::TrinoResponse;
 
 use queryflux_core::engine_registry::{
@@ -410,9 +410,38 @@ impl AsyncAdapter for TrinoAdapter {
         })
     }
 
-    async fn cancel_query(&self, _backend_id: &BackendQueryId) -> Result<()> {
-        // Trino cancel: DELETE the nextUri. We'd need to look it up from persistence.
-        // For now this is handled by the frontend which has the stored next_uri.
+    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
+        // `DELETE /v1/query/{id}` cancels a running query without needing nextUri.
+        let url = self.trino_url(&format!("/v1/query/{}", backend_id.0));
+        match self
+            .apply_cluster_auth(self.http_client.delete(&url))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    "Trino query cancelled (DELETE /v1/query)"
+                );
+            }
+            Ok(resp) => {
+                debug!(
+                    cluster = %self.cluster_name,
+                    status = %resp.status(),
+                    query_id = %backend_id,
+                    "Trino cancel DELETE non-success (ignored)"
+                );
+            }
+            Err(e) => {
+                debug!(
+                    cluster = %self.cluster_name,
+                    query_id = %backend_id,
+                    error = %e,
+                    "Trino cancel DELETE failed (ignored)"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -423,6 +452,7 @@ impl AsyncAdapter for TrinoAdapter {
         credentials: &queryflux_auth::QueryCredentials,
         tags: &queryflux_core::tags::QueryTags,
         params: &queryflux_core::params::QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> crate::Result<crate::SyncExecution> {
         use crate::SyncExecution;
         use queryflux_core::query::QueryPollResult;
@@ -445,6 +475,7 @@ impl AsyncAdapter for TrinoAdapter {
                     ..
                 } => (backend_query_id, None, initial_response, engine_stats),
             };
+        id_slot.publish(backend_query_id.0.clone());
 
         let (batch_tx, batch_rx) = tokio::sync::mpsc::channel::<crate::Result<RecordBatch>>(32);
         let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();

--- a/crates/queryflux-frontend/src/abort.rs
+++ b/crates/queryflux-frontend/src/abort.rs
@@ -1,6 +1,14 @@
 //! Abort a spawned query task when the caller is dropped (client disconnect).
 
+use tokio::net::tcp::OwnedReadHalf;
 use tokio::task::{JoinError, JoinHandle};
+
+/// Resolves when the client TCP stream is readable — EOF, a socket error, or
+/// a pipelined next command — without consuming any bytes.
+pub async fn wait_client_gone(reader: &mut OwnedReadHalf) {
+    let mut buf = [0u8; 1];
+    let _ = reader.peek(&mut buf).await;
+}
 
 /// Wraps a [`JoinHandle`] and aborts the task if dropped before [`join`](Self::join).
 pub struct AbortOnDrop<T> {
@@ -15,8 +23,17 @@ impl<T> AbortOnDrop<T> {
     }
 
     /// Await the task and disarm the abort-on-drop.
+    ///
+    /// The handle stays stored until the await resolves so dropping the `join`
+    /// future still aborts the task.
     pub async fn join(mut self) -> std::result::Result<T, JoinError> {
-        self.handle.take().expect("AbortOnDrop joined twice").await
+        let result = self
+            .handle
+            .as_mut()
+            .expect("AbortOnDrop handle is always Some before Drop")
+            .await;
+        self.handle.take();
+        result
     }
 }
 
@@ -59,5 +76,27 @@ mod tests {
     async fn join_does_not_abort() {
         let handle = AbortOnDrop::new(tokio::spawn(async { 7u8 }));
         assert_eq!(handle.join().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn dropping_join_future_still_aborts() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = AbortOnDrop::new(tokio::spawn(async move {
+            struct SendOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
+            impl Drop for SendOnDrop {
+                fn drop(&mut self) {
+                    if let Some(tx) = self.0.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            }
+            let _guard = SendOnDrop(Some(tx));
+            std::future::pending::<()>().await
+        }));
+        let join = handle.join();
+        drop(join);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("dropping join should still abort the task");
     }
 }

--- a/crates/queryflux-frontend/src/abort.rs
+++ b/crates/queryflux-frontend/src/abort.rs
@@ -1,0 +1,63 @@
+//! Abort a spawned query task when the caller is dropped (client disconnect).
+
+use tokio::task::{JoinError, JoinHandle};
+
+/// Wraps a [`JoinHandle`] and aborts the task if dropped before [`join`](Self::join).
+pub struct AbortOnDrop<T> {
+    handle: Option<JoinHandle<T>>,
+}
+
+impl<T> AbortOnDrop<T> {
+    pub fn new(handle: JoinHandle<T>) -> Self {
+        Self {
+            handle: Some(handle),
+        }
+    }
+
+    /// Await the task and disarm the abort-on-drop.
+    pub async fn join(mut self) -> std::result::Result<T, JoinError> {
+        self.handle.take().expect("AbortOnDrop joined twice").await
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AbortOnDrop;
+
+    #[tokio::test]
+    async fn drop_aborts_the_task() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = AbortOnDrop::new(tokio::spawn(async move {
+            struct SendOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
+            impl Drop for SendOnDrop {
+                fn drop(&mut self) {
+                    if let Some(tx) = self.0.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            }
+            let _guard = SendOnDrop(Some(tx));
+            std::future::pending::<()>().await;
+        }));
+        drop(handle);
+        // Ok(()) = Drop ran and signalled; RecvError = the future was dropped
+        // before first poll (sender dropped with the task). Both mean abort worked.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("aborted task should be dropped");
+    }
+
+    #[tokio::test]
+    async fn join_does_not_abort() {
+        let handle = AbortOnDrop::new(tokio::spawn(async { 7u8 }));
+        assert_eq!(handle.join().await.unwrap(), 7);
+    }
+}

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
@@ -991,15 +991,29 @@ impl Drop for SyncCancelGuard {
     }
 }
 
+/// Outer deadline for detached `cancel_query` tasks. Matches adapter control-plane
+/// timeouts (ClickHouse / StarRocks pool checkout) so a hung backend cannot leak tasks.
+const SYNC_CANCEL_TIMEOUT: Duration = Duration::from_secs(10);
+
 fn spawn_sync_cancel(adapter: DispatchAdapter, id_slot: BackendQueryIdSlot) {
     let Some(id) = id_slot.get() else {
         return;
     };
     tokio::spawn(async move {
-        if let Err(e) = adapter.cancel_query(&id).await {
-            warn!(backend = %id, "Best-effort sync cancel on client disconnect: {e}");
-        } else {
-            debug!(backend = %id, "Issued backend cancel after client disconnect");
+        match tokio::time::timeout(SYNC_CANCEL_TIMEOUT, adapter.cancel_query(&id)).await {
+            Err(_) => {
+                warn!(
+                    backend = %id,
+                    timeout_secs = SYNC_CANCEL_TIMEOUT.as_secs(),
+                    "Sync cancel timed out"
+                );
+            }
+            Ok(Err(e)) => {
+                warn!(backend = %id, "Best-effort sync cancel on client disconnect: {e}");
+            }
+            Ok(Ok(())) => {
+                debug!(backend = %id, "Issued backend cancel after client disconnect");
+            }
         }
     });
 }
@@ -1105,13 +1119,12 @@ struct SyncOutcome {
     /// Engine-reported execution stats received via `SyncExecution.stats` after stream exhaustion.
     /// `None` for engines that do not expose structured stats (DuckDB, StarRocks today).
     engine_stats: Option<QueryEngineStats>,
-    backend_query_id: Option<String>,
 }
 
 impl From<SyncOutcome> for QueryOutcome {
     fn from(o: SyncOutcome) -> QueryOutcome {
         QueryOutcome {
-            backend_query_id: o.backend_query_id,
+            backend_query_id: None,
             status: o.status,
             execution_ms: o.elapsed_ms,
             rows: o.rows,
@@ -1397,7 +1410,6 @@ async fn execute_stream(
                 error: Some(msg.clone()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
-                backend_query_id: None,
             };
             return (outcome, sink.on_error(&msg).await);
         }
@@ -1419,7 +1431,6 @@ async fn execute_stream(
                     error: Some(msg.clone()),
                     elapsed_ms: elapsed(),
                     engine_stats: None,
-                    backend_query_id: None,
                 };
                 return (outcome, sink.on_error(&msg).await);
             }
@@ -1432,7 +1443,6 @@ async fn execute_stream(
                             error: Some("client disconnected during schema send".to_string()),
                             elapsed_ms: elapsed(),
                             engine_stats: None,
-                            backend_query_id: None,
                         };
                         return (outcome, Err(e));
                     }
@@ -1448,7 +1458,6 @@ async fn execute_stream(
                         error: Some(msg),
                         elapsed_ms: elapsed(),
                         engine_stats: None,
-                        backend_query_id: None,
                     };
                     return (outcome, Err(e));
                 }
@@ -1470,7 +1479,6 @@ async fn execute_stream(
                 error: Some("client disconnected during empty schema send".to_string()),
                 elapsed_ms,
                 engine_stats,
-                backend_query_id: None,
             };
             return (outcome, Err(e));
         }
@@ -1488,7 +1496,6 @@ async fn execute_stream(
         error: None,
         elapsed_ms,
         engine_stats,
-        backend_query_id: None,
     };
 
     (outcome, sink.on_complete(&stats).await)
@@ -1521,7 +1528,6 @@ async fn execute_native_to_sink(
                 error: Some(msg.to_string()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
-                backend_query_id: None,
             };
             return (outcome, sink.on_error(msg).await);
         }
@@ -1553,7 +1559,6 @@ async fn execute_native_to_sink(
                 error: Some(msg.clone()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
-                backend_query_id: None,
             };
             return (outcome, sink.on_error(&msg).await);
         }
@@ -1573,7 +1578,6 @@ async fn execute_native_to_sink(
                     error: Some(msg.clone()),
                     elapsed_ms: elapsed(),
                     engine_stats: None,
-                    backend_query_id: None,
                 };
                 return (outcome, sink.on_error(&msg).await);
             }
@@ -1587,7 +1591,6 @@ async fn execute_native_to_sink(
                         error: Some(msg.clone()),
                         elapsed_ms: elapsed(),
                         engine_stats: None,
-                        backend_query_id: None,
                     };
                     return (outcome, Err(e));
                 }
@@ -1610,7 +1613,6 @@ async fn execute_native_to_sink(
         error: None,
         elapsed_ms,
         engine_stats,
-        backend_query_id: None,
     };
 
     (outcome, sink.on_complete(&stats).await)
@@ -1970,12 +1972,14 @@ async fn execute_to_sink_inner(
     } else {
         execute_stream(&setup, sink, &id_slot).await
     };
-    outcome.backend_query_id = id_slot.get().map(|id| id.0);
-
     if sink_result.is_err() {
         // Client gone mid-stream (or during schema send): stop the engine query.
         cancel.fire();
-        outcome.status = QueryStatus::Cancelled;
+        // Only reclassify when the engine itself did not already fail — otherwise
+        // an engine error delivered to a departed client is logged as a cancel.
+        if outcome.status == QueryStatus::Success {
+            outcome.status = QueryStatus::Cancelled;
+        }
         if outcome.error.is_none() {
             outcome.error = Some("client disconnected".to_string());
         }
@@ -1987,6 +1991,7 @@ async fn execute_to_sink_inner(
     // slot.release() is idempotent and sets released=true so Drop is a no-op.
     setup.slot.release().await;
     let mut final_outcome: QueryOutcome = outcome.into();
+    final_outcome.backend_query_id = id_slot.get().map(|id| id.0);
     // Prepend guard actions (allow/warn) collected before execution.
     if !setup.guard_actions.is_empty() {
         setup.guard_actions.extend(final_outcome.guard_actions);

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -20,7 +20,9 @@ use queryflux_core::{
     },
     session::SessionContext,
 };
-use queryflux_engine_adapters::{AdapterKind, AsyncAdapter, ConnectionFormat, SyncAdapter};
+use queryflux_engine_adapters::{
+    AdapterKind, AsyncAdapter, BackendQueryIdSlot, ConnectionFormat, SyncAdapter,
+};
 use queryflux_guardrails::{GuardChain, GuardContext, GuardLayer};
 use queryflux_metrics::MetricsStore;
 use queryflux_translation::SchemaContext;
@@ -905,6 +907,104 @@ impl Drop for ClusterSlotGuard {
 }
 
 // ---------------------------------------------------------------------------
+// SyncCancelGuard — kill the engine query if the client drops mid-flight
+// ---------------------------------------------------------------------------
+
+/// Issues `adapter.cancel_query` when dropped without [`SyncCancelGuard::disarm`].
+///
+/// Adapters publish the engine-side id into `id_slot` before the blocking wait.
+/// On HTTP handler cancellation the future is dropped, this guard fires, and
+/// the backend query is stopped (ClickHouse `KILL QUERY`, StarRocks `KILL QUERY`,
+/// DuckDB interrupt, Athena `StopQueryExecution`, Trino `DELETE /v1/query`).
+struct SyncCancelGuard {
+    adapter: DispatchAdapter,
+    id_slot: BackendQueryIdSlot,
+    state: Option<Arc<AppState>>,
+    ctx: Option<QueryContext>,
+    start: Instant,
+    disarmed: bool,
+}
+
+impl SyncCancelGuard {
+    fn new(
+        adapter: DispatchAdapter,
+        id_slot: BackendQueryIdSlot,
+        state: Arc<AppState>,
+        ctx: QueryContext,
+        start: Instant,
+    ) -> Self {
+        Self {
+            adapter,
+            id_slot,
+            state: Some(state),
+            ctx: Some(ctx),
+            start,
+            disarmed: false,
+        }
+    }
+
+    /// Do not cancel — the query finished (success or engine error).
+    fn disarm(&mut self) {
+        self.disarmed = true;
+        self.state = None;
+        self.ctx = None;
+    }
+
+    /// Spawn a best-effort cancel now. Idempotent with [`Drop`].
+    fn fire(&mut self) {
+        if self.disarmed {
+            return;
+        }
+        self.disarmed = true;
+        self.state = None;
+        self.ctx = None;
+        spawn_sync_cancel(self.adapter.clone(), self.id_slot.clone());
+    }
+}
+
+impl Drop for SyncCancelGuard {
+    fn drop(&mut self) {
+        if self.disarmed {
+            return;
+        }
+        self.disarmed = true;
+        spawn_sync_cancel(self.adapter.clone(), self.id_slot.clone());
+        if let (Some(state), Some(ctx)) = (self.state.take(), self.ctx.take()) {
+            let backend_query_id = self.id_slot.get().map(|id| id.0);
+            state.record_query(
+                &ctx,
+                QueryOutcome {
+                    backend_query_id,
+                    status: QueryStatus::Cancelled,
+                    execution_ms: self.start.elapsed().as_millis() as u64,
+                    rows: None,
+                    error: Some("client disconnected".to_string()),
+                    routing_trace: None,
+                    engine_stats: None,
+                    guard_actions: vec![],
+                    was_guard_blocked: false,
+                    queue_duration_ms: 0,
+                    cache_hit: false,
+                },
+            );
+        }
+    }
+}
+
+fn spawn_sync_cancel(adapter: DispatchAdapter, id_slot: BackendQueryIdSlot) {
+    let Some(id) = id_slot.get() else {
+        return;
+    };
+    tokio::spawn(async move {
+        if let Err(e) = adapter.cancel_query(&id).await {
+            warn!(backend = %id, "Best-effort sync cancel on client disconnect: {e}");
+        } else {
+            debug!(backend = %id, "Issued backend cancel after client disconnect");
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Sync execution path — shared by MySQL wire, Postgres wire, Flight SQL
 // ---------------------------------------------------------------------------
 
@@ -913,6 +1013,7 @@ impl Drop for ClusterSlotGuard {
 /// Async engines (Trino) implement `execute_as_arrow` internally by driving their own
 /// submit+poll loop — allowing MySQL/Postgres clients to query them without needing a
 /// separate execution path in dispatch.
+#[derive(Clone)]
 enum DispatchAdapter {
     Sync(Arc<dyn SyncAdapter>),
     Async(Arc<dyn AsyncAdapter>),
@@ -926,16 +1027,24 @@ impl DispatchAdapter {
         credentials: &QueryCredentials,
         tags: &queryflux_core::tags::QueryTags,
         params: &QueryParams,
+        id_slot: &BackendQueryIdSlot,
     ) -> Result<queryflux_engine_adapters::SyncExecution> {
         match self {
             Self::Sync(a) => {
-                a.execute_as_arrow(sql, session, credentials, tags, params)
+                a.execute_as_arrow(sql, session, credentials, tags, params, id_slot)
                     .await
             }
             Self::Async(a) => {
-                a.execute_as_arrow(sql, session, credentials, tags, params)
+                a.execute_as_arrow(sql, session, credentials, tags, params, id_slot)
                     .await
             }
+        }
+    }
+
+    async fn cancel_query(&self, backend_id: &queryflux_core::query::BackendQueryId) -> Result<()> {
+        match self {
+            Self::Sync(a) => a.cancel_query(backend_id).await,
+            Self::Async(a) => a.cancel_query(backend_id).await,
         }
     }
 
@@ -996,12 +1105,13 @@ struct SyncOutcome {
     /// Engine-reported execution stats received via `SyncExecution.stats` after stream exhaustion.
     /// `None` for engines that do not expose structured stats (DuckDB, StarRocks today).
     engine_stats: Option<QueryEngineStats>,
+    backend_query_id: Option<String>,
 }
 
 impl From<SyncOutcome> for QueryOutcome {
     fn from(o: SyncOutcome) -> QueryOutcome {
         QueryOutcome {
-            backend_query_id: None,
+            backend_query_id: o.backend_query_id,
             status: o.status,
             execution_ms: o.elapsed_ms,
             rows: o.rows,
@@ -1252,6 +1362,7 @@ async fn setup_sync_query(
 async fn execute_stream(
     setup: &SyncQuerySetup,
     sink: &mut impl ResultSink,
+    id_slot: &BackendQueryIdSlot,
 ) -> (SyncOutcome, Result<()>) {
     let elapsed = || setup.start.elapsed().as_millis() as u64;
 
@@ -1263,6 +1374,7 @@ async fn execute_stream(
             &setup.credentials,
             &setup.ctx.query_tags,
             &setup.params,
+            id_slot,
         )
         .await
     {
@@ -1285,6 +1397,7 @@ async fn execute_stream(
                 error: Some(msg.clone()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
+                backend_query_id: None,
             };
             return (outcome, sink.on_error(&msg).await);
         }
@@ -1306,6 +1419,7 @@ async fn execute_stream(
                     error: Some(msg.clone()),
                     elapsed_ms: elapsed(),
                     engine_stats: None,
+                    backend_query_id: None,
                 };
                 return (outcome, sink.on_error(&msg).await);
             }
@@ -1318,6 +1432,7 @@ async fn execute_stream(
                             error: Some("client disconnected during schema send".to_string()),
                             elapsed_ms: elapsed(),
                             engine_stats: None,
+                            backend_query_id: None,
                         };
                         return (outcome, Err(e));
                     }
@@ -1333,6 +1448,7 @@ async fn execute_stream(
                         error: Some(msg),
                         elapsed_ms: elapsed(),
                         engine_stats: None,
+                        backend_query_id: None,
                     };
                     return (outcome, Err(e));
                 }
@@ -1354,6 +1470,7 @@ async fn execute_stream(
                 error: Some("client disconnected during empty schema send".to_string()),
                 elapsed_ms,
                 engine_stats,
+                backend_query_id: None,
             };
             return (outcome, Err(e));
         }
@@ -1371,6 +1488,7 @@ async fn execute_stream(
         error: None,
         elapsed_ms,
         engine_stats,
+        backend_query_id: None,
     };
 
     (outcome, sink.on_complete(&stats).await)
@@ -1384,6 +1502,7 @@ async fn execute_native_to_sink(
     setup: &SyncQuerySetup,
     protocol: &FrontendProtocol,
     sink: &mut impl ResultSink,
+    id_slot: &BackendQueryIdSlot,
 ) -> (SyncOutcome, Result<()>) {
     let elapsed = || setup.start.elapsed().as_millis() as u64;
 
@@ -1402,6 +1521,7 @@ async fn execute_native_to_sink(
                 error: Some(msg.to_string()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
+                backend_query_id: None,
             };
             return (outcome, sink.on_error(msg).await);
         }
@@ -1415,6 +1535,7 @@ async fn execute_native_to_sink(
             &setup.credentials,
             &setup.ctx.query_tags,
             &setup.params,
+            id_slot,
         )
         .await
     {
@@ -1432,6 +1553,7 @@ async fn execute_native_to_sink(
                 error: Some(msg.clone()),
                 elapsed_ms: elapsed(),
                 engine_stats: None,
+                backend_query_id: None,
             };
             return (outcome, sink.on_error(&msg).await);
         }
@@ -1451,6 +1573,7 @@ async fn execute_native_to_sink(
                     error: Some(msg.clone()),
                     elapsed_ms: elapsed(),
                     engine_stats: None,
+                    backend_query_id: None,
                 };
                 return (outcome, sink.on_error(&msg).await);
             }
@@ -1464,6 +1587,7 @@ async fn execute_native_to_sink(
                         error: Some(msg.clone()),
                         elapsed_ms: elapsed(),
                         engine_stats: None,
+                        backend_query_id: None,
                     };
                     return (outcome, Err(e));
                 }
@@ -1486,6 +1610,7 @@ async fn execute_native_to_sink(
         error: None,
         elapsed_ms,
         engine_stats,
+        backend_query_id: None,
     };
 
     (outcome, sink.on_complete(&stats).await)
@@ -1828,15 +1953,35 @@ async fn execute_to_sink_inner(
     // Native path: skip Arrow when backend connection format matches frontend protocol.
     // All other guarantees (slot release, record_query) are upheld by this function's
     // outer structure — only the inner execution subroutine is swapped.
-    let (outcome, sink_result) = if setup
+    let id_slot = BackendQueryIdSlot::new();
+    let mut cancel = SyncCancelGuard::new(
+        setup.adapter.clone(),
+        id_slot.clone(),
+        state.clone(),
+        setup.ctx.clone(),
+        setup.start,
+    );
+    let (mut outcome, sink_result) = if setup
         .adapter
         .connection_format()
         .matches_frontend(&protocol)
     {
-        execute_native_to_sink(&setup, &protocol, sink).await
+        execute_native_to_sink(&setup, &protocol, sink, &id_slot).await
     } else {
-        execute_stream(&setup, sink).await
+        execute_stream(&setup, sink, &id_slot).await
     };
+    outcome.backend_query_id = id_slot.get().map(|id| id.0);
+
+    if sink_result.is_err() {
+        // Client gone mid-stream (or during schema send): stop the engine query.
+        cancel.fire();
+        outcome.status = QueryStatus::Cancelled;
+        if outcome.error.is_none() {
+            outcome.error = Some("client disconnected".to_string());
+        }
+    }
+    // Successful completion and engine errors: the query is already finished.
+    cancel.disarm();
 
     // Guaranteed single exit: release slot, then record.
     // slot.release() is idempotent and sets released=true so Drop is a no-op.

--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
@@ -41,6 +42,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
+use crate::abort::AbortOnDrop;
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
@@ -216,7 +218,7 @@ impl FlightSqlService for QueryFluxFlightSql {
         let state2 = self.state.clone();
         let sql2 = sql.clone();
 
-        tokio::spawn(async move {
+        let exec_task = AbortOnDrop::new(tokio::spawn(async move {
             let _ = execute_to_sink(
                 &state2,
                 sql2,
@@ -229,9 +231,12 @@ impl FlightSqlService for QueryFluxFlightSql {
             )
             .await;
             // sink drops here → tx closes → rx stream ends
-        });
+        }));
 
-        let batch_stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+        let batch_stream = AbortOnDropStream {
+            inner: tokio_stream::wrappers::UnboundedReceiverStream::new(rx),
+            _abort: exec_task,
+        };
 
         let flight_data_stream = FlightDataEncoderBuilder::new()
             .build(batch_stream)
@@ -278,6 +283,20 @@ impl ResultSink for FlightSqlResultSink {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Forwards an inner stream and aborts the execute task when the Flight client drops.
+struct AbortOnDropStream<S> {
+    inner: S,
+    _abort: AbortOnDrop<()>,
+}
+
+impl<S: Stream + Unpin> Stream for AbortOnDropStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
 
 /// Encode an empty Arrow schema as IPC bytes for FlightInfo.schema.
 fn encode_empty_schema() -> bytes::Bytes {

--- a/crates/queryflux-frontend/src/lib.rs
+++ b/crates/queryflux-frontend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod abort;
 pub mod admin;
 pub mod dispatch;
 pub mod flight_sql;

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -39,6 +39,7 @@ use queryflux_core::{
     tags::{parse_query_tags, QueryTags},
 };
 
+use crate::abort::AbortOnDrop;
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
@@ -238,8 +239,15 @@ async fn handle_connection(
                     .trim_end_matches('\0')
                     .to_string();
                 debug!(conn_id = connection_id, sql = %sql, "MySQL wire: query");
-                handle_com_query(&mut writer, &state, &mut session, &sql, seq.wrapping_add(1))
-                    .await?;
+                handle_com_query(
+                    &mut reader,
+                    &mut writer,
+                    &state,
+                    &mut session,
+                    &sql,
+                    seq.wrapping_add(1),
+                )
+                .await?;
             }
 
             COM_FIELD_LIST => {
@@ -267,13 +275,18 @@ async fn handle_connection(
 
 // ── Query execution ───────────────────────────────────────────────────────────
 
-async fn handle_com_query<W: AsyncWriteExt + Unpin>(
+async fn handle_com_query<R, W>(
+    reader: &mut R,
     writer: &mut W,
     state: &Arc<AppState>,
     session: &mut SessionContext,
     sql: &str,
     start_seq: u8,
-) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    R: AsyncReadExt + Unpin,
+    W: AsyncWriteExt + Unpin,
+{
     // Unwrap MySQL conditional comments: /*!40101 SET ... */ → SET ...
     let logical = strip_mysql_conditional_comment(sql);
     let sql_lower = logical.trim().to_lowercase();
@@ -383,7 +396,7 @@ async fn handle_com_query<W: AsyncWriteExt + Unpin>(
     let session2 = session.clone();
     let sql2 = sql.to_string();
 
-    let exec_task = tokio::spawn(async move {
+    let exec_task = AbortOnDrop::new(tokio::spawn(async move {
         execute_to_sink(
             &state2,
             sql2,
@@ -396,20 +409,40 @@ async fn handle_com_query<W: AsyncWriteExt + Unpin>(
         )
         .await
         // `sink` drops here — closes tx — rx.recv() will return None after last packet
-    });
+    }));
 
-    // Forward encoded MySQL packets to the client as they arrive.
-    while let Some(pkt) = rx.recv().await {
-        writer.write_all(&pkt).await?;
-        writer.flush().await?;
+    // Forward encoded MySQL packets. Abort the engine query if the client
+    // closes (or sends another command) while we are still waiting for results.
+    loop {
+        tokio::select! {
+            pkt = rx.recv() => {
+                match pkt {
+                    Some(pkt) => {
+                        writer.write_all(&pkt).await?;
+                        writer.flush().await?;
+                    }
+                    None => break,
+                }
+            }
+            _ = wait_client_gone(reader) => {
+                debug!("MySQL wire: client disconnected during query — aborting");
+                return Ok(());
+            }
+        }
     }
 
     // Log any panic in the execution task; result errors go through on_error → ERR packet.
-    if let Err(e) = exec_task.await {
+    if let Err(e) = exec_task.join().await {
         warn!("MySQL query task panicked: {e}");
     }
 
     Ok(())
+}
+
+/// Resolves when the client TCP stream is readable (typically EOF / next command).
+async fn wait_client_gone<R: AsyncReadExt + Unpin>(reader: &mut R) {
+    let mut buf = [0u8; 1];
+    let _ = reader.read(&mut buf).await;
 }
 
 // ── Synthetic result helpers ──────────────────────────────────────────────────

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -39,7 +39,7 @@ use queryflux_core::{
     tags::{parse_query_tags, QueryTags},
 };
 
-use crate::abort::AbortOnDrop;
+use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
@@ -160,7 +160,7 @@ async fn handle_connection(
     connection_id: u32,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     stream.set_nodelay(true)?;
-    let (mut reader, mut writer) = tokio::io::split(stream);
+    let (mut reader, mut writer) = stream.into_split();
 
     // Send server handshake.
     write_packet(&mut writer, 0, &build_handshake(connection_id)).await?;
@@ -275,18 +275,14 @@ async fn handle_connection(
 
 // ── Query execution ───────────────────────────────────────────────────────────
 
-async fn handle_com_query<R, W>(
-    reader: &mut R,
-    writer: &mut W,
+async fn handle_com_query(
+    reader: &mut tokio::net::tcp::OwnedReadHalf,
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
     state: &Arc<AppState>,
     session: &mut SessionContext,
     sql: &str,
     start_seq: u8,
-) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
-where
-    R: AsyncReadExt + Unpin,
-    W: AsyncWriteExt + Unpin,
-{
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Unwrap MySQL conditional comments: /*!40101 SET ... */ → SET ...
     let logical = strip_mysql_conditional_comment(sql);
     let sql_lower = logical.trim().to_lowercase();
@@ -437,12 +433,6 @@ where
     }
 
     Ok(())
-}
-
-/// Resolves when the client TCP stream is readable (typically EOF / next command).
-async fn wait_client_gone<R: AsyncReadExt + Unpin>(reader: &mut R) {
-    let mut buf = [0u8; 1];
-    let _ = reader.read(&mut buf).await;
 }
 
 // ── Synthetic result helpers ──────────────────────────────────────────────────

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -31,7 +31,7 @@ use queryflux_core::{
     tags::parse_query_tags,
 };
 
-use crate::abort::AbortOnDrop;
+use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
@@ -127,7 +127,7 @@ async fn handle_connection(
     connection_id: u32,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     stream.set_nodelay(true)?;
-    let (mut reader, mut writer) = tokio::io::split(stream);
+    let (mut reader, mut writer) = stream.into_split();
 
     // ── Startup phase ────────────────────────────────────────────────────────
 
@@ -285,17 +285,13 @@ async fn handle_connection(
 
 // ── Query execution ───────────────────────────────────────────────────────────
 
-async fn handle_simple_query<R, W>(
-    reader: &mut R,
-    writer: &mut W,
+async fn handle_simple_query(
+    reader: &mut tokio::net::tcp::OwnedReadHalf,
+    writer: &mut tokio::net::tcp::OwnedWriteHalf,
     state: &Arc<AppState>,
     session: &SessionContext,
     sql: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
-where
-    R: AsyncReadExt + Unpin,
-    W: AsyncWriteExt + Unpin,
-{
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     if sql.is_empty() {
         // Empty query: EmptyQueryResponse + ReadyForQuery.
         write_msg(writer, b'I', &[]).await?;
@@ -392,12 +388,6 @@ where
     // ReadyForQuery after each command.
     write_msg(writer, b'Z', b"I").await?;
     Ok(())
-}
-
-/// Resolves when the client TCP stream is readable (typically EOF / next message).
-async fn wait_client_gone<R: AsyncReadExt + Unpin>(reader: &mut R) {
-    let mut buf = [0u8; 1];
-    let _ = reader.read(&mut buf).await;
 }
 
 // ── PostgresResultSink ────────────────────────────────────────────────────────

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -31,6 +31,7 @@ use queryflux_core::{
     tags::parse_query_tags,
 };
 
+use crate::abort::AbortOnDrop;
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
@@ -243,7 +244,7 @@ async fn handle_connection(
                     .trim()
                     .to_string();
                 debug!(conn_id = connection_id, sql = %sql, "Postgres wire: query");
-                handle_simple_query(&mut writer, &state, &session, &sql).await?;
+                handle_simple_query(&mut reader, &mut writer, &state, &session, &sql).await?;
             }
 
             b'P' => {
@@ -284,12 +285,17 @@ async fn handle_connection(
 
 // ── Query execution ───────────────────────────────────────────────────────────
 
-async fn handle_simple_query<W: AsyncWriteExt + Unpin>(
+async fn handle_simple_query<R, W>(
+    reader: &mut R,
     writer: &mut W,
     state: &Arc<AppState>,
     session: &SessionContext,
     sql: &str,
-) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    R: AsyncReadExt + Unpin,
+    W: AsyncWriteExt + Unpin,
+{
     if sql.is_empty() {
         // Empty query: EmptyQueryResponse + ReadyForQuery.
         write_msg(writer, b'I', &[]).await?;
@@ -344,7 +350,7 @@ async fn handle_simple_query<W: AsyncWriteExt + Unpin>(
     let session2 = session.clone();
     let sql2 = sql.to_string();
 
-    let exec_task = tokio::spawn(async move {
+    let exec_task = AbortOnDrop::new(tokio::spawn(async move {
         execute_to_sink(
             &state2,
             sql2,
@@ -357,21 +363,41 @@ async fn handle_simple_query<W: AsyncWriteExt + Unpin>(
         )
         .await
         // sink drops here, closing tx
-    });
+    }));
 
-    // Forward encoded Postgres messages to the client as they arrive.
-    while let Some(msg) = rx.recv().await {
-        writer.write_all(&msg).await?;
-        writer.flush().await?;
+    // Forward encoded Postgres messages. Abort the engine query if the client
+    // closes (or sends another message) while we are still waiting for results.
+    loop {
+        tokio::select! {
+            msg = rx.recv() => {
+                match msg {
+                    Some(msg) => {
+                        writer.write_all(&msg).await?;
+                        writer.flush().await?;
+                    }
+                    None => break,
+                }
+            }
+            _ = wait_client_gone(reader) => {
+                debug!("Postgres wire: client disconnected during query — aborting");
+                return Ok(());
+            }
+        }
     }
 
-    if let Err(e) = exec_task.await {
+    if let Err(e) = exec_task.join().await {
         warn!("Postgres query task panicked: {e}");
     }
 
     // ReadyForQuery after each command.
     write_msg(writer, b'Z', b"I").await?;
     Ok(())
+}
+
+/// Resolves when the client TCP stream is readable (typically EOF / next message).
+async fn wait_client_gone<R: AsyncReadExt + Unpin>(reader: &mut R) {
+    let mut buf = [0u8; 1];
+    let _ = reader.read(&mut buf).await;
 }
 
 // ── PostgresResultSink ────────────────────────────────────────────────────────

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -95,6 +95,7 @@ pub struct AppState {
 /// Stable per-query metadata that does not change across the query's lifecycle.
 /// Built once (after cluster selection and SQL translation) and passed to every
 /// `record_query` call within the same dispatch function.
+#[derive(Clone)]
 pub struct QueryContext {
     pub query_id: ProxyQueryId,
     pub sql: String,

--- a/website/docs/architecture/adding-support/backend.md
+++ b/website/docs/architecture/adding-support/backend.md
@@ -61,7 +61,7 @@ Adapters implement one of two traits depending on their execution model:
 
 1. Add `src/your_engine/mod.rs` (or similar).
 2. Implement **`SyncAdapter`** or **`AsyncAdapter`** — pick the one that matches your engine's execution model. Copy the shape from StarRocks (`SyncAdapter`) or Trino (`AsyncAdapter`).
-   - **SyncAdapter** required methods: `execute_as_arrow`, `health_check`, `engine_type`, catalog helpers. Optional: `cancel_query` (default no-op) — override so a client disconnect can stop the engine query. Publish the engine-side id into the `id_slot` argument *before* the blocking wait (ClickHouse `query_id`, StarRocks `CONNECTION_ID()`, Athena execution id, …).
+   - **SyncAdapter** required methods: `execute_as_arrow`, `health_check`, `engine_type`, catalog helpers. Optional: `cancel_query` (default no-op) — override so a client disconnect can stop the engine query. Publish a **real** engine-side id into the `id_slot` argument *before* the blocking wait (ClickHouse `query_id`, StarRocks `CONNECTION_ID()`, Athena execution id, …). Leave the slot unset when the engine has no cancel API — do not publish a synthetic UUID.
    - **AsyncAdapter** required methods: `submit_query` + `poll_query` + `cancel_query`, `health_check`, `engine_type`, catalog helpers.
 3. **Declare `connection_format()`** — this is how dispatch knows which result-encoding path to use:
 

--- a/website/docs/architecture/adding-support/backend.md
+++ b/website/docs/architecture/adding-support/backend.md
@@ -61,7 +61,8 @@ Adapters implement one of two traits depending on their execution model:
 
 1. Add `src/your_engine/mod.rs` (or similar).
 2. Implement **`SyncAdapter`** or **`AsyncAdapter`** — pick the one that matches your engine's execution model. Copy the shape from StarRocks (`SyncAdapter`) or Trino (`AsyncAdapter`).
-   - Required methods: `execute_as_arrow` / `submit_query` + `poll_query` + `cancel_query`, `health_check`, `engine_type`, catalog helpers (`list_catalogs`, `list_databases`, `list_tables`, `describe_table`).
+   - **SyncAdapter** required methods: `execute_as_arrow`, `health_check`, `engine_type`, catalog helpers. Optional: `cancel_query` (default no-op) — override so a client disconnect can stop the engine query. Publish the engine-side id into the `id_slot` argument *before* the blocking wait (ClickHouse `query_id`, StarRocks `CONNECTION_ID()`, Athena execution id, …).
+   - **AsyncAdapter** required methods: `submit_query` + `poll_query` + `cancel_query`, `health_check`, `engine_type`, catalog helpers.
 3. **Declare `connection_format()`** — this is how dispatch knows which result-encoding path to use:
 
    ```rust

--- a/website/docs/architecture/frontends/trino-http.md
+++ b/website/docs/architecture/frontends/trino-http.md
@@ -27,8 +27,10 @@ Config key: `trinoHttp`. Protocol identifier: `FrontendProtocol::TrinoHttp`. Def
 | `GET` | `/v1/statement/qf/queued/{id}/{seq}` | Poll a queued query (proxy-side backoff) |
 | `GET` | `/v1/statement/qf/executing/{id}` | Poll an executing query |
 | `GET` | `/v1/statement/{*path}` | Forward Trino-style poll paths |
-| `DELETE` | `/v1/statement/qf/executing/{id}` | Cancel a running query |
-| `DELETE` | `/v1/statement/{*path}` | Cancel via forwarded Trino path |
+| `DELETE` | `/v1/statement/qf/executing/{id}` | Cancel a running **async** query (persisted `ExecutingQuery`) |
+| `DELETE` | `/v1/statement/{*path}` | Cancel via forwarded Trino path (async only) |
+
+Sync engines (ClickHouse, StarRocks, DuckDB, …) do not persist an executing record. Cancel for those is driven by **client disconnect**: the HTTP handler future is dropped and dispatch issues the engine kill (`KILL QUERY`, interrupt, …).
 
 ## Authentication
 

--- a/website/docs/architecture/system-map.md
+++ b/website/docs/architecture/system-map.md
@@ -124,23 +124,19 @@ QueryExecution::Sync { result: QueryPollResult }
 | StarRocks | Sync | MySQL protocol, single round-trip |
 | ClickHouse | Sync | HTTP interface, `ArrowStream` response decoded to Arrow record batches |
 
-### EngineAdapterTrait (`queryflux-engine-adapters`)
+### Engine adapters (`queryflux-engine-adapters`)
+
+There is no single `EngineAdapterTrait`. Engines implement **`SyncAdapter`** (DuckDB, StarRocks, ClickHouse, ADBC) or **`AsyncAdapter`** (Trino, Athena).
 
 ```rust
-pub trait EngineAdapterTrait: Send + Sync {
-    async fn submit_query(&self, sql: &str, session: &SessionContext) -> Result<QueryExecution>;
-    async fn poll_query(&self, backend_id: &BackendQueryId, next_uri: Option<&str>) -> Result<QueryPollResult>;
-    async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()>;
-    async fn health_check(&self) -> bool;
-    fn engine_type(&self) -> EngineType;
+// SyncAdapter — execute_as_arrow / optional execute_native
+async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()>; // default no-op
 
-    // Catalog discovery — feeds schema context for translation
-    async fn list_catalogs(&self) -> Result<Vec<String>>;
-    async fn list_databases(&self, catalog: &str) -> Result<Vec<String>>;
-    async fn list_tables(&self, catalog: &str, db: &str) -> Result<Vec<String>>;
-    async fn describe_table(&self, catalog: &str, db: &str, table: &str) -> Result<Option<TableSchema>>;
-}
+// AsyncAdapter — submit_query + poll_query
+async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()>; // required
 ```
+
+On the sync path, dispatch holds a `SyncCancelGuard`. Adapters publish a `BackendQueryId` into a shared slot as soon as the engine id is known (before the blocking wait). If the client disconnects, the guard calls `cancel_query` (ClickHouse `KILL QUERY WHERE query_id = …`, StarRocks `KILL QUERY <connection_id>`, DuckDB `interrupt()`, Athena `StopQueryExecution`, Trino `DELETE /v1/query/{id}`). DuckDB HTTP and ADBC have no cross-thread kill API — cancel is a documented no-op; dropping the HTTP request is best-effort.
 
 ### RouterTrait (`queryflux-routing`)
 


### PR DESCRIPTION
## Summary
- Extend `SyncAdapter` with `cancel_query` and an early-published `BackendQueryIdSlot` so client disconnect can stop the engine query, not just release the QueryFlux slot.
- Implement per-engine kill: ClickHouse `KILL QUERY WHERE query_id`, StarRocks `KILL QUERY <connection_id>`, DuckDB `interrupt()`, Athena `StopQueryExecution`, Trino `DELETE /v1/query/{id}`. DuckDB HTTP / ADBC remain documented no-ops.
- Abort spawned MySQL / Postgres / Flight execute tasks on TCP/gRPC drop, record `QueryStatus::Cancelled`, and add unit + ClickHouse e2e coverage.

Closes #111

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p queryflux-engine-adapters -p queryflux-frontend --lib`
- [x] `cargo clippy -p queryflux-engine-adapters -p queryflux-frontend --all-targets -- -D warnings`
- [x] `make test-e2e` — especially `clickhouse_client_disconnect_kills_backend_query`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added cancellation of in-flight queries when clients disconnect.
  * Added backend query tracking across supported database engines.
  * Added engine-specific cancellation and interruption support.
  * Query results now report cancellation status when execution is interrupted.

* **Bug Fixes**
  * Prevented abandoned query tasks from continuing after result streams are dropped.

* **Documentation**
  * Updated adapter and cancellation behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->