### PR TITLE
feat(security): persist query owner and allow operator/admin cancel

### DIFF
--- a/crates/queryflux-auth/src/authorization.rs
+++ b/crates/queryflux-auth/src/authorization.rs
@@ -7,32 +7,135 @@ use tracing::{debug, warn};
 
 use crate::credentials::AuthContext;
 
-/// Checks whether an authenticated subject may execute queries against a cluster group.
+/// Action on an existing (or about-to-run) query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryAction {
+    /// Read in-flight results (poll). Owner only — this is result data.
+    Poll,
+    /// Take a queued query and dispatch it. Owner only — otherwise B runs A's SQL.
+    Dequeue,
+    /// Stop an in-flight or queued query. Owner or operator.
+    Cancel,
+}
+
+/// Query identity used for action checks.
+#[derive(Debug, Clone)]
+pub struct QueryAuthz {
+    pub submitted_by: String,
+    pub group: String,
+}
+
+/// IdP roles/groups that may act as operators (cancel any query).
+#[derive(Debug, Clone, Default)]
+pub struct OperatorPolicy {
+    pub roles: Vec<String>,
+    pub groups: Vec<String>,
+}
+
+impl OperatorPolicy {
+    pub fn from_lists(roles: Vec<String>, groups: Vec<String>) -> Self {
+        Self { roles, groups }
+    }
+
+    pub fn is_operator(&self, auth: &AuthContext) -> bool {
+        if self.roles.iter().any(|r| auth.roles.iter().any(|a| a == r)) {
+            return true;
+        }
+        self.groups
+            .iter()
+            .any(|g| auth.groups.iter().any(|a| a == g))
+    }
+}
+
+fn is_anonymous(user: &str) -> bool {
+    user.is_empty() || user == "anonymous"
+}
+
+/// Owner match used by poll/dequeue/cancel.
+///
+/// Empty `submitted_by` (legacy rows) is allowed. Two anonymous identities
+/// cannot be distinguished and are allowed.
+pub fn is_query_owner(auth: &AuthContext, submitted_by: &str) -> bool {
+    if submitted_by.is_empty() {
+        return true;
+    }
+    if is_anonymous(&auth.user) && is_anonymous(submitted_by) {
+        return true;
+    }
+    auth.user == submitted_by
+}
+
+/// Shared rules: poll/dequeue → owner; cancel → owner or operator.
+pub fn allow_query_action(
+    auth: &AuthContext,
+    action: QueryAction,
+    query: &QueryAuthz,
+    operators: &OperatorPolicy,
+) -> bool {
+    if is_query_owner(auth, &query.submitted_by) {
+        return true;
+    }
+    matches!(action, QueryAction::Cancel) && operators.is_operator(auth)
+}
+
+/// Checks whether an authenticated subject may execute queries against a cluster group,
+/// and whether they may poll / dequeue / cancel an existing query.
 ///
 /// Implementations:
-/// - `AllowAllAuthorization`      — default; permits everything (Phase 1 / no config)
+/// - `AllowAllAuthorization`      — default; permits run-on-any-group (Phase 1 / no config)
 /// - `SimpleAuthorizationPolicy`  — reads `allowGroups`/`allowUsers` from config (Phase 3)
 /// - `OpenFgaAuthorizationClient` — Zanzibar-style fine-grained authz (Phase 3)
 #[async_trait]
 pub trait AuthorizationChecker: Send + Sync {
-    /// Returns `true` if `auth_ctx.user` (and/or their groups) may access `group`.
+    /// Returns `true` if `auth_ctx.user` (and/or their groups) may run queries on `group`.
     async fn check(&self, auth_ctx: &AuthContext, group: &str) -> bool;
+
+    /// Returns `true` if `auth_ctx` may perform `action` on `query`.
+    ///
+    /// Default: owner for all actions; operators may cancel.
+    async fn check_query(
+        &self,
+        auth_ctx: &AuthContext,
+        action: QueryAction,
+        query: &QueryAuthz,
+    ) -> bool;
 }
 
 // ---------------------------------------------------------------------------
 // AllowAllAuthorization
 // ---------------------------------------------------------------------------
 
-/// Permits all requests. Used when no `authorization` block is configured.
+/// Permits all run-on-group requests. Used when no `authorization` block is configured.
 ///
-/// This preserves today's behavior: anyone who can reach the gateway may run queries.
-/// Operators opt in to access control by configuring `authorization.provider`.
-pub struct AllowAllAuthorization;
+/// Query actions still enforce owner (and optional operators for cancel).
+#[derive(Default)]
+pub struct AllowAllAuthorization {
+    operators: OperatorPolicy,
+}
+
+impl AllowAllAuthorization {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_operators(operators: OperatorPolicy) -> Self {
+        Self { operators }
+    }
+}
 
 #[async_trait]
 impl AuthorizationChecker for AllowAllAuthorization {
     async fn check(&self, _auth_ctx: &AuthContext, _group: &str) -> bool {
         true
+    }
+
+    async fn check_query(
+        &self,
+        auth_ctx: &AuthContext,
+        action: QueryAction,
+        query: &QueryAuthz,
+    ) -> bool {
+        allow_query_action(auth_ctx, action, query, &self.operators)
     }
 }
 
@@ -54,11 +157,20 @@ impl AuthorizationChecker for AllowAllAuthorization {
 pub struct SimpleAuthorizationPolicy {
     /// cluster_group_name → authorization config
     policies: HashMap<String, ClusterGroupAuthorizationConfig>,
+    operators: OperatorPolicy,
 }
 
 impl SimpleAuthorizationPolicy {
     pub fn new(policies: HashMap<String, ClusterGroupAuthorizationConfig>) -> Self {
-        Self { policies }
+        Self {
+            policies,
+            operators: OperatorPolicy::default(),
+        }
+    }
+
+    pub fn with_operators(mut self, operators: OperatorPolicy) -> Self {
+        self.operators = operators;
+        self
     }
 }
 
@@ -92,6 +204,15 @@ impl AuthorizationChecker for SimpleAuthorizationPolicy {
         warn!(user = %auth_ctx.user, group, "SimplePolicy: access denied");
         false
     }
+
+    async fn check_query(
+        &self,
+        auth_ctx: &AuthContext,
+        action: QueryAction,
+        query: &QueryAuthz,
+    ) -> bool {
+        allow_query_action(auth_ctx, action, query, &self.operators)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +242,7 @@ pub struct OpenFgaAuthorizationClient {
     http_client: reqwest::Client,
     /// Cached OAuth token for client_credentials flow: (token, expires_at).
     token_cache: tokio::sync::Mutex<Option<(String, std::time::Instant)>>,
+    operators: OperatorPolicy,
 }
 
 impl OpenFgaAuthorizationClient {
@@ -132,7 +254,13 @@ impl OpenFgaAuthorizationClient {
                 .build()
                 .expect("build OpenFGA http client"),
             token_cache: tokio::sync::Mutex::new(None),
+            operators: OperatorPolicy::default(),
         }
+    }
+
+    pub fn with_operators(mut self, operators: OperatorPolicy) -> Self {
+        self.operators = operators;
+        self
     }
 
     async fn bearer_token(&self) -> Option<String> {
@@ -183,6 +311,50 @@ impl OpenFgaAuthorizationClient {
             }
         }
     }
+
+    async fn check_relation(&self, auth_ctx: &AuthContext, relation: &str, group: &str) -> bool {
+        let url = format!(
+            "{}/stores/{}/check",
+            self.config.url.trim_end_matches('/'),
+            self.config.store_id,
+        );
+
+        let body = CheckRequest {
+            tuple_key: TupleKey {
+                user: format!("user:{}", auth_ctx.user),
+                relation: relation.to_string(),
+                object: format!("cluster_group:{group}"),
+            },
+        };
+
+        let mut req = self.http_client.post(&url).json(&body);
+        if let Some(token) = self.bearer_token().await {
+            req = req.bearer_auth(token);
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => match resp.json::<CheckResponse>().await {
+                Ok(r) => {
+                    if !r.allowed {
+                        warn!(user = %auth_ctx.user, group, relation, "OpenFGA: access denied");
+                    }
+                    r.allowed
+                }
+                Err(e) => {
+                    warn!(error = %e, "OpenFGA: failed to parse check response — denying");
+                    false
+                }
+            },
+            Ok(resp) => {
+                warn!(status = %resp.status(), user = %auth_ctx.user, group, relation, "OpenFGA: check returned error status — denying");
+                false
+            }
+            Err(e) => {
+                warn!(error = %e, "OpenFGA: check request failed — denying");
+                false
+            }
+        }
+    }
 }
 
 /// OpenFGA check request body.
