### PR TITLE
fix: heartbeat queue claims so slow dispatch cannot double-run

### DIFF
--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -25,6 +25,55 @@ use tracing::{error, info, warn};
 use super::result_sink::TrinoHttpResultSink;
 use crate::dispatch::{dispatch_query, execute_to_sink, rewrite_trino_uri, DispatchOutcome};
 use crate::state::{AppState, QueryContext, QueryOutcome};
+use queryflux_persistence::QueueCoordinator;
+
+/// Stale-claim cutoff. Heartbeats must run more often than this while dispatch
+/// is in progress so a slow submit cannot look like a crashed replica.
+const QUEUE_CLAIM_TIMEOUT_SECS: i64 = 60;
+const QUEUE_CLAIM_HEARTBEAT_SECS: u64 = 15;
+
+/// Refreshes `claimed_at` until dropped so another replica cannot take over.
+struct QueueClaimHeartbeat {
+    stop: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl QueueClaimHeartbeat {
+    fn start(qc: Arc<dyn QueueCoordinator>, query_id: String, instance_id: String) -> Self {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(Duration::from_secs(QUEUE_CLAIM_HEARTBEAT_SECS));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            interval.tick().await;
+            loop {
+                tokio::select! {
+                    _ = &mut rx => break,
+                    _ = interval.tick() => {
+                        match qc.refresh_claim(&query_id, &instance_id).await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                warn!(id = %query_id, "Queue claim lost during dispatch");
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(id = %query_id, "Queue claim refresh failed: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        Self { stop: Some(tx) }
+    }
+}
+
+impl Drop for QueueClaimHeartbeat {
+    fn drop(&mut self) {
+        if let Some(tx) = self.stop.take() {
+            let _ = tx.send(());
+        }
+    }
+}
 
 fn trino_error_response(query_id: &str, message: &str) -> Response<Body> {
     let resp = queryflux_engine_adapters::trino::api::TrinoResponse {
@@ -640,15 +689,22 @@ pub async fn get_queued_statement(
     //
     // Claims are held only for the duration of one dispatch attempt. A claim
     // older than the timeout means the claiming replica crashed mid-dispatch,
-    // so it is treated as abandoned and taken over.
-    const QUEUE_CLAIM_TIMEOUT_SECS: i64 = 60;
+    // so it is treated as abandoned and taken over. Heartbeat while dispatch
+    // runs so a slow submit cannot look like a crash.
+    let mut claim_heartbeat = None;
     if let Some(qc) = &state.queue_coordinator {
         let stale_before = chrono::Utc::now() - chrono::Duration::seconds(QUEUE_CLAIM_TIMEOUT_SECS);
         match qc
             .try_claim(&query_id.0, &state.instance_id, stale_before)
             .await
         {
-            Ok(Some(_)) => {} // claimed successfully, proceed with dispatch
+            Ok(Some(_)) => {
+                claim_heartbeat = Some(QueueClaimHeartbeat::start(
+                    qc.clone(),
+                    query_id.0.clone(),
+                    state.instance_id.clone(),
+                ));
+            }
             Ok(None) => {
                 // `None` means either claimed by another replica or the row no
                 // longer exists (finished/cleaned up). Distinguish them: a
@@ -710,6 +766,7 @@ pub async fn get_queued_statement(
             }
         }
     }
+    let _claim_heartbeat = claim_heartbeat;
 
     let queued = match state.persistence.get_queued(&query_id).await {
         Ok(Some(q)) => q,

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1282,6 +1282,19 @@ pub async fn delete_executing_statement(
 }
 
 #[cfg(test)]
+mod queue_claim_heartbeat_tests {
+    use super::{QUEUE_CLAIM_HEARTBEAT_SECS, QUEUE_CLAIM_TIMEOUT_SECS};
+
+    #[test]
+    fn heartbeat_interval_is_well_below_stale_claim_timeout() {
+        assert!(
+            QUEUE_CLAIM_HEARTBEAT_SECS * 2 <= QUEUE_CLAIM_TIMEOUT_SECS as u64,
+            "heartbeat must run at least twice within the stale-claim window"
+        );
+    }
+}
+
+#[cfg(test)]
 mod trino_session_property_encoding_tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -866,6 +866,10 @@ impl QueueCoordinator for InMemoryPersistence {
         Ok(())
     }
 
+    async fn refresh_claim(&self, query_id: &str, _instance_id: &str) -> Result<bool> {
+        Ok(self.queued.contains_key(query_id))
+    }
+
     async fn list_unclaimed(&self, _stale_before: DateTime<Utc>) -> Result<Vec<QueuedQuery>> {
         // Single instance — all queued queries are effectively unclaimed.
         Ok(self.queued.iter().map(|e| e.value().clone()).collect())
@@ -1270,6 +1274,18 @@ mod tests {
             .await
             .unwrap();
         assert!(claimed.is_none());
+    }
+
+    #[tokio::test]
+    async fn queue_refresh_claim_true_while_queued() {
+        let store = InMemoryPersistence::new();
+        store.upsert_queued(make_queued("q-hb")).await.unwrap();
+        assert!(store.refresh_claim("q-hb", "inst-1").await.unwrap());
+        store
+            .delete_queued(&ProxyQueryId("q-hb".into()))
+            .await
+            .unwrap();
+        assert!(!store.refresh_claim("q-hb", "inst-1").await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/queryflux-persistence/src/lib.rs
+++ b/crates/queryflux-persistence/src/lib.rs
@@ -369,6 +369,15 @@ pub trait QueueCoordinator: Send + Sync {
     /// or the claiming instance is shutting down).
     async fn release_claim(&self, query_id: &str) -> Result<()>;
 
+    /// Refresh `claimed_at` if `instance_id` still owns the claim.
+    ///
+    /// Dispatch can take longer than the stale-claim cutoff. Callers must
+    /// heartbeat while they hold the claim so another replica does not
+    /// take over and double-dispatch.
+    ///
+    /// Returns `true` if this instance still owns the claim.
+    async fn refresh_claim(&self, query_id: &str, instance_id: &str) -> Result<bool>;
+
     /// List queued queries that are not currently claimed by any instance.
     /// Claims older than `stale_before` count as unclaimed.
     async fn list_unclaimed(&self, stale_before: DateTime<Utc>) -> Result<Vec<QueuedQuery>>;

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -1932,6 +1932,23 @@ impl QueueCoordinator for PostgresStore {
         Ok(())
     }
 
+    async fn refresh_claim(&self, query_id: &str, instance_id: &str) -> Result<bool> {
+        let row: Option<(String,)> = sqlx::query_as(
+            r#"
+            UPDATE queued_queries
+            SET claimed_at = now()
+            WHERE id = $1 AND claimed_by = $2
+            RETURNING id
+            "#,
+        )
+        .bind(query_id)
+        .bind(instance_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| QueryFluxError::Persistence(format!("refresh_claim: {e}")))?;
+        Ok(row.is_some())
+    }
+
     async fn list_unclaimed(&self, stale_before: DateTime<Utc>) -> Result<Vec<QueuedQuery>> {
         let rows: Vec<(serde_json::Value,)> = sqlx::query_as(
             r#"
@@ -2532,6 +2549,25 @@ mod tests {
             "second claim by different instance should fail"
         );
 
+        store.delete_queued(&ProxyQueryId(qid)).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn pg_queue_refresh_claim_only_for_owner() {
+        let store = test_store().await;
+        let qid = unique_id("hb");
+        store.upsert_queued(make_queued(&qid)).await.unwrap();
+        assert!(store
+            .try_claim(&qid, "inst-A", no_stale())
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store.refresh_claim(&qid, "inst-A").await.unwrap());
+        assert!(
+            !store.refresh_claim(&qid, "inst-B").await.unwrap(),
+            "other instance must not refresh the claim"
+        );
         store.delete_queued(&ProxyQueryId(qid)).await.unwrap();
     }
 


### PR DESCRIPTION
## Summary

Queue claims expire after 60s. If dispatch takes longer than that, another replica can take over the same queued query and run it twice.

- `QueueCoordinator::refresh_claim` updates `claimed_at` for the owning instance.
- Dequeue heartbeats every 15s until dispatch finishes.
- Lost claims are not refreshed by a different instance.

## Test plan

- [ ] `cargo test -p queryflux-persistence --lib queue_refresh_claim`
- [ ] Clippy with `-D warnings` on `queryflux-persistence` and `queryflux-frontend`
- [ ] Two replicas: a dispatch longer than 60s is not taken over while the owner is still working

Made with [Cursor](https://cursor.com)