### PR TITLE
fix: persist admin password changes in Postgres

### DIFF
--- a/crates/queryflux-auth/src/admin_credentials.rs
+++ b/crates/queryflux-auth/src/admin_credentials.rs
@@ -10,8 +10,9 @@
 //!    Used until the operator changes the password via the web UI.
 //!
 //! # Persistence note
-//! Password changes require a `ProxySettingsStore` (Postgres). When running with
-//! in-memory persistence the change succeeds within the session but is lost on restart.
+//! Password changes require a `ProxySettingsStore`. With Postgres the bcrypt hash
+//! is written to `proxy_settings` under `"admin_credentials"` and survives restart.
+//! In-memory persistence keeps the override only for the process lifetime.
 
 use std::sync::Arc;
 
@@ -128,21 +129,17 @@ impl AdminCredentialsManager {
         let value = serde_json::to_value(&stored)
             .map_err(|e| QueryFluxError::Auth(format!("serialize credentials: {e}")))?;
 
-        match &self.store {
-            Some(store) => {
-                store.set_proxy_setting(SETTINGS_KEY, value).await?;
-                info!(username, "Admin password changed and stored in DB");
-            }
-            None => {
-                // No persistent store — store in the in-memory fallback path by
-                // writing directly to the settings map via the None branch.
-                // Since there is no store, the change cannot be persisted; warn loudly.
-                warn!(
-                    "No persistent store configured — admin password change will be lost on restart. \
-                     Configure Postgres persistence to make password changes permanent."
-                );
-            }
-        }
+        let Some(store) = &self.store else {
+            warn!(
+                "No settings store configured — admin password change refused. \
+                 Configure Postgres persistence to make password changes permanent."
+            );
+            return Err(QueryFluxError::Auth(
+                "admin password cannot be persisted: no settings store configured".to_string(),
+            ));
+        };
+        store.set_proxy_setting(SETTINGS_KEY, value).await?;
+        info!(username, "Admin password changed and stored in DB");
 
         Ok(())
     }
@@ -155,5 +152,51 @@ impl AdminCredentialsManager {
         let store = self.store.as_ref()?;
         let value = store.get_proxy_setting(SETTINGS_KEY).await.ok()??;
         serde_json::from_value(value).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_persistence::in_memory::InMemoryPersistence;
+
+    fn mgr(store: Option<Arc<dyn ProxySettingsStore>>) -> AdminCredentialsManager {
+        AdminCredentialsManager::new("admin".into(), "admin".into(), store)
+    }
+
+    #[tokio::test]
+    async fn bootstrap_accepts_default_until_override() {
+        let m = mgr(Some(Arc::new(InMemoryPersistence::new())));
+        assert!(m.verify("admin", "admin").await);
+        assert!(!m.has_db_override().await);
+    }
+
+    #[tokio::test]
+    async fn change_password_persists_and_rejects_bootstrap() {
+        let store = Arc::new(InMemoryPersistence::new());
+        let m = mgr(Some(store.clone()));
+        m.change_password("admin", "new-secret").await.unwrap();
+        assert!(m.has_db_override().await);
+        assert!(m.verify("admin", "new-secret").await);
+        assert!(!m.verify("admin", "admin").await);
+
+        let again = mgr(Some(store));
+        assert!(again.has_db_override().await);
+        assert!(again.verify("admin", "new-secret").await);
+    }
+
+    #[tokio::test]
+    async fn change_password_without_store_fails() {
+        let m = mgr(None);
+        let err = m.change_password("admin", "new-secret").await.unwrap_err();
+        assert!(err.to_string().contains("no settings store"));
+        assert!(m.verify("admin", "admin").await);
+    }
+
+    #[tokio::test]
+    async fn wrong_current_password_rejected() {
+        let m = mgr(Some(Arc::new(InMemoryPersistence::new())));
+        assert!(m.change_password("nope", "new-secret").await.is_err());
+        assert!(m.verify("admin", "admin").await);
     }
 }

--- a/crates/queryflux-auth/src/admin_credentials.rs
+++ b/crates/queryflux-auth/src/admin_credentials.rs
@@ -208,4 +208,29 @@ mod tests {
         assert!(m.change_password("nope", "new-secret").await.is_err());
         assert!(m.verify("admin", "admin").await);
     }
