### PR TITLE
fix(auth): require OIDC audience when auth.required=true

### DIFF
--- a/crates/queryflux-auth/src/provider.rs
+++ b/crates/queryflux-auth/src/provider.rs
@@ -233,6 +233,16 @@ impl AuthProvider for OidcAuthProvider {
             }
         };
 
+        // Audience validation is security-critical for production deployments.
+        // If the operator marked auth as required but did not configure `audience`,
+        // fail closed instead of skipping audience checks.
+        if self.required && self.config.audience.is_none() {
+            return Err(QueryFluxError::Auth(
+                "OIDC audience validation required: configure auth.oidc.audience when auth.required=true"
+                    .into(),
+            ));
+        }
+
         // Decode the header to get kid + algorithm.
         let header = decode_header(token)
             .map_err(|e| QueryFluxError::Auth(format!("invalid JWT header: {e}")))?;
@@ -293,6 +303,39 @@ impl AuthProvider for OidcAuthProvider {
             roles,
             raw_token: Some(token.to_string()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::config::OidcConfig;
+
+    #[tokio::test]
+    async fn oidc_audience_required_fails_fast_when_missing() {
+        let provider = OidcAuthProvider::new(
+            OidcConfig {
+                issuer: "https://idp".to_string(),
+                jwks_uri: "https://idp/jwks".to_string(),
+                audience: None,
+                groups_claim: "groups".to_string(),
+                roles_claim: None,
+            },
+            true,
+        );
+
+        let creds = Credentials {
+            username: None,
+            password: None,
+            bearer_token: Some("not-a-real-jwt".to_string()),
+        };
+
+        let err = provider.authenticate(&creds).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("OIDC audience validation required"),
+            "unexpected error: {err}"
+        );
     }
 }
 

--- a/crates/queryflux-auth/src/provider.rs
+++ b/crates/queryflux-auth/src/provider.rs
@@ -306,6 +306,33 @@ impl AuthProvider for OidcAuthProvider {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract a `Vec<String>` from a JWT claim by dot-notation path.
+/// E.g. `"realm_access.roles"` → `claims["realm_access"]["roles"]`.
+fn extract_string_array(claims: &Value, claim_path: &str) -> Vec<String> {
+    let value = resolve_dot_path(claims, claim_path);
+    match value {
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        Some(Value::String(s)) => vec![s.clone()],
+        _ => vec![],
+    }
+}
+
+/// Walk a dot-separated path through nested JSON objects.
+fn resolve_dot_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -337,31 +364,4 @@ mod tests {
             "unexpected error: {err}"
         );
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Extract a `Vec<String>` from a JWT claim by dot-notation path.
-/// E.g. `"realm_access.roles"` → `claims["realm_access"]["roles"]`.
-fn extract_string_array(claims: &Value, claim_path: &str) -> Vec<String> {
-    let value = resolve_dot_path(claims, claim_path);
-    match value {
-        Some(Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect(),
-        Some(Value::String(s)) => vec![s.clone()],
-        _ => vec![],
-    }
-}
-
-/// Walk a dot-separated path through nested JSON objects.
-fn resolve_dot_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
-    let mut current = value;
-    for segment in path.split('.') {
-        current = current.get(segment)?;
-    }
-    Some(current)
 }


### PR DESCRIPTION
## Summary

Fail closed when `auth.required=true` but OIDC `audience` is omitted.

## Changes

- `OidcAuthProvider` rejects requests with missing audience in required mode, before JWKS fetch.

## Test plan

- [ ] `oidc_audience_required_fails_fast_when_missing` unit test
- [ ] Clippy with `-D warnings`