### PR TITLE
fix: cancel Trino queries with cluster credentials before releasing slots

### DIFF
--- a/crates/queryflux-engine-adapters/src/trino/mod.rs
+++ b/crates/queryflux-engine-adapters/src/trino/mod.rs
@@ -427,36 +427,27 @@ impl AsyncAdapter for TrinoAdapter {
     async fn cancel_query(&self, backend_id: &BackendQueryId) -> Result<()> {
         // `DELETE /v1/query/{id}` cancels a running query without needing nextUri.
         let url = self.trino_url(&format!("/v1/query/{}", backend_id.0));
-        match self
+        let resp = self
             .with_control_timeout(self.apply_cluster_auth(self.http_client.delete(&url)))
             .send()
             .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                debug!(
-                    cluster = %self.cluster_name,
-                    query_id = %backend_id,
-                    "Trino query cancelled (DELETE /v1/query)"
-                );
-            }
-            Ok(resp) => {
-                debug!(
-                    cluster = %self.cluster_name,
-                    status = %resp.status(),
-                    query_id = %backend_id,
-                    "Trino cancel DELETE non-success (ignored)"
-                );
-            }
-            Err(e) => {
-                debug!(
-                    cluster = %self.cluster_name,
-                    query_id = %backend_id,
-                    error = %e,
-                    "Trino cancel DELETE failed (ignored)"
-                );
-            }
+            .map_err(|e| QueryFluxError::Engine(format!("Trino cancel failed: {e}")))?;
+
+        let status = resp.status();
+        if trino_cancel_succeeded(status) {
+            debug!(
+                cluster = %self.cluster_name,
+                query_id = %backend_id,
+                status = %status,
+                "Trino query cancelled (DELETE /v1/query)"
+            );
+            return Ok(());
         }
-        Ok(())
+
+        let body = resp.text().await.unwrap_or_default();
+        Err(QueryFluxError::Engine(format!(
+            "Trino cancel returned {status}: {body}"
+        )))
     }
 
     async fn execute_as_arrow(
@@ -1139,11 +1130,19 @@ impl crate::EngineAdapterFactory for TrinoFactory {
     }
 }
 
+fn trino_cancel_succeeded(status: StatusCode) -> bool {
+    status.is_success() || status == StatusCode::NOT_FOUND
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TrinoAdapter, TrinoConfig, TRINO_CONNECT_TIMEOUT, TRINO_CONTROL_TIMEOUT};
+    use super::{
+        trino_cancel_succeeded, TrinoAdapter, TrinoConfig, TRINO_CONNECT_TIMEOUT,
+        TRINO_CONTROL_TIMEOUT,
+    };
     use crate::AsyncAdapter;
     use queryflux_core::query::{BackendQueryId, ClusterGroupName, ClusterName, QueryPollResult};
+    use reqwest::StatusCode;
     use std::time::{Duration, Instant};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -1159,6 +1158,15 @@ mod tests {
             TRINO_CONTROL_TIMEOUT < typical_trino_long_poll,
             "poll GETs must not use the control timeout"
         );
+    }
+
+    #[test]
+    fn cancel_treats_success_and_not_found_as_done() {
+        assert!(trino_cancel_succeeded(StatusCode::OK));
+        assert!(trino_cancel_succeeded(StatusCode::NO_CONTENT));
+        assert!(trino_cancel_succeeded(StatusCode::NOT_FOUND));
+        assert!(!trino_cancel_succeeded(StatusCode::UNAUTHORIZED));
+        assert!(!trino_cancel_succeeded(StatusCode::INTERNAL_SERVER_ERROR));
     }
 
     #[tokio::test]

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1309,6 +1309,284 @@ mod queue_claim_heartbeat_tests {
 }
 
 #[cfg(test)]