+
+    #[test]
+    fn settings_are_durable_reflects_constructor() {
+        let store = Arc::new(InMemoryPersistence::new());
+        assert!(mgr(Some(store.clone()), true).settings_are_durable());
+        assert!(!mgr(Some(store), false).settings_are_durable());
+        assert!(!mgr(None, false).settings_are_durable());
+    }
+
+    #[tokio::test]
+    async fn change_password_stores_bcrypt_hash_under_admin_credentials_key() {
+        let store = Arc::new(InMemoryPersistence::new());
+        let m = mgr(Some(store.clone()), false);
+        m.change_password("admin", "new-secret").await.unwrap();
+
+        let raw = store
+            .get_proxy_setting(SETTINGS_KEY)
+            .await
+            .unwrap()
+            .expect("admin_credentials row");
+        assert_eq!(raw["username"], "admin");
+        let hash = raw["password_hash"].as_str().expect("bcrypt hash");
+        assert!(hash.starts_with("$2"), "expected bcrypt hash, got {hash}");
+        assert!(bcrypt::verify("new-secret", hash).unwrap());
+    }
 }

--- a/crates/queryflux-auth/src/admin_credentials.rs
+++ b/crates/queryflux-auth/src/admin_credentials.rs
@@ -38,6 +38,8 @@ pub struct AdminCredentialsManager {
     bootstrap_username: String,
     bootstrap_password: String,
     store: Option<Arc<dyn ProxySettingsStore>>,
+    /// `true` when settings are backed by Postgres (survive restart).
+    durable_store: bool,
 }
 
 impl AdminCredentialsManager {
@@ -45,12 +47,19 @@ impl AdminCredentialsManager {
         bootstrap_username: String,
         bootstrap_password: String,
         store: Option<Arc<dyn ProxySettingsStore>>,
+        durable_store: bool,
     ) -> Self {
         Self {
             bootstrap_username,
             bootstrap_password,
             store,
+            durable_store,
         }
+    }
+
+    /// `true` when the active settings store is Postgres-backed.
+    pub fn settings_are_durable(&self) -> bool {
+        self.durable_store
     }
 
     /// Returns `true` when the DB contains an overriding credential record.
@@ -160,13 +169,13 @@ mod tests {
     use super::*;
     use queryflux_persistence::in_memory::InMemoryPersistence;
 
-    fn mgr(store: Option<Arc<dyn ProxySettingsStore>>) -> AdminCredentialsManager {
-        AdminCredentialsManager::new("admin".into(), "admin".into(), store)
+    fn mgr(store: Option<Arc<dyn ProxySettingsStore>>, durable: bool) -> AdminCredentialsManager {
+        AdminCredentialsManager::new("admin".into(), "admin".into(), store, durable)
     }
 
     #[tokio::test]
     async fn bootstrap_accepts_default_until_override() {
-        let m = mgr(Some(Arc::new(InMemoryPersistence::new())));
+        let m = mgr(Some(Arc::new(InMemoryPersistence::new())), false);
         assert!(m.verify("admin", "admin").await);
         assert!(!m.has_db_override().await);
     }
@@ -174,20 +183,20 @@ mod tests {
     #[tokio::test]
     async fn change_password_persists_and_rejects_bootstrap() {
         let store = Arc::new(InMemoryPersistence::new());
-        let m = mgr(Some(store.clone()));
+        let m = mgr(Some(store.clone()), false);
         m.change_password("admin", "new-secret").await.unwrap();
         assert!(m.has_db_override().await);
         assert!(m.verify("admin", "new-secret").await);
         assert!(!m.verify("admin", "admin").await);
 
-        let again = mgr(Some(store));
+        let again = mgr(Some(store), false);
         assert!(again.has_db_override().await);
         assert!(again.verify("admin", "new-secret").await);
     }
 
     #[tokio::test]
     async fn change_password_without_store_fails() {
-        let m = mgr(None);
+        let m = mgr(None, false);
         let err = m.change_password("admin", "new-secret").await.unwrap_err();
         assert!(err.to_string().contains("no settings store"));
         assert!(m.verify("admin", "admin").await);
@@ -195,7 +204,7 @@ mod tests {
 
     #[tokio::test]
     async fn wrong_current_password_rejected() {
-        let m = mgr(Some(Arc::new(InMemoryPersistence::new())));
+        let m = mgr(Some(Arc::new(InMemoryPersistence::new())), false);
         assert!(m.change_password("nope", "new-secret").await.is_err());
         assert!(m.verify("admin", "admin").await);
     }

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -823,13 +823,13 @@ async fn change_password_handler(
     {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
         Err(e) => {
-            let msg = e.to_string();
-            let status = if msg.contains("incorrect") {
-                StatusCode::UNAUTHORIZED
-            } else {
-                StatusCode::BAD_REQUEST
-            };
-            (status, Json(serde_json::json!({"error": msg}))).into_response()
+            // Always 400 — 401 would clear the Studio session even when Basic
+            // auth is still valid and only the "current password" field is wrong.
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e.to_string()})),
+            )
+                .into_response()
         }
     }
 }

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -16,7 +16,7 @@ use queryflux_core::{
         ClusterGroupConfig, FrontendConfig, FrontendsConfig, OpenFgaCredentials, RouterConfig,
     },
     engine_registry::EngineRegistry,
-    error::Result,
+    error::{QueryFluxError, Result},
     query::{ClusterGroupName, ClusterName},
 };
 use queryflux_metrics::prometheus_store::PrometheusMetrics;
@@ -799,11 +799,17 @@ struct AuthStatusResponse {
     /// `true` once the operator has changed the password via the web UI.
     /// `false` means bootstrap (YAML/env) credentials are still in use.
     db_override: bool,
+    /// `true` when settings are backed by Postgres (survive restart).
+    durable_store: bool,
 }
 
 async fn auth_status_handler(State(state): State<Arc<AdminState>>) -> impl IntoResponse {
     let db_override = state.admin_creds.has_db_override().await;
-    Json(AuthStatusResponse { db_override })
+    let durable_store = state.admin_creds.settings_are_durable();
+    Json(AuthStatusResponse {
+        db_override,
+        durable_store,
+    })
 }
 
 #[derive(Deserialize)]
@@ -822,12 +828,24 @@ async fn change_password_handler(
         .await
     {
         Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
-        Err(e) => {
-            // Always 400 — 401 would clear the Studio session even when Basic
-            // auth is still valid and only the "current password" field is wrong.
+        Err(QueryFluxError::Auth(msg)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": msg})),
+        )
+            .into_response(),
+        Err(QueryFluxError::Persistence(e)) => {
+            tracing::error!(error = %e, "failed to persist admin password change");
             (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": e.to_string()})),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "failed to persist password change"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "unexpected error changing admin password");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "failed to change password"})),
             )
                 .into_response()
         }

--- a/crates/queryflux-persistence/src/postgres/migrations/20260812000001_proxy_settings.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260812000001_proxy_settings.sql
@@ -1,0 +1,7 @@
+-- Generic key/value settings used by ProxySettingsStore for keys that are
+-- not backed by a dedicated table (e.g. admin_credentials).
+CREATE TABLE IF NOT EXISTS proxy_settings (
+    key         TEXT PRIMARY KEY,
+    value       JSONB        NOT NULL,
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -1000,7 +1000,17 @@ impl ProxySettingsStore for PostgresStore {
                     serde_json::json!({ "global": global, "groups": groups }),
                 ))
             }
-            _ => Ok(None),
+            other => {
+                let row: Option<(serde_json::Value,)> =
+                    sqlx::query_as(r#"SELECT value FROM proxy_settings WHERE key = $1"#)
+                        .bind(other)
+                        .fetch_optional(&self.pool)
+                        .await
+                        .map_err(|e| {
+                            QueryFluxError::Persistence(format!("get_proxy_setting: {e}"))
+                        })?;
+                Ok(row.map(|(v,)| v))
+            }
         }
     }
 
@@ -1072,7 +1082,17 @@ impl ProxySettingsStore for PostgresStore {
                     QueryFluxError::Persistence(format!("guardrails tx commit: {e}"))
                 })?;
             }