@@ -207,46 +379,140 @@ struct CheckResponse {
 #[async_trait]
 impl AuthorizationChecker for OpenFgaAuthorizationClient {
     async fn check(&self, auth_ctx: &AuthContext, group: &str) -> bool {
-        let url = format!(
-            "{}/stores/{}/check",
-            self.config.url.trim_end_matches('/'),
-            self.config.store_id,
+        self.check_relation(auth_ctx, "reader", group).await
+    }
+
+    async fn check_query(
+        &self,
+        auth_ctx: &AuthContext,
+        action: QueryAction,
+        query: &QueryAuthz,
+    ) -> bool {
+        if allow_query_action(auth_ctx, action, query, &self.operators) {
+            return true;
+        }
+        if matches!(action, QueryAction::Cancel) && !query.group.is_empty() {
+            return self
+                .check_relation(auth_ctx, "can_cancel", &query.group)
+                .await;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(user: &str) -> AuthContext {
+        AuthContext {
+            user: user.to_string(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        }
+    }
+
+    fn ctx_ops(user: &str, roles: &[&str], groups: &[&str]) -> AuthContext {
+        AuthContext {
+            user: user.to_string(),
+            groups: groups.iter().map(|s| s.to_string()).collect(),
+            roles: roles.iter().map(|s| s.to_string()).collect(),
+            raw_token: None,
+        }
+    }
+
+    fn q(owner: &str) -> QueryAuthz {
+        QueryAuthz {
+            submitted_by: owner.to_string(),
+            group: "g1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn owner_can_poll_and_cancel() {
+        let authz = AllowAllAuthorization::default();
+        let alice = ctx("alice");
+        assert!(
+            authz
+                .check_query(&alice, QueryAction::Poll, &q("alice"))
+                .await
         );
+        assert!(
+            authz
+                .check_query(&alice, QueryAction::Cancel, &q("alice"))
+                .await
+        );
+        assert!(
+            authz
+                .check_query(&alice, QueryAction::Dequeue, &q("alice"))
+                .await
+        );
+    }
 
-        let body = CheckRequest {
-            tuple_key: TupleKey {
-                user: format!("user:{}", auth_ctx.user),
-                relation: "reader".to_string(),
-                object: format!("cluster_group:{group}"),
-            },
-        };
+    #[tokio::test]
+    async fn other_user_cannot_poll_or_cancel() {
+        let authz = AllowAllAuthorization::default();
+        let bob = ctx("bob");
+        assert!(
+            !authz
+                .check_query(&bob, QueryAction::Poll, &q("alice"))
+                .await
+        );
+        assert!(
+            !authz
+                .check_query(&bob, QueryAction::Dequeue, &q("alice"))
+                .await
+        );
+        assert!(
+            !authz
+                .check_query(&bob, QueryAction::Cancel, &q("alice"))
+                .await
+        );
+    }
 
-        let mut req = self.http_client.post(&url).json(&body);
-        if let Some(token) = self.bearer_token().await {
-            req = req.bearer_auth(token);
-        }
+    #[tokio::test]
+    async fn operator_role_can_cancel_but_not_poll() {
+        let authz = AllowAllAuthorization::with_operators(OperatorPolicy::from_lists(
+            vec!["queryflux-operator".into()],
+            vec![],
+        ));
+        let ops = ctx_ops("oncall", &["queryflux-operator"], &[]);
+        assert!(
+            authz
+                .check_query(&ops, QueryAction::Cancel, &q("alice"))
+                .await
+        );
+        assert!(
+            !authz
+                .check_query(&ops, QueryAction::Poll, &q("alice"))
+                .await
+        );
+        assert!(
+            !authz
+                .check_query(&ops, QueryAction::Dequeue, &q("alice"))
+                .await
+        );
+    }
 
-        match req.send().await {
-            Ok(resp) if resp.status().is_success() => match resp.json::<CheckResponse>().await {
-                Ok(r) => {
-                    if !r.allowed {
-                        warn!(user = %auth_ctx.user, group, "OpenFGA: access denied");
-                    }
-                    r.allowed
-                }
-                Err(e) => {
-                    warn!(error = %e, "OpenFGA: failed to parse check response — denying");
-                    false
-                }
-            },
-            Ok(resp) => {
-                warn!(status = %resp.status(), user = %auth_ctx.user, group, "OpenFGA: check returned error status — denying");
-                false
-            }
-            Err(e) => {
-                warn!(error = %e, "OpenFGA: check request failed — denying");
-                false
-            }
-        }
+    #[tokio::test]
+    async fn operator_group_can_cancel() {
+        let authz = AllowAllAuthorization::with_operators(OperatorPolicy::from_lists(
+            vec![],
+            vec!["platform-ops".into()],
+        ));
+        let ops = ctx_ops("oncall", &[], &["platform-ops"]);
+        assert!(
+            authz
+                .check_query(&ops, QueryAction::Cancel, &q("alice"))
+                .await
+        );
+    }
+
+    #[test]
+    fn legacy_empty_owner_is_owner() {
+        assert!(is_query_owner(&ctx("alice"), ""));
+        assert!(is_query_owner(&ctx("anonymous"), "anonymous"));
+        assert!(!is_query_owner(&ctx("bob"), "alice"));
     }
 }

--- a/crates/queryflux-auth/src/authorization.rs
+++ b/crates/queryflux-auth/src/authorization.rs
@@ -57,6 +57,10 @@ fn is_anonymous(user: &str) -> bool {
 /// cannot be distinguished and are allowed.
 pub fn is_query_owner(auth: &AuthContext, submitted_by: &str) -> bool {
     if submitted_by.is_empty() {
+        warn!(
+            user = %auth.user,
+            "Query has no recorded owner — allowing action (legacy compatibility)"
+        );
         return true;
     }
     if is_anonymous(&auth.user) && is_anonymous(submitted_by) {
@@ -91,8 +95,6 @@ pub trait AuthorizationChecker: Send + Sync {
     async fn check(&self, auth_ctx: &AuthContext, group: &str) -> bool;
 
     /// Returns `true` if `auth_ctx` may perform `action` on `query`.
-    ///
-    /// Default: owner for all actions; operators may cancel.
     async fn check_query(
         &self,
         auth_ctx: &AuthContext,

--- a/crates/queryflux-auth/src/credentials.rs
+++ b/crates/queryflux-auth/src/credentials.rs
@@ -36,6 +36,35 @@ pub struct AuthContext {
     pub raw_token: Option<String>,
 }
 
+/// Reject poll/cancel/dequeue when the caller is not the query owner.
+///
+/// - Empty `submitted_by` (legacy in-flight rows) is allowed so a rolling
+///   deploy does not brick queries persisted before this field existed.
+/// - Two anonymous identities cannot be distinguished and are allowed
+///   (network-trust / `auth.provider: none` with no username).
+/// - Otherwise the authenticated user must equal `submitted_by`.
+pub fn require_query_owner(
+    auth: &AuthContext,
+    submitted_by: &str,
+) -> queryflux_core::error::Result<()> {
+    if submitted_by.is_empty() {
+        return Ok(());
+    }
+    if is_anonymous(&auth.user) && is_anonymous(submitted_by) {
+        return Ok(());
+    }
+    if auth.user != submitted_by {
+        return Err(queryflux_core::error::QueryFluxError::Unauthorized(
+            "query belongs to a different user".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_anonymous(user: &str) -> bool {
+    user.is_empty() || user == "anonymous"
+}
+
 /// Resolved wire credentials for a specific backend query execution.
 ///
 /// Produced by `BackendIdentityResolver` from `(AuthContext, queryAuth config)`.
@@ -69,4 +98,53 @@ pub enum QueryCredentials {
     /// The adapter sets `Authorization: Bearer <token>` on the outgoing request.
     /// Used by `tokenExchange` mode (Phase 6 — Snowflake, Databricks).
     Bearer { token: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(user: &str) -> AuthContext {
+        AuthContext {
+            user: user.to_string(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        }
+    }
+
+    #[test]
+    fn owner_matches() {
+        assert!(require_query_owner(&ctx("alice"), "alice").is_ok());
+    }
+
+    #[test]
+    fn different_user_denied() {
+        let err = require_query_owner(&ctx("bob"), "alice").unwrap_err();
+        assert!(matches!(
+            err,
+            queryflux_core::error::QueryFluxError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn anonymous_cannot_access_named_owner() {
+        assert!(require_query_owner(&ctx("anonymous"), "alice").is_err());
+    }
+
+    #[test]
+    fn named_user_cannot_access_anonymous_query() {
+        assert!(require_query_owner(&ctx("alice"), "anonymous").is_err());
+    }
+
+    #[test]
+    fn both_anonymous_allowed() {
+        assert!(require_query_owner(&ctx("anonymous"), "anonymous").is_ok());
+    }
+
+    #[test]
+    fn legacy_empty_owner_allowed() {
+        assert!(require_query_owner(&ctx("alice"), "").is_ok());
+        assert!(require_query_owner(&ctx("anonymous"), "").is_ok());
+    }
 }

--- a/crates/queryflux-auth/src/credentials.rs
+++ b/crates/queryflux-auth/src/credentials.rs
@@ -1,4 +1,7 @@
+use queryflux_core::error::{QueryFluxError, Result};
 use serde::{Deserialize, Serialize};
+
+use crate::authorization::is_query_owner;
 
 /// Raw credential material extracted from the frontend protocol before any verification.
 ///
@@ -43,26 +46,14 @@ pub struct AuthContext {
 /// - Two anonymous identities cannot be distinguished and are allowed
 ///   (network-trust / `auth.provider: none` with no username).
 /// - Otherwise the authenticated user must equal `submitted_by`.
-pub fn require_query_owner(
-    auth: &AuthContext,
-    submitted_by: &str,
-) -> queryflux_core::error::Result<()> {
-    if submitted_by.is_empty() {
-        return Ok(());
-    }
-    if is_anonymous(&auth.user) && is_anonymous(submitted_by) {
-        return Ok(());
-    }
-    if auth.user != submitted_by {
-        return Err(queryflux_core::error::QueryFluxError::Unauthorized(
+pub fn require_query_owner(auth: &AuthContext, submitted_by: &str) -> Result<()> {
+    if is_query_owner(auth, submitted_by) {
+        Ok(())
+    } else {
+        Err(QueryFluxError::Unauthorized(
             "query belongs to a different user".to_string(),
-        ));
+        ))
     }
-    Ok(())
-}
-
-fn is_anonymous(user: &str) -> bool {
-    user.is_empty() || user == "anonymous"
 }
 
 /// Resolved wire credentials for a specific backend query execution.

--- a/crates/queryflux-auth/src/lib.rs
+++ b/crates/queryflux-auth/src/lib.rs
@@ -7,10 +7,10 @@ pub mod resolver;
 
 pub use admin_credentials::AdminCredentialsManager;
 pub use authorization::{
-    AllowAllAuthorization, AuthorizationChecker, OpenFgaAuthorizationClient,
-    SimpleAuthorizationPolicy,
+    allow_query_action, is_query_owner, AllowAllAuthorization, AuthorizationChecker,
+    OpenFgaAuthorizationClient, OperatorPolicy, QueryAction, QueryAuthz, SimpleAuthorizationPolicy,
 };
-pub use credentials::{AuthContext, Credentials, QueryCredentials};
+pub use credentials::{require_query_owner, AuthContext, Credentials, QueryCredentials};
 pub use ldap::LdapAuthProvider;
 pub use provider::{AuthProvider, NoneAuthProvider, OidcAuthProvider, StaticAuthProvider};
 pub use resolver::BackendIdentityResolver;

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -308,6 +308,12 @@ pub struct AuthConfig {
     pub ldap: Option<LdapConfig>,
     #[serde(default)]
     pub static_users: Option<StaticUsersConfig>,
+    /// IdP roles that may cancel any in-flight or queued query (not poll).
+    #[serde(default)]
+    pub operator_roles: Vec<String>,
+    /// IdP groups that may cancel any in-flight or queued query (not poll).
+    #[serde(default)]
+    pub operator_groups: Vec<String>,
 }
 
 impl Default for AuthConfig {
@@ -318,6 +324,8 @@ impl Default for AuthConfig {
             oidc: None,
             ldap: None,
             static_users: None,
+            operator_roles: Vec::new(),
+            operator_groups: Vec::new(),
         }
     }
 }

--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -281,6 +281,11 @@ pub struct ExecutingQuery {
     /// True when a guard blocked this query at submit time.
     #[serde(default)]
     pub was_guard_blocked: bool,
+    /// Authenticated user who submitted the query. Used to reject poll/cancel
+    /// from a different subject (IDOR). Empty on rows written before this field
+    /// existed — those are treated as legacy and not ownership-checked.
+    #[serde(default)]
+    pub submitted_by: String,
 }
 
 // --- Query execution result model ---
@@ -297,6 +302,10 @@ pub struct QueuedQuery {
     pub last_accessed: DateTime<Utc>,
     /// How many times the client has polled. Used for exponential backoff.
     pub sequence: u64,
+    /// Authenticated user who enqueued the query. Dequeue/poll must match.
+    /// Empty on legacy rows — not ownership-checked.
+    #[serde(default)]
+    pub submitted_by: String,
 }
 
 /// Returned by `AsyncAdapter::submit_query`.
@@ -388,4 +397,41 @@ pub enum QueryStatus {
     Success,
     Failed,
     Cancelled,
+}
+
+#[cfg(test)]
+mod submitted_by_serde_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn executing_query_missing_submitted_by_defaults_empty() {
+        let v = json!({
+            "id": "p1",
+            "sql": "SELECT 1",
+            "cluster_group": "g",
+            "cluster_name": "c",
+            "backend_query_id": "b1",
+            "creation_time": "2026-01-01T00:00:00Z",
+            "last_accessed": "2026-01-01T00:00:00Z"
+        });
+        let q: ExecutingQuery = serde_json::from_value(v).expect("legacy executing row");
+        assert!(q.submitted_by.is_empty());
+    }
+
+    #[test]
+    fn queued_query_missing_submitted_by_defaults_empty() {
+        let mut v = json!({
+            "id": "p1",
+            "sql": "SELECT 1",
+            "frontend_protocol": "trinoHttp",
+            "cluster_group": "g",
+            "creation_time": "2026-01-01T00:00:00Z",
+            "last_accessed": "2026-01-01T00:00:00Z",
+            "sequence": 0
+        });
+        v["session"] = serde_json::to_value(SessionContext::default()).unwrap();
+        let q: QueuedQuery = serde_json::from_value(v).expect("legacy queued row");
+        assert!(q.submitted_by.is_empty());
+    }
 }

--- a/crates/queryflux-core/src/security_setting.rs
+++ b/crates/queryflux-core/src/security_setting.rs
@@ -47,6 +47,8 @@ pub fn parse_security_setting(v: &Value) -> (Option<AuthConfig>, Option<Authoriz
             "oidc": camelize_value(v.get("oidc").unwrap_or(&Value::Null)),
             "ldap": camelize_value(v.get("ldap").unwrap_or(&Value::Null)),
             "staticUsers": normalize_static_users(v.get("static_users").or_else(|| v.get("staticUsers")).unwrap_or(&Value::Null)),
+            "operatorRoles": json_string_array(v, "operator_roles", "operatorRoles"),
+            "operatorGroups": json_string_array(v, "operator_groups", "operatorGroups"),
         }))
         .ok()
     } else {
@@ -226,6 +228,13 @@ fn merge_openfga_secrets(incoming: &mut Value, prev: &Value) {
     }
 }
 
+fn json_string_array(v: &Value, snake: &str, camel: &str) -> Value {
+    match v.get(snake).or_else(|| v.get(camel)) {
+        Some(x) if x.is_array() => x.clone(),
+        _ => json!([]),
+    }
+}
+
 fn snake_to_camel(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut up = false;
@@ -362,5 +371,49 @@ mod tests {
         let (auth, authz) = parse_security_setting(&json!({ "something": "else" }));
         assert!(auth.is_none());
         assert!(authz.is_none());
+    }
+
+    #[test]
+    fn operator_lists_parse() {
+        let v = json!({
+            "auth_provider": "none",
+            "auth_required": true,
+            "authorization_provider": "none",
+            "operator_roles": ["queryflux-operator"],
+            "operator_groups": ["platform-ops"],
+        });
+        let (auth, _) = parse_security_setting(&v);
+        let auth = auth.expect("auth section should parse");
+        assert_eq!(auth.operator_roles, vec!["queryflux-operator"]);
+        assert_eq!(auth.operator_groups, vec!["platform-ops"]);
+    }
+
+    #[test]
+    fn null_operator_lists_default_empty() {
+        let v = json!({
+            "auth_provider": "none",
+            "auth_required": false,
+            "authorization_provider": "none",
+            "operator_roles": null,
+            "operator_groups": null,
+        });
+        let (auth, _) = parse_security_setting(&v);
+        let auth = auth.expect("null operator lists must not fail parse");
+        assert!(auth.operator_roles.is_empty());
+        assert!(auth.operator_groups.is_empty());
+    }
+
+    #[test]
+    fn operator_lists_parse_camel_case_typed_input() {
+        let v = json!({
+            "provider": "none",
+            "required": true,
+            "operatorRoles": ["queryflux-operator"],
+            "operatorGroups": ["platform-ops"],
+        });
+        let (auth, _) = parse_security_setting(&v);
+        let auth = auth.expect("camelCase operator lists should parse");
+        assert_eq!(auth.operator_roles, vec!["queryflux-operator"]);
+        assert_eq!(auth.operator_groups, vec!["platform-ops"]);
     }
 }

--- a/crates/queryflux-core/src/session.rs
+++ b/crates/queryflux-core/src/session.rs
@@ -297,8 +297,8 @@ mod tests {
             ],
         )
         .without_auth_headers();
-        assert!(s.extra.get("authorization").is_none());
-        assert!(s.extra.get("proxy-authorization").is_none());
+        assert!(!s.extra.contains_key("authorization"));
+        assert!(!s.extra.contains_key("proxy-authorization"));
         assert_eq!(
             s.extra.get("x-trino-catalog").map(String::as_str),
             Some("hive")

--- a/crates/queryflux-core/src/session.rs
+++ b/crates/queryflux-core/src/session.rs
@@ -195,6 +195,16 @@ impl SessionContext {
             .or_else(|| self.extra.get("client_name"))
             .map(|s| s.as_str())
     }
+
+    /// Drop hop-by-hop credentials so they are not persisted on queued/executing rows.
+    ///
+    /// Client `Authorization` must not be stored in Postgres JSON or replayed onto
+    /// a later poller's backend request.
+    pub fn without_auth_headers(mut self) -> Self {
+        self.extra.remove("authorization");
+        self.extra.remove("proxy-authorization");
+        self
+    }
 }
 
 #[cfg(test)]
@@ -273,6 +283,27 @@ mod tests {
         // SessionContext itself does no case folding.
         let s = session(None, None, &[("X-Trino-Source", "app")]);
         assert_eq!(s.client_source(), None); // uppercase key is not matched
+    }
+
+    #[test]
+    fn without_auth_headers_strips_credentials_keeps_session() {
+        let s = session(
+            Some("alice"),
+            Some("tpch"),
+            &[
+                ("authorization", "Bearer stolen"),
+                ("proxy-authorization", "Basic abc"),
+                ("x-trino-catalog", "hive"),
+            ],
+        )
+        .without_auth_headers();
+        assert!(s.extra.get("authorization").is_none());
+        assert!(s.extra.get("proxy-authorization").is_none());
+        assert_eq!(
+            s.extra.get("x-trino-catalog").map(String::as_str),
+            Some("hive")
+        );
+        assert_eq!(s.user(), Some("alice"));
     }
 
     #[test]

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -330,7 +330,8 @@ impl TestHarness {
             group_default_tags: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
-            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
         };
         let records = Arc::new(Mutex::new(Vec::<QueryRecord>::new()));
         let state = Arc::new(AppState {
@@ -568,7 +569,8 @@ impl WireTestHarness {
             group_default_tags: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
-            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
         };
 
         let state = Arc::new(AppState {
@@ -701,7 +703,8 @@ impl WireTestHarness {
             group_default_tags: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
-            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
         };
 
         let state = Arc::new(AppState {

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1053,6 +1053,50 @@ fn sql_preview(sql: &str) -> String {
     }
 }
 
+/// Build the admin "running queries" response from persistence.
+async fn collect_running_queries(
+    persistence: &dyn queryflux_persistence::Persistence,
+) -> queryflux_core::error::Result<Vec<RunningQueryDto>> {
+    let mut out = Vec::new();
+    for q in persistence.list_all().await? {
+        out.push(RunningQueryDto {
+            id: q.id.0,
+            backend_query_id: Some(q.backend_query_id.0),
+            submitted_by: q.submitted_by,
+            group: q.cluster_group.0,
+            cluster: Some(q.cluster_name.0),
+            sql_preview: sql_preview(&q.sql),
+            state: "executing".to_string(),
+        });
+    }
+    for q in persistence.list_queued().await? {
+        out.push(RunningQueryDto {
+            id: q.id.0,
+            backend_query_id: None,
+            submitted_by: q.submitted_by,
+            group: q.cluster_group.0,
+            cluster: None,
+            sql_preview: sql_preview(&q.sql),
+            state: "queued".to_string(),
+        });
+    }
+    Ok(out)
+}
+
+/// Admin cancel path for a queued query (claim release handled by caller).
+async fn delete_queued_if_exists(
+    persistence: &dyn queryflux_persistence::Persistence,
+    id: &str,
+) -> queryflux_core::error::Result<bool> {
+    let qid = ProxyQueryId(id.to_string());
+    if persistence.get_queued(&qid).await?.is_some() {
+        persistence.delete_queued(&qid).await?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 /// In-flight executing + queued queries (not history).
 #[utoipa::path(
     get,
@@ -1064,44 +1108,10 @@ fn sql_preview(sql: &str) -> String {
     )
 )]
 async fn list_running_queries_handler(State(state): State<Arc<AdminState>>) -> impl IntoResponse {
-    let mut out = Vec::new();
-    match state.app.persistence.list_all().await {
-        Ok(rows) => {
-            for q in rows {
-                out.push(RunningQueryDto {
-                    id: q.id.0,
-                    backend_query_id: Some(q.backend_query_id.0),
-                    submitted_by: q.submitted_by,
-                    group: q.cluster_group.0,
-                    cluster: Some(q.cluster_name.0),
-                    sql_preview: sql_preview(&q.sql),
-                    state: "executing".to_string(),
-                });
-            }
-        }
-        Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
+    match collect_running_queries(state.app.persistence.as_ref()).await {
+        Ok(out) => Json(out).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
-    match state.app.persistence.list_queued().await {
-        Ok(rows) => {
-            for q in rows {
-                out.push(RunningQueryDto {
-                    id: q.id.0,
-                    backend_query_id: None,
-                    submitted_by: q.submitted_by,
-                    group: q.cluster_group.0,
-                    cluster: None,
-                    sql_preview: sql_preview(&q.sql),
-                    state: "queued".to_string(),
-                });
-            }
-        }
-        Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    }
-    Json(out).into_response()
 }
 
 /// Cancel any in-flight or queued query. Admin Basic auth is the privilege.
@@ -1141,18 +1151,15 @@ async fn cancel_query_handler(
     }
 
     let qid = ProxyQueryId(id.clone());
-    match persistence.get_queued(&qid).await {
-        Ok(Some(queued)) => {
+    match delete_queued_if_exists(persistence.as_ref(), &id).await {
+        Ok(true) => {
             if let Some(qc) = &state.app.queue_coordinator {
-                let _ = qc.release_claim(&queued.id.0).await;
+                let _ = qc.release_claim(&qid.0).await;
             }
-            if let Err(e) = persistence.delete_queued(&qid).await {
-                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-            }
-            info!(id = %qid, owner = %queued.submitted_by, "Admin cancelled queued query");
+            info!(id = %qid, "Admin cancelled queued query");
             StatusCode::NO_CONTENT.into_response()
         }
-        Ok(None) => (StatusCode::NOT_FOUND, "query not found").into_response(),
+        Ok(false) => (StatusCode::NOT_FOUND, "query not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }
@@ -2626,12 +2633,23 @@ async fn invalidate_group_cache_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::{GuardrailsConfigDto, SecurityConfigDto};
+    use super::{
+        collect_running_queries, delete_queued_if_exists, sql_preview, GuardrailsConfigDto,
+        SecurityConfigDto,
+    };
+    use chrono::Utc;
     use queryflux_core::config::{
         AuthConfig, AuthProviderConfig, AuthorizationConfig, StaticUserEntry, StaticUsersConfig,
     };
+    use queryflux_core::query::{
+        BackendQueryId, ClusterGroupName, ClusterName, ExecutingQuery, FrontendProtocol,
+        ProxyQueryId, QueuedQuery,
+    };
+    use queryflux_core::session::SessionContext;
+    use queryflux_persistence::{in_memory::InMemoryPersistence, Persistence};
     use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn security_config_dto_omits_static_user_passwords() {
@@ -2658,6 +2676,102 @@ mod tests {
         assert_eq!(dto.static_user_summaries.len(), 1);
         assert_eq!(dto.static_user_summaries[0].username, "alice");
         assert_eq!(dto.static_user_summaries[0].groups, vec!["analytics"]);
+    }
+
+    #[test]
+    fn sql_preview_truncates_to_160_chars() {
+        let long = "word ".repeat(50);
+        let preview = sql_preview(&long);
+        assert!(preview.chars().count() <= 160);
+        assert!(preview.ends_with('…'));
+    }
+
+    #[test]
+    fn sql_preview_collapses_whitespace() {
+        assert_eq!(sql_preview("SELECT   1\nFROM  t"), "SELECT 1 FROM t");
+    }
+
+    #[tokio::test]
+    async fn collect_running_queries_includes_executing_and_queued() {
+        let store = Arc::new(InMemoryPersistence::new());
+        let now = Utc::now();
+        store
+            .upsert(ExecutingQuery {
+                id: ProxyQueryId("exec-1".into()),
+                sql: "SELECT 1".into(),
+                translated_sql: None,
+                cluster_group: ClusterGroupName("analytics".into()),
+                cluster_name: ClusterName("trino".into()),
+                cluster_group_config_id: None,
+                cluster_config_id: None,
+                backend_query_id: BackendQueryId("backend-1".into()),
+                poll_base_url: None,
+                creation_time: now,
+                last_accessed: now,
+                query_tags: Default::default(),
+                agent_context: None,
+                submitted_guard_actions: vec![],
+                was_guard_blocked: false,
+                submitted_by: "alice".into(),
+            })
+            .await
+            .unwrap();
+        store
+            .upsert_queued(QueuedQuery {
+                id: ProxyQueryId("queued-1".into()),
+                sql: "SELECT 2".into(),
+                session: SessionContext::default(),
+                frontend_protocol: FrontendProtocol::TrinoHttp,
+                cluster_group: ClusterGroupName("analytics".into()),
+                creation_time: now,
+                last_accessed: now,
+                sequence: 0,
+                submitted_by: "bob".into(),
+            })
+            .await
+            .unwrap();
+
+        let rows = collect_running_queries(store.as_ref()).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        let exec = rows.iter().find(|r| r.id == "exec-1").unwrap();
+        assert_eq!(exec.state, "executing");
+        assert_eq!(exec.submitted_by, "alice");
+        assert_eq!(exec.backend_query_id.as_deref(), Some("backend-1"));
+        let queued = rows.iter().find(|r| r.id == "queued-1").unwrap();
+        assert_eq!(queued.state, "queued");
+        assert_eq!(queued.submitted_by, "bob");
+        assert!(queued.backend_query_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_queued_if_exists_removes_row() {
+        let store = Arc::new(InMemoryPersistence::new());
+        store
+            .upsert_queued(QueuedQuery {
+                id: ProxyQueryId("q-cancel".into()),
+                sql: "SELECT 1".into(),
+                session: SessionContext::default(),
+                frontend_protocol: FrontendProtocol::TrinoHttp,
+                cluster_group: ClusterGroupName("g".into()),
+                creation_time: Utc::now(),
+                last_accessed: Utc::now(),
+                sequence: 0,
+                submitted_by: "alice".into(),
+            })
+            .await
+            .unwrap();
+
+        assert!(delete_queued_if_exists(store.as_ref(), "q-cancel")
+            .await
+            .unwrap());
+        assert!(store
+            .get_queued(&ProxyQueryId("q-cancel".into()))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(!delete_queued_if_exists(store.as_ref(), "missing")
+            .await
+            .unwrap());
     }
 
     #[test]

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -17,7 +17,7 @@ use queryflux_core::{
     },
     engine_registry::EngineRegistry,
     error::{QueryFluxError, Result},
-    query::{BackendQueryId, ClusterGroupName, ClusterName, ProxyQueryId},
+    query::{BackendQueryId, ClusterGroupName, ClusterName, ExecutingQuery, ProxyQueryId},
 };
 use queryflux_metrics::prometheus_store::PrometheusMetrics;
 use queryflux_persistence::{
@@ -1097,6 +1097,20 @@ async fn delete_queued_if_exists(
     }
 }
 
+async fn find_executing_query(
+    persistence: &dyn queryflux_persistence::Persistence,
+    id: &str,
+) -> queryflux_core::error::Result<Option<ExecutingQuery>> {
+    if let Some(q) = persistence.get(&BackendQueryId(id.to_string())).await? {
+        return Ok(Some(q));
+    }
+    Ok(persistence
+        .list_all()
+        .await?
+        .into_iter()
+        .find(|q| q.id.0 == id))
+}
+
 /// In-flight executing + queued queries (not history).
 #[utoipa::path(
     get,
@@ -1132,19 +1146,9 @@ async fn cancel_query_handler(
 ) -> impl IntoResponse {
     let persistence = &state.app.persistence;
 
-    match persistence.get(&BackendQueryId(id.clone())).await {
+    match find_executing_query(persistence.as_ref(), &id).await {
         Ok(Some(executing)) => return cancel_executing(&state, executing).await,
         Ok(None) => {}
-        Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
-        }
-    }
-    match persistence.list_all().await {
-        Ok(all) => {
-            if let Some(executing) = all.into_iter().find(|q| q.id.0 == id) {
-                return cancel_executing(&state, executing).await;
-            }
-        }
         Err(e) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
@@ -1153,13 +1157,29 @@ async fn cancel_query_handler(
     let qid = ProxyQueryId(id.clone());
     match delete_queued_if_exists(persistence.as_ref(), &id).await {
         Ok(true) => {
+            // A worker may have claimed and started executing between the first
+            // lookup and this delete. Cancel that path too.
+            match find_executing_query(persistence.as_ref(), &id).await {
+                Ok(Some(executing)) => return cancel_executing(&state, executing).await,
+                Ok(None) => {}
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+                }
+            }
             if let Some(qc) = &state.app.queue_coordinator {
                 let _ = qc.release_claim(&qid.0).await;
             }
             info!(id = %qid, "Admin cancelled queued query");
             StatusCode::NO_CONTENT.into_response()
         }
-        Ok(false) => (StatusCode::NOT_FOUND, "query not found").into_response(),
+        Ok(false) => {
+            // Claimed and moved to executing after the first lookup.
+            match find_executing_query(persistence.as_ref(), &id).await {
+                Ok(Some(executing)) => cancel_executing(&state, executing).await,
+                Ok(None) => (StatusCode::NOT_FOUND, "query not found").into_response(),
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+            }
+        }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1047,7 +1047,7 @@ pub struct RunningQueryDto {
 fn sql_preview(sql: &str) -> String {
     let t = sql.split_whitespace().collect::<Vec<_>>().join(" ");
     if t.chars().count() > 160 {
-        format!("{}…", t.chars().take(160).collect::<String>())
+        format!("{}…", t.chars().take(159).collect::<String>())
     } else {
         t
     }
@@ -1122,12 +1122,21 @@ async fn cancel_query_handler(
 ) -> impl IntoResponse {
     let persistence = &state.app.persistence;
 
-    if let Ok(Some(executing)) = persistence.get(&BackendQueryId(id.clone())).await {
-        return cancel_executing(&state, executing).await;
+    match persistence.get(&BackendQueryId(id.clone())).await {
+        Ok(Some(executing)) => return cancel_executing(&state, executing).await,
+        Ok(None) => {}
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
     }
-    if let Ok(all) = persistence.list_all().await {
-        if let Some(executing) = all.into_iter().find(|q| q.id.0 == id) {
-            return cancel_executing(&state, executing).await;
+    match persistence.list_all().await {
+        Ok(all) => {
+            if let Some(executing) = all.into_iter().find(|q| q.id.0 == id) {
+                return cancel_executing(&state, executing).await;
+            }
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
         }
     }
 
@@ -1152,16 +1161,20 @@ async fn cancel_executing(
     state: &AdminState,
     executing: queryflux_core::query::ExecutingQuery,
 ) -> Response {
+    let mut cancelled = false;
     if let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await {
         if let Some(async_adapter) = adapter.as_async() {
-            if let Err(e) = async_adapter
+            if async_adapter
                 .cancel_query(&executing.backend_query_id)
                 .await
+                .is_ok()
             {
+                cancelled = true;
+            } else {
                 warn!(
                     id = %executing.id,
                     backend = %executing.backend_query_id,
-                    "Admin adapter cancel failed: {e}"
+                    "Admin adapter cancel failed"
                 );
             }
         }
@@ -1172,7 +1185,22 @@ async fn cancel_executing(
             base.trim_end_matches('/'),
             executing.backend_query_id.0
         );
-        let _ = state.app.http_client.delete(&url).send().await;
+        match state.app.http_client.delete(&url).send().await {
+            Ok(resp) if resp.status().is_success() => cancelled = true,
+            Ok(resp) => warn!(
+                id = %executing.id,
+                status = %resp.status(),
+                "Admin HTTP cancel returned non-success"
+            ),
+            Err(e) => warn!(id = %executing.id, "Admin HTTP cancel failed: {e}"),
+        }
+    }
+    if !cancelled {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to cancel query on backend",
+        )
+            .into_response();
     }
     state
         .app

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -17,7 +17,7 @@ use queryflux_core::{
     },
     engine_registry::EngineRegistry,
     error::{QueryFluxError, Result},
-    query::{ClusterGroupName, ClusterName},
+    query::{BackendQueryId, ClusterGroupName, ClusterName, ProxyQueryId},
 };
 use queryflux_metrics::prometheus_store::PrometheusMetrics;
 use queryflux_persistence::{
@@ -42,7 +42,10 @@ use utoipa::{OpenApi, ToSchema};
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::{state::LiveConfig, FrontendListenerTrait, ShutdownRx};
+use crate::{
+    state::{AppState, LiveConfig},
+    FrontendListenerTrait, ShutdownRx,
+};
 
 /// Callback type for testing a cluster config without persisting it.
 /// Receives `(engine_key, config_json)` → returns `Ok(true)` if healthy, `Ok(false)` if
@@ -87,6 +90,8 @@ pub struct ClusterStateDto {
         update_cluster_handler,
         engine_registry_handler,
         list_queries_handler,
+        list_running_queries_handler,
+        cancel_query_handler,
         get_stats_handler,
         list_engines_handler,
         get_engine_stats_handler,
@@ -127,6 +132,7 @@ pub struct ClusterStateDto {
         ClusterStateDto,
         ClusterUpdateRequest,
         QuerySummary,
+        RunningQueryDto,
         DashboardStats,
         EngineStatRow,
         GroupStatRow,
@@ -170,6 +176,12 @@ pub struct SecurityConfigDto {
     pub openfga: Option<OpenFgaConfigDto>,
     /// Per-cluster-group simple allow-lists (used when authorization_provider = "none").
     pub group_authorization: HashMap<String, GroupAuthzDto>,
+    /// IdP roles that may cancel any query.
+    #[serde(default)]
+    pub operator_roles: Vec<String>,
+    /// IdP groups that may cancel any query.
+    #[serde(default)]
+    pub operator_groups: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -225,6 +237,8 @@ impl Default for SecurityConfigDto {
             authorization_provider: "none".to_string(),
             openfga: None,
             group_authorization: HashMap::new(),
+            operator_roles: Vec::new(),
+            operator_groups: Vec::new(),
         }
     }
 }
@@ -442,6 +456,8 @@ impl SecurityConfigDto {
             authorization_provider,
             openfga,
             group_authorization,
+            operator_roles: auth.operator_roles.clone(),
+            operator_groups: auth.operator_groups.clone(),
         }
     }
 }
@@ -483,6 +499,10 @@ pub struct UpsertSecurityConfig {
     pub static_users: Option<serde_json::Value>,
     pub authorization_provider: String,
     pub openfga: Option<serde_json::Value>,
+    #[serde(default)]
+    pub operator_roles: Option<Vec<String>>,
+    #[serde(default)]
+    pub operator_groups: Option<Vec<String>>,
 }
 
 /// Request body for PUT /admin/config/routing
@@ -523,6 +543,8 @@ struct AdminState {
     test_cluster_fn: TestClusterFn,
     /// Query result cache for invalidation endpoints.
     result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
+    /// Shared proxy state — in-flight queries, adapters, slot release.
+    app: Arc<AppState>,
 }
 
 // ---------------------------------------------------------------------------
@@ -543,6 +565,7 @@ pub struct AdminFrontend {
     test_cluster_fn: TestClusterFn,
     cors_allowed_origins: Vec<String>,
     result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
+    app: Arc<AppState>,
 }
 
 impl AdminFrontend {
@@ -561,6 +584,7 @@ impl AdminFrontend {
         test_cluster_fn: TestClusterFn,
         cors_allowed_origins: Vec<String>,
         result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
+        app: Arc<AppState>,
     ) -> Self {
         Self {
             prometheus,
@@ -576,6 +600,7 @@ impl AdminFrontend {
             test_cluster_fn,
             cors_allowed_origins,
             result_cache,
+            app,
         }
     }
 
@@ -592,6 +617,7 @@ impl AdminFrontend {
             admin_creds: self.admin_creds.clone(),
             test_cluster_fn: self.test_cluster_fn.clone(),
             result_cache: self.result_cache.clone(),
+            app: self.app.clone(),
         });
 
         let spec_json =
@@ -621,6 +647,8 @@ impl AdminFrontend {
         let protected = Router::new()
             .route("/admin/clusters", get(clusters_handler))
             .route("/admin/queries", get(list_queries_handler))
+            .route("/admin/queries/running", get(list_running_queries_handler))
+            .route("/admin/queries/{id}", delete(cancel_query_handler))
             .route("/admin/agents", get(list_agents_handler))
             .route("/admin/conversations", get(list_conversations_handler))
             .route("/admin/conversations/{id}", get(get_conversation_handler))
@@ -1002,6 +1030,173 @@ async fn list_queries_handler(
         Ok(rows) => Json::<Vec<QuerySummary>>(rows).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RunningQueryDto {
+    pub id: String,
+    pub backend_query_id: Option<String>,
+    pub submitted_by: String,
+    pub group: String,
+    pub cluster: Option<String>,
+    pub sql_preview: String,
+    /// `executing` or `queued`
+    pub state: String,
+}
+
+fn sql_preview(sql: &str) -> String {
+    let t = sql.split_whitespace().collect::<Vec<_>>().join(" ");
+    if t.chars().count() > 160 {
+        format!("{}…", t.chars().take(160).collect::<String>())
+    } else {
+        t
+    }
+}
+
+/// In-flight executing + queued queries (not history).
+#[utoipa::path(
+    get,
+    path = "/admin/queries/running",
+    tag = "admin",
+    responses(
+        (status = 200, description = "In-flight queries", body = Vec<RunningQueryDto>),
+        (status = 500, description = "Internal error", body = str),
+    )
+)]
+async fn list_running_queries_handler(State(state): State<Arc<AdminState>>) -> impl IntoResponse {
+    let mut out = Vec::new();
+    match state.app.persistence.list_all().await {
+        Ok(rows) => {
+            for q in rows {
+                out.push(RunningQueryDto {
+                    id: q.id.0,
+                    backend_query_id: Some(q.backend_query_id.0),
+                    submitted_by: q.submitted_by,
+                    group: q.cluster_group.0,
+                    cluster: Some(q.cluster_name.0),
+                    sql_preview: sql_preview(&q.sql),
+                    state: "executing".to_string(),
+                });
+            }
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+    match state.app.persistence.list_queued().await {
+        Ok(rows) => {
+            for q in rows {
+                out.push(RunningQueryDto {
+                    id: q.id.0,
+                    backend_query_id: None,
+                    submitted_by: q.submitted_by,
+                    group: q.cluster_group.0,
+                    cluster: None,
+                    sql_preview: sql_preview(&q.sql),
+                    state: "queued".to_string(),
+                });
+            }
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    }
+    Json(out).into_response()
+}
+
+/// Cancel any in-flight or queued query. Admin Basic auth is the privilege.
+#[utoipa::path(
+    delete,
+    path = "/admin/queries/{id}",
+    tag = "admin",
+    params(("id" = String, Path, description = "Proxy query id or backend query id")),
+    responses(
+        (status = 204, description = "Cancelled"),
+        (status = 404, description = "Query not found", body = str),
+        (status = 500, description = "Internal error", body = str),
+    )
+)]
+async fn cancel_query_handler(
+    State(state): State<Arc<AdminState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let persistence = &state.app.persistence;
+
+    if let Ok(Some(executing)) = persistence.get(&BackendQueryId(id.clone())).await {
+        return cancel_executing(&state, executing).await;
+    }
+    if let Ok(all) = persistence.list_all().await {
+        if let Some(executing) = all.into_iter().find(|q| q.id.0 == id) {
+            return cancel_executing(&state, executing).await;
+        }
+    }
+
+    let qid = ProxyQueryId(id.clone());
+    match persistence.get_queued(&qid).await {
+        Ok(Some(queued)) => {
+            if let Some(qc) = &state.app.queue_coordinator {
+                let _ = qc.release_claim(&queued.id.0).await;
+            }
+            if let Err(e) = persistence.delete_queued(&qid).await {
+                return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            }
+            info!(id = %qid, owner = %queued.submitted_by, "Admin cancelled queued query");
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "query not found").into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+async fn cancel_executing(
+    state: &AdminState,
+    executing: queryflux_core::query::ExecutingQuery,
+) -> Response {
+    if let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await {
+        if let Some(async_adapter) = adapter.as_async() {
+            if let Err(e) = async_adapter
+                .cancel_query(&executing.backend_query_id)
+                .await
+            {
+                warn!(
+                    id = %executing.id,
+                    backend = %executing.backend_query_id,
+                    "Admin adapter cancel failed: {e}"
+                );
+            }
+        }
+    }
+    if let Some(base) = executing.poll_base_url.as_deref() {
+        let url = format!(
+            "{}/v1/statement/executing/{}/0",
+            base.trim_end_matches('/'),
+            executing.backend_query_id.0
+        );
+        let _ = state.app.http_client.delete(&url).send().await;
+    }
+    state
+        .app
+        .release_query_slot(
+            &executing.cluster_group,
+            &executing.cluster_name,
+            &executing.id.0,
+        )
+        .await;
+    if let Err(e) = state
+        .app
+        .persistence
+        .delete(&executing.backend_query_id)
+        .await
+    {
+        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    }
+    info!(
+        id = %executing.id,
+        backend = %executing.backend_query_id,
+        owner = %executing.submitted_by,
+        "Admin cancelled executing query"
+    );
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Distinct agents that have run queries, with aggregate stats.

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -181,6 +181,7 @@ pub async fn dispatch_query(
             already_queued,
             sequence,
             max_queued_queries,
+            auth_ctx,
         )
         .await?;
         return Ok(DispatchOutcome::Queued {
@@ -204,6 +205,7 @@ pub async fn dispatch_query(
                         already_queued,
                         sequence,
                         max_queued_queries,
+                        auth_ctx,
                     )
                     .await?;
                     return Ok(DispatchOutcome::Queued {
@@ -224,6 +226,7 @@ pub async fn dispatch_query(
                 already_queued,
                 sequence,
                 max_queued_queries,
+                auth_ctx,
             )
             .await?;
             return Ok(DispatchOutcome::Queued {
@@ -463,6 +466,7 @@ pub async fn dispatch_query(
                 agent_context: resolved_agent_ctx,
                 submitted_guard_actions,
                 was_guard_blocked: false,
+                submitted_by: auth_ctx.user.clone(),
             };
 
             match execution {
@@ -756,6 +760,7 @@ async fn persist_queued_query(
     _already_stored: bool,
     sequence: u64,
     max_queued_queries: Option<u64>,
+    auth_ctx: &AuthContext,
 ) -> Result<String> {
     // Enforce queue depth limit before admitting to the queue.
     if let Some(limit) = max_queued_queries {
@@ -781,12 +786,13 @@ async fn persist_queued_query(
     let queued = QueuedQuery {
         id: query_id.clone(),
         sql,
-        session,
+        session: session.without_auth_headers(),
         frontend_protocol: protocol,
         cluster_group: group,
         creation_time: now,
         last_accessed: now,
         sequence,
+        submitted_by: auth_ctx.user.clone(),
     };
     state.persistence.upsert_queued(queued).await?;
     let next_seq = sequence + 1;

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -331,7 +331,8 @@ pub mod test_fixtures {
             group_default_tags: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(auth_required)) as Arc<dyn AuthProvider>,
-            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
         };
         Arc::new(AppState {
             external_address: "http://127.0.0.1:8080".into(),

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use bytes::Bytes;
 use chrono::Utc;
-use queryflux_auth::Credentials;
+use queryflux_auth::{Credentials, QueryAction, QueryAuthz};
 use queryflux_core::{
     error::QueryFluxError,
     query::{BackendQueryId, FrontendProtocol, ProxyQueryId, QueryPollResult, QueryStatus},
@@ -73,6 +73,31 @@ impl Drop for QueueClaimHeartbeat {
             let _ = tx.send(());
         }
     }
+}
+
+async fn allow_query_action_or_forbid(
+    state: &AppState,
+    auth_ctx: &queryflux_auth::AuthContext,
+    action: QueryAction,
+    submitted_by: &str,
+    group: &str,
+) -> Option<Response<Body>> {
+    let authz = state.live.read().await.authorization.clone();
+    let query = QueryAuthz {
+        submitted_by: submitted_by.to_string(),
+        group: group.to_string(),
+    };
+    if authz.check_query(auth_ctx, action, &query).await {
+        return None;
+    }
+    warn!(
+        action = ?action,
+        user = %auth_ctx.user,
+        owner = %submitted_by,
+        group,
+        "Query action denied"
+    );
+    Some(StatusCode::FORBIDDEN.into_response())
 }
 
 fn trino_error_response(query_id: &str, message: &str) -> Response<Body> {
@@ -685,6 +710,29 @@ pub async fn get_queued_statement(
 
     let query_id = ProxyQueryId(id);
 
+    // Load first so we can reject a non-owner *before* taking a distributed
+    // claim (otherwise an attacker could pin the row for the claim TTL).
+    let queued = match state.persistence.get_queued(&query_id).await {
+        Ok(Some(q)) => q,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            warn!("Persistence error: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    if let Some(resp) = allow_query_action_or_forbid(
+        &state,
+        &auth_ctx,
+        QueryAction::Dequeue,
+        &queued.submitted_by,
+        &queued.cluster_group.0,
+    )
+    .await
+    {
+        return resp;
+    }
+
     // In distributed mode, try to claim ownership of this queued query so only
     // one replica dispatches it. If another replica already claimed it, return
     // a "still queued" response and let the client poll again.
@@ -769,15 +817,6 @@ pub async fn get_queued_statement(
         }
     }
     let _claim_heartbeat = claim_heartbeat;
-
-    let queued = match state.persistence.get_queued(&query_id).await {
-        Ok(Some(q)) => q,
-        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
-        Err(e) => {
-            warn!("Persistence error: {e}");
-            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    };
 
     if let Err(e) = state
         .persistence
@@ -942,13 +981,16 @@ pub async fn get_executing_statement(
         }
     };
 
-    // TODO: verify query ownership once submitter_user is stored in ExecutingQuery
-    if auth_ctx.user != "anonymous" {
-        tracing::debug!(
-            id = %executing.id,
-            poll_user = %auth_ctx.user,
-            "Authenticated poll request — ownership check deferred until submitter is persisted"
-        );
+    if let Some(resp) = allow_query_action_or_forbid(
+        &state,
+        &auth_ctx,
+        QueryAction::Poll,
+        &executing.submitted_by,
+        &executing.cluster_group.0,
+    )
+    .await
+    {
+        return resp;
     }
 
     let adapter = match state.adapter(&executing.cluster_name.0).await {
@@ -1256,13 +1298,16 @@ pub async fn delete_executing_statement(
         }
     };
 
-    // TODO: verify query ownership once submitter_user is stored in ExecutingQuery
-    if auth_ctx.user != "anonymous" {
-        tracing::debug!(
-            id = %executing.id,
-            cancel_user = %auth_ctx.user,
-            "Authenticated cancel request — ownership check deferred until submitter is persisted"
-        );
+    if let Some(resp) = allow_query_action_or_forbid(
+        &state,
+        &auth_ctx,
+        QueryAction::Cancel,
+        &executing.submitted_by,
+        &executing.cluster_group.0,
+    )
+    .await
+    {
+        return resp;
     }
 
     let Some(adapter) = state.adapter(&executing.cluster_name.0).await else {

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -100,6 +100,26 @@ async fn allow_query_action_or_forbid(
     Some(StatusCode::FORBIDDEN.into_response())
 }
 
+/// Restore backend auth stripped from persisted queued sessions.
+///
+/// Called only after the dequeue caller is verified as the query owner.
+fn session_for_queued_dispatch(
+    mut session: SessionContext,
+    headers: &HeaderMap,
+    auth_ctx: &queryflux_auth::AuthContext,
+) -> SessionContext {
+    if let Some(v) = headers.get("authorization").and_then(|h| h.to_str().ok()) {
+        session
+            .extra
+            .insert("authorization".to_string(), v.to_string());
+    } else if let Some(token) = &auth_ctx.raw_token {
+        session
+            .extra
+            .insert("authorization".to_string(), format!("Bearer {token}"));
+    }
+    session
+}
+
 fn trino_error_response(query_id: &str, message: &str) -> Response<Body> {
     let resp = queryflux_engine_adapters::trino::api::TrinoResponse {
         id: query_id.to_string(),
@@ -829,7 +849,7 @@ pub async fn get_queued_statement(
     queued_backoff_delay(seq).await;
 
     let sql = queued.sql.clone();
-    let session = queued.session.clone();
+    let session = session_for_queued_dispatch(queued.session.clone(), &headers, &auth_ctx);
     let protocol = queued.frontend_protocol.clone();
     let group = queued.cluster_group.clone();
 

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -863,6 +863,21 @@ pub async fn get_queued_statement(
         }
     };
 
+    // Admin cancel deletes the queued row. Abort if it disappeared after claim
+    // so dequeue cannot dispatch a query that already returned 204.
+    match state.persistence.get_queued(&query_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            release_claim(&state, &query_id.0).await;
+            return StatusCode::NOT_FOUND.into_response();
+        }
+        Err(e) => {
+            warn!("Persistence error re-checking queued query before dispatch: {e}");
+            release_claim(&state, &query_id.0).await;
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    }
+
     let use_cache_path = {
         let live = state.live.read().await;
         let caching_requested = live.group_cache_settings.contains_key(&group.0)

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1542,7 +1542,8 @@ mod cancel_executing_statement_tests {
             group_default_tags: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
-            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
         };
         Arc::new(AppState {
             external_address: "http://127.0.0.1:8080".into(),
@@ -1577,6 +1578,7 @@ mod cancel_executing_statement_tests {
             agent_context: None,
             submitted_guard_actions: vec![],
             was_guard_blocked: false,
+            submitted_by: "anonymous".into(),
         };
         state
             .persistence

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -1250,7 +1250,22 @@ mod tests {
             creation_time: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
             sequence: 0,
+            submitted_by: String::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn queued_submitted_by_survives_upsert() {
+        let store = InMemoryPersistence::new();
+        let mut q = make_queued("q-owner");
+        q.submitted_by = "alice".to_string();
+        store.upsert_queued(q).await.unwrap();
+        let got = store
+            .get_queued(&ProxyQueryId("q-owner".into()))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.submitted_by, "alice");
     }
 
     #[tokio::test]

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -2124,6 +2124,7 @@ mod tests {
             creation_time: chrono::Utc::now(),
             last_accessed: chrono::Utc::now(),
             sequence: 0,
+            submitted_by: String::new(),
         }
     }
 
@@ -2377,6 +2378,7 @@ mod tests {
             creation_time,
             last_accessed,
             sequence: 0,
+            submitted_by: String::new(),
         }
     }
 

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -614,7 +614,11 @@ async fn main() -> Result<()> {
     let router_chain = RouterChain::new(routers, fallback);
 
     let auth_provider = build_auth_provider(&config.auth)?;
-    let authorization = build_authorization(&config.authorization, &config.cluster_groups)?;
+    let authorization = build_authorization(
+        &config.authorization,
+        &config.cluster_groups,
+        operators_from_auth(&config.auth),
+    )?;
 
     // --- Production safety warnings ---
     if matches!(
@@ -972,6 +976,7 @@ async fn main() -> Result<()> {
         test_cluster_fn,
         cors_origins,
         app_state.result_cache.clone(),
+        app_state.clone(),
     );
 
     // --- Start Trino HTTP frontend ---
@@ -2252,7 +2257,7 @@ async fn build_live_config(
         group_default_tags,
         group_cache_settings,
         auth_provider: Arc::new(NoneAuthProvider::new(false)),
-        authorization: Arc::new(AllowAllAuthorization),
+        authorization: Arc::new(AllowAllAuthorization::default()),
     })
 }
 
@@ -2375,6 +2380,10 @@ async fn reload_live_config(
         Ok(Some(v)) => {
             let (auth_cfg, authz_cfg) =
                 queryflux_core::security_setting::parse_security_setting(&v);
+            let operators = auth_cfg
+                .as_ref()
+                .map(operators_from_auth)
+                .unwrap_or_default();
             match auth_cfg.map(|cfg| build_auth_provider(&cfg)) {
                 Some(Ok(provider)) => live.auth_provider = provider,
                 Some(Err(e)) => {
@@ -2384,7 +2393,7 @@ async fn reload_live_config(
                     "Reload: security_config has no recognizable auth section; keeping previous"
                 ),
             }
-            match authz_cfg.map(|cfg| build_authorization(&cfg, &cluster_groups)) {
+            match authz_cfg.map(|cfg| build_authorization(&cfg, &cluster_groups, operators)) {
                 Some(Ok(checker)) => live.authorization = checker,
                 Some(Err(e)) => {
                     tracing::warn!("Reload: failed to rebuild authorization; keeping previous: {e}")
@@ -2442,11 +2451,28 @@ fn build_auth_provider(
     })
 }
 
+fn operators_from_auth(
+    auth: &queryflux_core::config::AuthConfig,
+) -> queryflux_auth::OperatorPolicy {
+    queryflux_auth::OperatorPolicy::from_lists(
+        auth.operator_roles.clone(),
+        auth.operator_groups.clone(),
+    )
+}
+
 fn build_authorization(
     authz: &queryflux_core::config::AuthorizationConfig,
     cluster_groups: &HashMap<String, queryflux_core::config::ClusterGroupConfig>,
+    operators: queryflux_auth::OperatorPolicy,
 ) -> Result<Arc<dyn queryflux_auth::AuthorizationChecker>> {
     use queryflux_core::config::AuthorizationProviderConfig;
+    if !operators.roles.is_empty() || !operators.groups.is_empty() {
+        info!(
+            operator_roles = ?operators.roles,
+            operator_groups = ?operators.groups,
+            "Query operators configured (may cancel any query)"
+        );
+    }
     Ok(match &authz.provider {
         AuthorizationProviderConfig::None => {
             let policies = cluster_groups
@@ -2459,10 +2485,10 @@ fn build_authorization(
             });
             if has_any_policy {
                 info!("Authorization: simple allow-list policy");
-                Arc::new(SimpleAuthorizationPolicy::new(policies))
+                Arc::new(SimpleAuthorizationPolicy::new(policies).with_operators(operators))
             } else {
                 info!("Authorization: allow-all (no allow-lists configured)");
-                Arc::new(AllowAllAuthorization)
+                Arc::new(AllowAllAuthorization::with_operators(operators))
             }
         }
         AuthorizationProviderConfig::OpenFga => {
@@ -2470,7 +2496,7 @@ fn build_authorization(
                 "authorization.provider = openfga requires authorization.openfga to be configured",
             )?;
             info!(url = %openfga_cfg.url, store_id = %openfga_cfg.store_id, "Authorization: OpenFGA");
-            Arc::new(OpenFgaAuthorizationClient::new(openfga_cfg))
+            Arc::new(OpenFgaAuthorizationClient::new(openfga_cfg).with_operators(operators))
         }
     })
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -2380,11 +2380,7 @@ async fn reload_live_config(
         Ok(Some(v)) => {
             let (auth_cfg, authz_cfg) =
                 queryflux_core::security_setting::parse_security_setting(&v);
-            let operators = auth_cfg
-                .as_ref()
-                .map(operators_from_auth)
-                .unwrap_or_default();
-            match auth_cfg.map(|cfg| build_auth_provider(&cfg)) {
+            match auth_cfg.as_ref().map(|cfg| build_auth_provider(cfg)) {
                 Some(Ok(provider)) => live.auth_provider = provider,
                 Some(Err(e)) => {
                     tracing::warn!("Reload: failed to rebuild auth provider; keeping previous: {e}")
@@ -2393,14 +2389,28 @@ async fn reload_live_config(
                     "Reload: security_config has no recognizable auth section; keeping previous"
                 ),
             }
-            match authz_cfg.map(|cfg| build_authorization(&cfg, &cluster_groups, operators)) {
-                Some(Ok(checker)) => live.authorization = checker,
-                Some(Err(e)) => {
-                    tracing::warn!("Reload: failed to rebuild authorization; keeping previous: {e}")
+            match auth_cfg {
+                Some(auth) => {
+                    let operators = operators_from_auth(&auth);
+                    match authz_cfg.map(|cfg| build_authorization(&cfg, &cluster_groups, operators))
+                    {
+                        Some(Ok(checker)) => live.authorization = checker,
+                        Some(Err(e)) => {
+                            tracing::warn!(
+                                "Reload: failed to rebuild authorization; keeping previous: {e}"
+                            )
+                        }
+                        None => tracing::warn!(
+                            "Reload: security_config has no recognizable authorization section; keeping previous"
+                        ),
+                    }
                 }
-                None => tracing::warn!(
-                    "Reload: security_config has no recognizable authorization section; keeping previous"
-                ),
+                None if authz_cfg.is_some() => {
+                    tracing::warn!(
+                        "Reload: security_config has authorization but no auth section; keeping previous authorization (operator policy unchanged)"
+                    );
+                }
+                None => {}
             }
         }
         Ok(None) => {}

--- a/queryflux-studio/app/security/security-editor.tsx
+++ b/queryflux-studio/app/security/security-editor.tsx
@@ -324,6 +324,13 @@ export function SecurityEditor({ initialSecurity }: Props) {
     operator_groups: initialSecurity?.operator_groups ?? [],
   });
 
+  const [operatorRolesText, setOperatorRolesText] = useState(
+    () => (initialSecurity?.operator_roles ?? []).join(", "),
+  );
+  const [operatorGroupsText, setOperatorGroupsText] = useState(
+    () => (initialSecurity?.operator_groups ?? []).join(", "),
+  );
+
   const [securityForm, setSecurityForm] = useState<UpsertSecurityConfig>(initSecurityForm);
   const [securitySaving, setSecuritySaving] = useState(false);
   const [securityMsg, setSecurityMsg] = useState<{ text: string; ok: boolean } | null>(null);
@@ -353,7 +360,17 @@ export function SecurityEditor({ initialSecurity }: Props) {
     setSecuritySaving(true);
     setSecurityMsg(null);
     try {
-      await putSecurityConfig(securityForm);
+      await putSecurityConfig({
+        ...securityForm,
+        operator_roles: operatorRolesText
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        operator_groups: operatorGroupsText
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      });
       setSecurityMsg({ text: "Saved. The proxy reloads config automatically.", ok: true });
     } catch (e) {
       setSecurityMsg({ text: String(e), ok: false });
@@ -859,30 +876,14 @@ export function SecurityEditor({ initialSecurity }: Props) {
             <div className="grid grid-cols-2 gap-3">
               <TextInput
                 label="Operator roles (comma-separated)"
-                value={(securityForm.operator_roles ?? []).join(", ")}
-                onChange={(v) =>
-                  setSecurityForm((f) => ({
-                    ...f,
-                    operator_roles: v
-                      .split(",")
-                      .map((s) => s.trim())
-                      .filter(Boolean),
-                  }))
-                }
+                value={operatorRolesText}
+                onChange={setOperatorRolesText}
                 placeholder="queryflux-operator"
               />
               <TextInput
                 label="Operator groups (comma-separated)"
-                value={(securityForm.operator_groups ?? []).join(", ")}
-                onChange={(v) =>
-                  setSecurityForm((f) => ({
-                    ...f,
-                    operator_groups: v
-                      .split(",")
-                      .map((s) => s.trim())
-                      .filter(Boolean),
-                  }))
-                }
+                value={operatorGroupsText}
+                onChange={setOperatorGroupsText}
                 placeholder="platform-ops"
               />
             </div>

--- a/queryflux-studio/app/security/security-editor.tsx
+++ b/queryflux-studio/app/security/security-editor.tsx
@@ -320,6 +320,8 @@ export function SecurityEditor({ initialSecurity }: Props) {
           credentials: null, // never pre-fill secrets
         }
       : null,
+    operator_roles: initialSecurity?.operator_roles ?? [],
+    operator_groups: initialSecurity?.operator_groups ?? [],
   });
 
   const [securityForm, setSecurityForm] = useState<UpsertSecurityConfig>(initSecurityForm);
@@ -842,6 +844,49 @@ export function SecurityEditor({ initialSecurity }: Props) {
               </div>
             </div>
           )}
+
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 space-y-3">
+            <div>
+              <p className="text-xs font-semibold text-slate-600 uppercase tracking-widest">
+                Query operators
+              </p>
+              <p className="text-xs text-slate-500 mt-1">
+                IdP roles or groups that may cancel any in-flight or queued query.
+                Operators cannot poll another user&apos;s results. The Admin API
+                can always cancel.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <TextInput
+                label="Operator roles (comma-separated)"
+                value={(securityForm.operator_roles ?? []).join(", ")}
+                onChange={(v) =>
+                  setSecurityForm((f) => ({
+                    ...f,
+                    operator_roles: v
+                      .split(",")
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  }))
+                }
+                placeholder="queryflux-operator"
+              />
+              <TextInput
+                label="Operator groups (comma-separated)"
+                value={(securityForm.operator_groups ?? []).join(", ")}
+                onChange={(v) =>
+                  setSecurityForm((f) => ({
+                    ...f,
+                    operator_groups: v
+                      .split(",")
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  }))
+                }
+                placeholder="platform-ops"
+              />
+            </div>
+          </div>
 
           <SaveBar
             saving={securitySaving}

--- a/queryflux-studio/app/security/security-editor.tsx
+++ b/queryflux-studio/app/security/security-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { changePassword, getAuthStatus, putSecurityConfig } from "@/lib/api";
 import type { SecurityConfigDto, UpsertSecurityConfig, GroupAuthzDto } from "@/lib/api-types";
@@ -330,6 +330,30 @@ export function SecurityEditor({ initialSecurity }: Props) {
   const [operatorGroupsText, setOperatorGroupsText] = useState(
     () => (initialSecurity?.operator_groups ?? []).join(", "),
   );
+
+  const lastSyncedRolesText = useRef(operatorRolesText);
+  const lastSyncedGroupsText = useRef(operatorGroupsText);
+  const rolesFromProps = (initialSecurity?.operator_roles ?? []).join(", ");
+  const groupsFromProps = (initialSecurity?.operator_groups ?? []).join(", ");
+
+  useEffect(() => {
+    setOperatorRolesText((current) => {
+      if (current === lastSyncedRolesText.current) {
+        lastSyncedRolesText.current = rolesFromProps;
+        return rolesFromProps;
+      }
+      lastSyncedRolesText.current = rolesFromProps;
+      return current;
+    });
+    setOperatorGroupsText((current) => {
+      if (current === lastSyncedGroupsText.current) {
+        lastSyncedGroupsText.current = groupsFromProps;
+        return groupsFromProps;
+      }
+      lastSyncedGroupsText.current = groupsFromProps;
+      return current;
+    });
+  }, [rolesFromProps, groupsFromProps]);
 
   const [securityForm, setSecurityForm] = useState<UpsertSecurityConfig>(initSecurityForm);
   const [securitySaving, setSecuritySaving] = useState(false);

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -354,6 +354,10 @@ export interface SecurityConfigDto {
   openfga: OpenFgaConfigDto | null;
   /** Per-cluster-group allow-lists (used when authorization_provider = "none"). */
   group_authorization: Record<string, GroupAuthzDto>;
+  /** IdP roles that may cancel any query. */
+  operator_roles?: string[];
+  /** IdP groups that may cancel any query. */
+  operator_groups?: string[];
 }
 
 export interface RoutingConfigDto {
@@ -449,6 +453,8 @@ export interface UpsertSecurityConfig {
   } | null;
   static_users?: Record<string, { password: string; groups?: string[]; roles?: string[] }> | null;
   authorization_provider: string;
+  operator_roles?: string[];
+  operator_groups?: string[];
   openfga?: {
     url: string;
     store_id: string;

--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -354,6 +354,9 @@ struct AuthContext {
 auth:
   provider: none | static | oidc | ldap
   required: true   # with NoneProvider: network-trust only, not cryptographic assurance
+  # IdP roles/groups that may cancel any query (not poll another user's results).
+  operatorRoles: [queryflux-operator]
+  operatorGroups: [platform-ops]
   oidc:
     issuer: https://...
     jwksUri: https://...


### PR DESCRIPTION
## Summary
- Persist `submitted_by` on executing/queued queries and strip `Authorization` from stored session extras so poll/dequeue cannot be used as IDOR.
- Cancel is allowed for the owner, configured IdP `operatorRoles` / `operatorGroups`, or Admin Basic auth (`DELETE /admin/queries/{id}`, `GET /admin/queries/running`).
- Operators still cannot poll another user's results. Studio Security can edit operator lists; OpenFGA may also grant `can_cancel` on a cluster group.

## Test plan
- [x] `cargo test -p queryflux-auth --lib authorization::tests`
- [x] `cargo test -p queryflux-auth --lib credentials::tests`
- [x] `cargo test -p queryflux -- parse_security_setting`
- [x] Submit a query as user A; confirm user B gets 403 on poll/dequeue and cannot cancel unless they have an operator role/group — covered by `authorization::tests` (`other_user_cannot_poll_or_cancel`, `operator_role_can_cancel_but_not_poll`, `operator_group_can_cancel`)
- [x] Confirm owner can cancel; Admin `DELETE /admin/queries/{id}` cancels any query — covered by `authorization::tests::owner_can_poll_and_cancel` and `queryflux-frontend` `delete_queued_if_exists_removes_row`
- [x] Confirm `GET /admin/queries/running` lists executing + queued rows — covered by `queryflux-frontend` `collect_running_queries_includes_executing_and_queued`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authorization for polling, dequeuing, and cancelling queries.
  * Query owners can manage their queries, while configured operators can cancel queries across users.
  * Added admin views for running and queued queries, including cancellation and SQL previews.
  * Added configuration fields and UI controls for operator roles and groups.
* **Security**
  * Authentication data is sanitized before queued-query persistence.
  * Legacy queries without ownership data remain compatible.
* **Documentation**
  * Documented operator role and group configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->