### PR TITLE
fix(auth): enforce auth for frontend SET and metadata fast paths

### DIFF
--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -287,6 +287,22 @@ async fn handle_com_query(
     let logical = strip_mysql_conditional_comment(sql);
     let sql_lower = logical.trim().to_lowercase();
 
+    // Auth-complete early gate: all statement/metadata fast paths must still
+    // be subject to authentication when `auth.required=true`.
+    let protocol = FrontendProtocol::MySqlWire;
+    let creds = Credentials {
+        username: session.user().map(|s| s.to_string()),
+        ..Default::default()
+    };
+    let auth_provider = state.live.read().await.auth_provider.clone();
+    let auth_ctx = match auth_provider.authenticate(&creds).await {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            write_packet(writer, start_seq, &build_err(1045, &e.to_string())).await?;
+            return Ok(());
+        }
+    };
+
     // Fast-path: SET query_tags / SET SESSION query_tags — update session tags and ACK.
     if let Some(new_tags) = try_parse_set_query_tags(logical) {
         session.tags = new_tags;
@@ -354,21 +370,6 @@ async fn handle_com_query(
     if let Some(col_vals) = try_parse_mysql_metadata_select(&sql_lower, session) {
         return write_synthetic_multi_column_row(writer, &col_vals, start_seq).await;
     }
-
-    let protocol = FrontendProtocol::MySqlWire;
-
-    let creds = Credentials {
-        username: session.user().map(|s| s.to_string()),
-        ..Default::default()
-    };
-    let auth_provider = state.live.read().await.auth_provider.clone();
-    let auth_ctx = match auth_provider.authenticate(&creds).await {
-        Ok(ctx) => ctx,
-        Err(e) => {
-            write_packet(writer, start_seq, &build_err(1045, &e.to_string())).await?;
-            return Ok(());
-        }
-    };
 
     let routing_result = {
         let live = state.live.read().await;

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -1702,4 +1702,43 @@ mod tests {
         let ctx = s.resolved_agent_context().expect("should resolve");
         assert_eq!(ctx.agent_id, "second");
     }
+
+    #[tokio::test]
+    async fn set_fast_path_rejects_unauthenticated_when_required() {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::{TcpListener, TcpStream};
+
+        use crate::state::test_fixtures;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let state = test_fixtures::app_state(true);
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (mut reader, mut writer) = stream.into_split();
+            let mut session = SessionContext::default();
+            super::handle_com_query(
+                &mut reader,
+                &mut writer,
+                &state,
+                &mut session,
+                "SET query_tags='team:eng'",
+                0,
+            )
+            .await
+            .expect("handle_com_query");
+        });
+
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        let mut buf = [0u8; 512];
+        let n = stream.read(&mut buf).await.expect("read");
+        server.await.expect("server");
+
+        assert!(n >= 5, "expected MySQL packet, got {n} bytes");
+        assert_eq!(
+            buf[4], 0xff,
+            "expected MySQL ERR packet when auth is required"
+        );
+    }
 }

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -666,4 +666,41 @@ mod tests {
             Some("region-us")
         );
     }
+
+    #[tokio::test]
+    async fn set_fast_path_rejects_unauthenticated_when_required() {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::{TcpListener, TcpStream};
+
+        use crate::state::test_fixtures;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let state = test_fixtures::app_state(true);
+        let session = SessionContext::default();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (mut reader, mut writer) = stream.into_split();
+            super::handle_simple_query(
+                &mut reader,
+                &mut writer,
+                &state,
+                &session,
+                "SET search_path = public",
+            )
+            .await
+            .expect("handle_simple_query");
+        });
+
+        let mut stream = TcpStream::connect(addr).await.expect("connect");
+        let mut msg_type = [0u8; 1];
+        stream.read_exact(&mut msg_type).await.expect("read type");
+        server.await.expect("server");
+
+        assert_eq!(
+            msg_type[0], b'E',
+            "expected Postgres ErrorResponse when auth is required"
+        );
+    }
 }

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -301,13 +301,6 @@ async fn handle_simple_query(
 
     let sql_lower = sql.trim().to_lowercase();
 
-    // Fast-path: SET statements.
-    if sql_lower.starts_with("set ") || sql_lower.starts_with("set\t") {
-        write_msg(writer, b'C', b"SET\0").await?;
-        write_msg(writer, b'Z', b"I").await?;
-        return Ok(());
-    }
-
     let protocol = FrontendProtocol::PostgresWire;
 
     let creds = Credentials {
@@ -323,6 +316,14 @@ async fn handle_simple_query(
             return Ok(());
         }
     };
+
+    // Auth-complete fast path: `SET` statements are handled locally by the proxy,
+    // but must still go through authentication when `auth.required=true`.
+    if sql_lower.starts_with("set ") || sql_lower.starts_with("set\t") {
+        write_msg(writer, b'C', b"SET\0").await?;
+        write_msg(writer, b'Z', b"I").await?;
+        return Ok(());
+    }
 
     let routing_result = {
         let live = state.live.read().await;

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -271,3 +271,80 @@ impl AppState {
         });
     }
 }