+mod cancel_executing_statement_tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use axum::extract::{Path, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::response::IntoResponse;
+    use chrono::Utc;
+    use queryflux_auth::{
+        AllowAllAuthorization, AuthProvider, AuthorizationChecker, BackendIdentityResolver,
+        NoneAuthProvider,
+    };
+    use queryflux_cluster_manager::{
+        cluster_state::ClusterState, simple::SimpleClusterGroupManager,
+    };
+    use queryflux_core::{
+        error::{QueryFluxError, Result},
+        query::{
+            BackendQueryId, ClusterGroupName, ClusterName, EngineType, ExecutingQuery,
+            ProxyQueryId, QueryExecution, QueryPollResult, SqlDialect,
+        },
+    };
+    use queryflux_engine_adapters::{AdapterKind, AsyncAdapter};
+    use queryflux_metrics::NoopMetricsStore;
+    use queryflux_persistence::in_memory::InMemoryPersistence;
+    use queryflux_routing::chain::RouterChain;
+    use queryflux_translation::TranslationService;
+    use tokio::sync::RwLock;
+
+    use super::delete_executing_statement;
+    use crate::state::{AppState, LiveConfig};
+
+    struct CancelStubAdapter {
+        calls: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl AsyncAdapter for CancelStubAdapter {
+        async fn submit_query(
+            &self,
+            _sql: &str,
+            _session: &queryflux_core::session::SessionContext,
+            _credentials: &queryflux_auth::QueryCredentials,
+            _tags: &queryflux_core::tags::QueryTags,
+            _params: &queryflux_core::params::QueryParams,
+        ) -> Result<QueryExecution> {
+            Err(QueryFluxError::Engine("not used in cancel tests".into()))
+        }
+
+        async fn poll_query(
+            &self,
+            _backend_id: &BackendQueryId,
+            _poll_token: Option<&str>,
+        ) -> Result<QueryPollResult> {
+            Err(QueryFluxError::Engine("not used in cancel tests".into()))
+        }
+
+        async fn cancel_query(&self, _backend_id: &BackendQueryId) -> Result<()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                Err(QueryFluxError::Engine("cancel rejected".into()))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn engine_type(&self) -> EngineType {
+            EngineType::Trino
+        }
+
+        fn translation_target_dialect(&self) -> SqlDialect {
+            SqlDialect::Trino
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+
+        async fn list_catalogs(&self) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        async fn describe_table(
+            &self,
+            _catalog: &str,
+            _database: &str,
+            _table: &str,
+        ) -> Result<Option<queryflux_core::catalog::TableSchema>> {
+            Ok(None)
+        }
+    }
+
+    fn test_cluster_names() -> (ClusterGroupName, ClusterName) {
+        (
+            ClusterGroupName("default".into()),
+            ClusterName("trino".into()),
+        )
+    }
+
+    async fn test_state(adapter: Option<AdapterKind>) -> Arc<AppState> {
+        let (group_name, cluster_name) = test_cluster_names();
+        let cluster_state = Arc::new(ClusterState::new(
+            cluster_name.clone(),
+            group_name.clone(),
+            None,
+            None,
+            EngineType::Trino,
+            Some("http://trino.test:8080".into()),
+            10,
+            true,
+        ));
+        let mut adapters = HashMap::new();
+        if let Some(adapter) = adapter {
+            adapters.insert(cluster_name.0.clone(), adapter);
+        }
+        let mut group_members = HashMap::new();
+        group_members.insert(group_name.0.clone(), vec![cluster_name.0.clone()]);
+        let mut groups = HashMap::new();
+        groups.insert(
+            group_name.clone(),
+            (
+                vec![cluster_state],
+                Arc::new(queryflux_cluster_manager::strategy::RoundRobinStrategy::new())
+                    as Arc<dyn queryflux_cluster_manager::strategy::ClusterSelectionStrategy>,
+            ),
+        );
+        let live = LiveConfig {
+            router_chain: RouterChain::new(vec![], group_name.clone()),
+            guard_chain: None,
+            group_guard_chains: HashMap::new(),
+            cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),
+            adapters,
+            health_check_targets: vec![],
+            cluster_configs: HashMap::new(),
+            group_members,
+            group_order: vec![group_name.0.clone()],
+            group_translation_scripts: HashMap::new(),
+            group_default_tags: HashMap::new(),
+            group_cache_settings: HashMap::new(),
+            auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
+            authorization: Arc::new(AllowAllAuthorization) as Arc<dyn AuthorizationChecker>,
+        };
+        Arc::new(AppState {
+            external_address: "http://127.0.0.1:8080".into(),
+            live: Arc::new(RwLock::new(live)),
+            persistence: Arc::new(InMemoryPersistence::new()),
+            translation: Arc::new(TranslationService::disabled()),
+            metrics: Arc::new(NoopMetricsStore),
+            identity_resolver: Arc::new(BackendIdentityResolver::new()),
+            capacity_store: None,
+            queue_coordinator: None,
+            instance_id: "test".into(),
+            http_client: reqwest::Client::new(),
+            result_cache: Arc::new(queryflux_cache::noop::NoopResultCache),
+        })
+    }
+
+    async fn seed_executing(state: &AppState, backend_id: &str) {
+        let (group_name, cluster_name) = test_cluster_names();
+        let executing = ExecutingQuery {
+            id: ProxyQueryId("proxy-1".into()),
+            sql: "SELECT 1".into(),
+            translated_sql: None,
+            cluster_group: group_name,
+            cluster_name,
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            backend_query_id: BackendQueryId(backend_id.into()),
+            poll_base_url: None,
+            creation_time: Utc::now(),
+            last_accessed: Utc::now(),
+            query_tags: HashMap::new(),
+            agent_context: None,
+            submitted_guard_actions: vec![],
+            was_guard_blocked: false,
+        };
+        state
+            .persistence
+            .upsert(executing)
+            .await
+            .expect("seed executing query");
+    }
+
+    #[tokio::test]
+    async fn cancel_removes_executing_record_after_adapter_succeeds() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let adapter = AdapterKind::Async(Arc::new(CancelStubAdapter {
+            calls: calls.clone(),
+            fail: false,
+        }));
+        let state = test_state(Some(adapter)).await;
+        seed_executing(&state, "trino-q-ok").await;
+
+        let resp = delete_executing_statement(
+            State(state.clone()),
+            Path("executing/trino-q-ok".into()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(
+            state
+                .persistence
+                .get(&BackendQueryId("trino-q-ok".into()))
+                .await
+                .expect("get")
+                .is_none(),
+            "executing record must be deleted only after backend cancel succeeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_keeps_executing_record_when_adapter_fails() {
+        let adapter = AdapterKind::Async(Arc::new(CancelStubAdapter {
+            calls: Arc::new(AtomicUsize::new(0)),
+            fail: true,
+        }));
+        let state = test_state(Some(adapter)).await;
+        seed_executing(&state, "trino-q-fail").await;
+
+        let resp = delete_executing_statement(
+            State(state.clone()),
+            Path("executing/trino-q-fail".into()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            state
+                .persistence
+                .get(&BackendQueryId("trino-q-fail".into()))
+                .await
+                .expect("get")
+                .is_some(),
+            "slot must not be released when backend cancel fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_refuses_when_cluster_adapter_missing() {
+        let state = test_state(None).await;
+        seed_executing(&state, "trino-q-no-adapter").await;
+
+        let resp = delete_executing_statement(
+            State(state.clone()),
+            Path("executing/trino-q-no-adapter".into()),
+            HeaderMap::new(),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert!(state
+            .persistence
+            .get(&BackendQueryId("trino-q-no-adapter".into()))
+            .await
+            .expect("get")
+            .is_some());
+    }
+}
+
+#[cfg(test)]
 mod trino_session_property_encoding_tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1245,37 +1245,51 @@ pub async fn delete_executing_statement(
     };
     let backend_id = BackendQueryId(trino_id);
 
-    if let Ok(Some(executing)) = state.persistence.get(&backend_id).await {
-        // TODO: verify query ownership once submitter_user is stored in ExecutingQuery
-        if auth_ctx.user != "anonymous" {
-            tracing::debug!(
-                id = %executing.id,
-                cancel_user = %auth_ctx.user,
-                "Authenticated cancel request — ownership check deferred until submitter is persisted"
-            );
+    let executing = match state.persistence.get(&backend_id).await {
+        Ok(Some(q)) => q,
+        Ok(None) => return StatusCode::NO_CONTENT.into_response(),
+        Err(e) => {
+            warn!("Persistence error on cancel: {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
+    };
 
-        let trino_url = format!(
-            "{}/v1/statement/{}",
-            executing
-                .poll_base_url
-                .as_deref()
-                .unwrap_or_default()
-                .trim_end_matches('/'),
-            trino_path
+    // TODO: verify query ownership once submitter_user is stored in ExecutingQuery
+    if auth_ctx.user != "anonymous" {
+        tracing::debug!(
+            id = %executing.id,
+            cancel_user = %auth_ctx.user,
+            "Authenticated cancel request — ownership check deferred until submitter is persisted"
         );
-        let _ = state.http_client.delete(&trino_url).send().await;
+    }
 
-        state
-            .release_query_slot(
-                &executing.cluster_group,
-                &executing.cluster_name,
-                &executing.id.0,
-            )
-            .await;
-        if let Err(e) = state.persistence.delete(&backend_id).await {
-            warn!(id = %executing.id, "Failed to delete executing record on cancel: {e}");
-        }
+    let Some(adapter) = state.adapter(&executing.cluster_name.0).await else {
+        warn!(
+            id = %executing.id,
+            cluster = %executing.cluster_name,
+            "No adapter for cluster; refusing to release slot without backend cancel"
+        );
+        return (StatusCode::BAD_GATEWAY, "failed to cancel query on backend").into_response();
+    };
+
+    if let Err(e) = adapter.cancel_query(&executing.backend_query_id).await {
+        warn!(
+            id = %executing.id,
+            backend = %executing.backend_query_id,
+            "Cancel with cluster credentials failed: {e}"
+        );
+        return (StatusCode::BAD_GATEWAY, "failed to cancel query on backend").into_response();
+    }
+
+    state
+        .release_query_slot(
+            &executing.cluster_group,
+            &executing.cluster_name,
+            &executing.id.0,
+        )
+        .await;
+    if let Err(e) = state.persistence.delete(&backend_id).await {
+        warn!(id = %executing.id, "Failed to delete executing record on cancel: {e}");
     }
 
     StatusCode::NO_CONTENT.into_response()


### PR DESCRIPTION
## Summary

Client cancel issued an unauthenticated DELETE to Trino, then released the capacity slot even when the engine kept running.

- `TrinoAdapter::cancel_query` uses cluster credentials and returns an error unless the backend responds 2xx or 404.
- `DELETE /v1/statement/...` calls the adapter cancel path and does not release the slot if cancel fails.

## Test plan

- [ ] `cargo test -p queryflux-engine-adapters --lib cancel_treats_success`
- [ ] Clippy with `-D warnings` on `queryflux-engine-adapters` and `queryflux-frontend`
- [ ] Cancel a running Trino query: backend stops, slot is released
- [ ] If Trino cancel fails (e.g. 401), the proxy keeps the executing record and slot

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Trino query cancellation handling for successful responses and missing queries.
  * Cancellation failures now return an appropriate server error without prematurely releasing resources or deleting query records.
  * Added clearer handling when the required cluster adapter is unavailable.
  * Unexpected cancellation responses now include relevant error details, while successful and not-found responses complete correctly.
  * Added coverage for successful, failed, and unavailable-adapter cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->