-            _ => {}
+            other => {
+                sqlx::query(
+                    r#"INSERT INTO proxy_settings (key, value) VALUES ($1, $2)
+                       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()"#,
+                )
+                .bind(other)
+                .bind(&value)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| QueryFluxError::Persistence(format!("set_proxy_setting: {e}")))?;
+            }
         }
         Ok(())
     }
@@ -1093,7 +1113,15 @@ impl ProxySettingsStore for PostgresStore {
                     .await
                     .map_err(|e| QueryFluxError::Persistence(format!("delete guardrails: {e}")))?;
             }
-            _ => {}
+            other => {
+                sqlx::query(r#"DELETE FROM proxy_settings WHERE key = $1"#)
+                    .bind(other)
+                    .execute(&self.pool)
+                    .await
+                    .map_err(|e| {
+                        QueryFluxError::Persistence(format!("delete_proxy_setting: {e}"))
+                    })?;
+            }
         }
         Ok(())
     }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -894,7 +894,7 @@ async fn main() -> Result<()> {
     let admin_store: Option<Arc<dyn AdminStore>> = backend
         .clone()
         .map(|b| b as Arc<dyn AdminStore>)
-        .or_else(|| mem_store.map(|m| m as Arc<dyn AdminStore>));
+        .or_else(|| mem_store.clone().map(|m| m as Arc<dyn AdminStore>));
     let security_config = Arc::new(AdminSecurityConfigDto::from_config(
         &config.auth,
         &config.authorization,
@@ -913,13 +913,19 @@ async fn main() -> Result<()> {
     );
 
     // Build admin credentials — env vars take precedence over YAML.
-    let admin_username =
-        std::env::var("QUERYFLUX_ADMIN_USER").unwrap_or_else(|_| config.admin_api.username.clone());
+    // Bootstrap lives on `queryflux.adminApi`, not the unused top-level `adminApi`.
+    let admin_username = std::env::var("QUERYFLUX_ADMIN_USER")
+        .unwrap_or_else(|_| config.queryflux.admin_api.username.clone());
     let admin_password = std::env::var("QUERYFLUX_ADMIN_PASSWORD")
-        .unwrap_or_else(|_| config.admin_api.password.clone());
+        .unwrap_or_else(|_| config.queryflux.admin_api.password.clone());
     let settings_store = backend
         .clone()
-        .map(|b| b as Arc<dyn queryflux_persistence::ProxySettingsStore>);
+        .map(|b| b as Arc<dyn queryflux_persistence::ProxySettingsStore>)
+        .or_else(|| {
+            mem_store
+                .clone()
+                .map(|m| m as Arc<dyn queryflux_persistence::ProxySettingsStore>)
+        });
     let admin_creds = Arc::new(queryflux_auth::AdminCredentialsManager::new(
         admin_username,
         admin_password,

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -930,6 +930,7 @@ async fn main() -> Result<()> {
         admin_username,
         admin_password,
         settings_store,
+        backend.is_some(),
     ));
 
     let test_cluster_fn: TestClusterFn = Arc::new(|engine_key, config_json| {

--- a/queryflux-studio/app/security/security-editor.tsx
+++ b/queryflux-studio/app/security/security-editor.tsx
@@ -179,11 +179,32 @@ function StaticUsersEditor({
 // Admin API password
 // ---------------------------------------------------------------------------
 
+function adminPasswordStatusMessage(
+  dbOverride: boolean | null,
+  durableStore: boolean | null,
+): string {
+  if (dbOverride === null || durableStore === null) {
+    return "Status unavailable.";
+  }
+  if (dbOverride && durableStore) {
+    return "A password hash is stored in the database and is used instead of YAML/env bootstrap credentials.";
+  }
+  if (dbOverride && !durableStore) {
+    return "A password override is active in memory only and will be lost on restart. Configure Postgres persistence for durable storage.";
+  }
+  if (!dbOverride && durableStore) {
+    return "Bootstrap credentials from YAML or QUERYFLUX_ADMIN_* are in use. Changing the password here persists it to the database.";
+  }
+  return "Bootstrap credentials from YAML or QUERYFLUX_ADMIN_* are in use. Without Postgres persistence, password changes cannot be stored durably.";
+}
+
 function AdminPasswordSection({
   dbOverride,
+  durableStore,
   onChanged,
 }: {
   dbOverride: boolean | null;
+  durableStore: boolean | null;
   onChanged: () => void;
 }) {
   const [currentPassword, setCurrentPassword] = useState("");
@@ -207,7 +228,12 @@ function AdminPasswordSection({
       setNewPassword("");
       setConfirmPassword("");
       onChanged();
-      setMsg({ text: "Password updated. Use it on the next Studio sign-in.", ok: true });
+      setMsg({
+        text: durableStore
+          ? "Password updated. Use it on the next Studio sign-in."
+          : "Password updated for this session. It will be lost on restart unless Postgres persistence is configured.",
+        ok: true,
+      });
     } catch (e) {
       setMsg({ text: String(e), ok: false });
     } finally {
@@ -220,11 +246,7 @@ function AdminPasswordSection({
       <SectionHeader icon={<Key size={15} />} title="Admin API Password" />
       <div className="p-6 space-y-4">
         <p className="text-xs text-slate-600">
-          {dbOverride === true
-            ? "A password hash is stored in the database and is used instead of YAML/env bootstrap credentials."
-            : dbOverride === false
-              ? "Bootstrap credentials from YAML or QUERYFLUX_ADMIN_* are in use. Changing the password here persists it to the database."
-              : "Status unavailable."}
+          {adminPasswordStatusMessage(dbOverride, durableStore)}
         </p>
         <div className="grid grid-cols-3 gap-3">
           <TextInput
@@ -302,11 +324,22 @@ export function SecurityEditor({ initialSecurity }: Props) {
   // ── Admin password status (read-only; password changes are not available in Studio) ──
 
   const [dbOverride, setDbOverride] = useState<boolean | null>(null);
+  const [durableStore, setDurableStore] = useState<boolean | null>(null);
+
+  const refreshAuthStatus = () => {
+    getAuthStatus()
+      .then((s) => {
+        setDbOverride(s.db_override);
+        setDurableStore(s.durable_store);
+      })
+      .catch(() => {
+        setDbOverride(null);
+        setDurableStore(null);
+      });
+  };
 
   useEffect(() => {
-    getAuthStatus()
-      .then((s) => setDbOverride(s.db_override))
-      .catch(() => setDbOverride(null));
+    refreshAuthStatus();
   }, []);
 
   const saveSecurityConfig = async () => {
@@ -345,7 +378,11 @@ export function SecurityEditor({ initialSecurity }: Props) {
       </div>
 
       {/* ── Admin API Password ───────────────────────────────────────────── */}
-      <AdminPasswordSection dbOverride={dbOverride} onChanged={() => setDbOverride(true)} />
+      <AdminPasswordSection
+        dbOverride={dbOverride}
+        durableStore={durableStore}
+        onChanged={refreshAuthStatus}
+      />
 
       {/* ── Authentication ───────────────────────────────────────────────── */}
       <section className="bg-white rounded-xl border border-slate-200 shadow-xs overflow-hidden">

--- a/queryflux-studio/app/security/security-editor.tsx
+++ b/queryflux-studio/app/security/security-editor.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
-import { getAuthStatus, putSecurityConfig } from "@/lib/api";
+import { changePassword, getAuthStatus, putSecurityConfig } from "@/lib/api";
 import type { SecurityConfigDto, UpsertSecurityConfig, GroupAuthzDto } from "@/lib/api-types";
 import { Field, SectionHeader, TextInput, SaveBar } from "@/components/studio-settings";
 import {
@@ -176,6 +176,84 @@ function StaticUsersEditor({
 
 
 // ---------------------------------------------------------------------------
+// Admin API password
+// ---------------------------------------------------------------------------
+
+function AdminPasswordSection({
+  dbOverride,
+  onChanged,
+}: {
+  dbOverride: boolean | null;
+  onChanged: () => void;
+}) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState<{ text: string; ok: boolean } | null>(null);
+
+  const save = async () => {
+    setSaving(true);
+    setMsg(null);
+    try {
+      if (newPassword.length < 8) {
+        throw new Error("New password must be at least 8 characters.");
+      }
+      if (newPassword !== confirmPassword) {
+        throw new Error("New password and confirmation do not match.");
+      }
+      await changePassword(currentPassword, newPassword);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      onChanged();
+      setMsg({ text: "Password updated. Use it on the next Studio sign-in.", ok: true });
+    } catch (e) {
+      setMsg({ text: String(e), ok: false });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="bg-white rounded-xl border border-slate-200 shadow-xs overflow-hidden">
+      <SectionHeader icon={<Key size={15} />} title="Admin API Password" />
+      <div className="p-6 space-y-4">
+        <p className="text-xs text-slate-600">
+          {dbOverride === true
+            ? "A password hash is stored in the database and is used instead of YAML/env bootstrap credentials."
+            : dbOverride === false
+              ? "Bootstrap credentials from YAML or QUERYFLUX_ADMIN_* are in use. Changing the password here persists it to the database."
+              : "Status unavailable."}
+        </p>
+        <div className="grid grid-cols-3 gap-3">
+          <TextInput
+            label="Current password"
+            type="password"
+            value={currentPassword}
+            onChange={setCurrentPassword}
+          />
+          <TextInput
+            label="New password"
+            type="password"
+            value={newPassword}
+            onChange={setNewPassword}
+            placeholder="at least 8 characters"
+          />
+          <TextInput
+            label="Confirm new password"
+            type="password"
+            value={confirmPassword}
+            onChange={setConfirmPassword}
+          />
+        </div>
+        <SaveBar saving={saving} message={msg} onSave={save} label="Change admin password" />
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main editor component
 // ---------------------------------------------------------------------------
 
@@ -267,18 +345,7 @@ export function SecurityEditor({ initialSecurity }: Props) {
       </div>
 
       {/* ── Admin API Password ───────────────────────────────────────────── */}
-      <section className="bg-white rounded-xl border border-slate-200 shadow-xs overflow-hidden">
-        <SectionHeader icon={<Key size={15} />} title="Admin API Password" />
-        <div className="p-6">
-          <p className="text-xs text-slate-600">
-            {dbOverride === true
-              ? "A password is stored in the database for the admin API (not managed from Studio)."
-              : dbOverride === false
-                ? "Bootstrap credentials from YAML or environment may be in use. Configure the admin password on the server."
-                : "Status unavailable."}
-          </p>
-        </div>
-      </section>
+      <AdminPasswordSection dbOverride={dbOverride} onChanged={() => setDbOverride(true)} />
 
       {/* ── Authentication ───────────────────────────────────────────────── */}
       <section className="bg-white rounded-xl border border-slate-200 shadow-xs overflow-hidden">

--- a/queryflux-studio/lib/api.ts
+++ b/queryflux-studio/lib/api.ts
@@ -431,7 +431,10 @@ export async function testClusterConfig(
 // Auth management
 // ---------------------------------------------------------------------------
 
-export async function getAuthStatus(): Promise<{ db_override: boolean }> {
+export async function getAuthStatus(): Promise<{
+  db_override: boolean;
+  durable_store: boolean;
+}> {
   return apiFetch("/admin/auth/status");
 }
 


### PR DESCRIPTION
## Summary
- `set_proxy_setting(\"admin_credentials\")` was a silent no-op on Postgres, so `POST /admin/auth/change-password` never survived restart.
- Add a `proxy_settings` table for generic keys and persist the bcrypt hash there.
- Bootstrap username/password now come from `queryflux.adminApi` (and `QUERYFLUX_ADMIN_*`), not the unused top-level `adminApi` defaults.
- Studio Security can change the admin password. Wrong current password returns 400 so the session is not cleared.

## Test plan
- [ ] `cargo test -p queryflux-auth --lib admin_credentials`
- [ ] With Postgres: change the admin password in Studio, restart the proxy, confirm `admin`/`admin` is rejected and the new password works.
- [ ] Confirm `SELECT key, value FROM proxy_settings` contains `admin_credentials` with a bcrypt `password_hash`.
- [ ] YAML `queryflux.adminApi.username/password` is used when no DB override exists.
- [ ] In-memory mode still accepts a change for the process lifetime via `InMemoryPersistence`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive admin password-change form with validation, success feedback, and clear error messages.
  * Added persistent storage for proxy settings, including custom key/value settings.
  * Added visibility into whether authentication settings are durably stored.
* **Bug Fixes**
  * Password changes now require configured storage and reject invalid credentials.
  * Admin credentials load from the correct configuration source while preserving environment-variable precedence.
  * Password-change errors now return appropriate responses without exposing sensitive details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->