+
+#[cfg(test)]
+pub mod test_fixtures {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use queryflux_auth::{
+        AllowAllAuthorization, AuthProvider, AuthorizationChecker, BackendIdentityResolver,
+        NoneAuthProvider,
+    };
+    use queryflux_cluster_manager::{
+        cluster_state::ClusterState, simple::SimpleClusterGroupManager,
+    };
+    use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType};
+    use queryflux_metrics::NoopMetricsStore;
+    use queryflux_persistence::in_memory::InMemoryPersistence;
+    use queryflux_routing::chain::RouterChain;
+    use queryflux_translation::TranslationService;
+    use tokio::sync::RwLock;
+
+    use super::{AppState, LiveConfig};
+
+    pub fn app_state(auth_required: bool) -> Arc<AppState> {
+        let group_name = ClusterGroupName("default".into());
+        let cluster_name = ClusterName("trino".into());
+        let cluster_state = Arc::new(ClusterState::new(
+            cluster_name.clone(),
+            group_name.clone(),
+            None,
+            None,
+            EngineType::Trino,
+            Some("http://trino.test:8080".into()),
+            10,
+            true,
+        ));
+        let mut group_members = HashMap::new();
+        group_members.insert(group_name.0.clone(), vec![cluster_name.0.clone()]);
+        let mut groups = HashMap::new();
+        groups.insert(
+            group_name.clone(),
+            (
+                vec![cluster_state],
+                Arc::new(queryflux_cluster_manager::strategy::RoundRobinStrategy::new())
+                    as Arc<dyn queryflux_cluster_manager::strategy::ClusterSelectionStrategy>,
+            ),
+        );
+        let live = LiveConfig {
+            router_chain: RouterChain::new(vec![], group_name.clone()),
+            guard_chain: None,
+            group_guard_chains: HashMap::new(),
+            cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),
+            adapters: HashMap::new(),
+            health_check_targets: vec![],
+            cluster_configs: HashMap::new(),
+            group_members,
+            group_order: vec![group_name.0.clone()],
+            group_translation_scripts: HashMap::new(),
+            group_default_tags: HashMap::new(),
+            group_cache_settings: HashMap::new(),
+            auth_provider: Arc::new(NoneAuthProvider::new(auth_required)) as Arc<dyn AuthProvider>,
+            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+        };
+        Arc::new(AppState {
+            external_address: "http://127.0.0.1:8080".into(),
+            live: Arc::new(RwLock::new(live)),
+            persistence: Arc::new(InMemoryPersistence::new()),
+            translation: Arc::new(TranslationService::disabled()),
+            metrics: Arc::new(NoopMetricsStore),
+            identity_resolver: Arc::new(BackendIdentityResolver::new()),
+            capacity_store: None,
+            queue_coordinator: None,
+            instance_id: "test".into(),
+            http_client: reqwest::Client::new(),
+            result_cache: Arc::new(queryflux_cache::noop::NoopResultCache),
+        })
+    }
+}

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1589,6 +1589,47 @@ mod cancel_executing_statement_tests {
 }
 
 #[cfg(test)]
+mod auth_fast_path_tests {
+    use axum::extract::State;
+    use axum::http::{HeaderMap, HeaderValue, StatusCode};
+    use axum::response::IntoResponse;
+    use bytes::Bytes;
+
+    use super::post_statement;
+    use crate::state::test_fixtures;
+
+    #[tokio::test]
+    async fn set_session_fast_path_rejects_unauthenticated_when_required() {
+        let state = test_fixtures::app_state(true);
+        let resp = post_statement(
+            State(state),
+            HeaderMap::new(),
+            Bytes::from("SET SESSION query_tags = 'team=eng'"),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn set_session_fast_path_allows_authenticated_user() {
+        let state = test_fixtures::app_state(true);
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Trino-User", HeaderValue::from_static("alice"));
+        let resp = post_statement(
+            State(state),
+            headers,
+            Bytes::from("SET SESSION query_tags = 'team=eng'"),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+#[cfg(test)]
 mod trino_session_property_encoding_tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -444,11 +444,6 @@ pub async fn post_statement(
     // Intercept SET SESSION query_tags/query_tag before routing to backend.
     // Trino doesn't know these properties; QueryFlux handles them locally and
     // returns X-Trino-Set-Session so the CLI carries the value in subsequent requests.
-    if let Some((prop_key, prop_val)) = try_parse_set_session_tags(&sql) {
-        let query_id = ProxyQueryId::new();
-        return set_session_response(&query_id.0, &prop_key, &prop_val).into_response();
-    }
-
     let session = extract_session(&headers);
     let protocol = FrontendProtocol::TrinoHttp;
 
@@ -462,6 +457,13 @@ pub async fn post_statement(
             return StatusCode::UNAUTHORIZED.into_response();
         }
     };
+
+    // Auth-complete fast path: `SET SESSION query_tag(s)` is handled locally by QueryFlux,
+    // but must still require authentication when `auth.required=true`.
+    if let Some((prop_key, prop_val)) = try_parse_set_session_tags(&sql) {
+        let query_id = ProxyQueryId::new();
+        return set_session_response(&query_id.0, &prop_key, &prop_val).into_response();
+    }
 
     // 2. Route — first matching router wins.
     // `route_with_trace` is CPU-bound (regex match, header lookup); holding the read lock


### PR DESCRIPTION
## Summary

Ensure `auth.required` cannot be bypassed via frontend fast-path handlers:

- Trino HTTP SET session properties
- Postgres wire SET
- MySQL wire metadata and session probes

These paths previously returned synthetic OK responses without calling `authenticate`. They now authenticate first; unauthenticated requests get 401.

## Test plan

- [ ] Clippy with `-D warnings`
- [ ] Unauthenticated SET/metadata requests fail when auth is required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication is now enforced before processing session settings and other locally handled requests.
  * Unauthenticated MySQL, PostgreSQL, and Trino requests receive the appropriate authentication error instead of bypassing access controls.
  * Authenticated requests continue to receive the expected responses for supported session-setting commands.

* **Tests**
  * Added coverage confirming authentication behavior across supported connection protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->