### PR TITLE
fix(athena): bound wait_for_completion and refresh RoleArn credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,7 +3961,6 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-athena",
- "aws-sdk-sts",
  "aws-types",
  "bytes",
  "duckdb",

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -895,6 +895,11 @@ pub struct ClusterConfig {
     /// Default Athena catalog. Defaults to `"AwsDataCatalog"` when omitted.
     #[serde(default)]
     pub catalog: Option<String>,
+    /// Max seconds QueryFlux will poll Athena for query completion
+    /// (`maxWaitSecs` in JSON/YAML). Defaults to 600 (10 minutes) when omitted.
+    /// On timeout the proxy calls `StopQueryExecution`.
+    #[serde(default)]
+    pub max_wait_secs: Option<u64>,
     /// Max bytes of a single query result QueryFlux buffers in memory
     /// (`maxResultBufferBytes` in JSON/YAML). ClickHouse only; defaults to
     /// 1 GiB when omitted. Other engines ignore this.

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -122,7 +122,7 @@ fn json_positive_usize(v: &serde_json::Value) -> Option<usize> {
 /// - StarRocks: `poolSize` → [`ClusterConfig::pool_size`] for YAML-compat / `from_cluster_config` builds
 ///
 /// Other engine-specific fields (`databasePath`, `region`, `s3OutputLocation`, `workgroup`, `catalog`,
-/// `tls`) are **not** extracted here — each adapter reads those directly from JSON via its own
+/// `maxWaitSecs`, `tls`) are **not** extracted here — each adapter reads those directly from JSON via its own
 /// [`EngineConfigParseable::from_json`] implementation.
 pub fn cluster_config_from_persisted_json(
     engine: EngineConfig,
@@ -143,6 +143,7 @@ pub fn cluster_config_from_persisted_json(
         s3_output_location: None,
         workgroup: None,
         catalog: None,
+        max_wait_secs: None,
         tls: None,
         max_result_buffer_bytes: None,
         auth,

--- a/crates/queryflux-engine-adapters/Cargo.toml
+++ b/crates/queryflux-engine-adapters/Cargo.toml
@@ -20,8 +20,7 @@ arrow = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
 aws-sdk-athena = "1.104.0"
-aws-sdk-sts = "1"
-aws-config = { version = "1", default-features = false, features = ["rustls"] }
+aws-config = { version = "1", default-features = false, features = ["rustls", "rt-tokio"] }
 aws-credential-types = "1"
 aws-types = "1"
 url = "2"

--- a/crates/queryflux-engine-adapters/src/athena/mod.rs
+++ b/crates/queryflux-engine-adapters/src/athena/mod.rs
@@ -28,7 +28,38 @@ pub struct AthenaConfig {
     pub s3_output_location: String,
     pub workgroup: Option<String>,
     pub catalog: Option<String>,
+    /// Max seconds to poll for query completion before `StopQueryExecution`.
+    pub max_wait_secs: u64,
     pub auth: Option<ClusterAuth>,
+}
+
+/// Default proxy-side wait for Athena completion (`maxWaitSecs`).
+pub const DEFAULT_ATHENA_MAX_WAIT_SECS: u64 = 600;
+const ATHENA_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Bound for best-effort `StopQueryExecution` after the main wait deadline expires.
+const ATHENA_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Parse optional `maxWaitSecs` (positive integer seconds). Defaults to
+/// [`DEFAULT_ATHENA_MAX_WAIT_SECS`].
+fn parse_max_wait_secs_from_json(json: &serde_json::Value, cluster_name: &str) -> Result<u64> {
+    match json.get("maxWaitSecs") {
+        None => Ok(DEFAULT_ATHENA_MAX_WAIT_SECS),
+        Some(v) => v.as_u64().filter(|&n| n >= 1).ok_or_else(|| {
+            QueryFluxError::Engine(format!(
+                "cluster '{cluster_name}': maxWaitSecs must be a positive integer"
+            ))
+        }),
+    }
+}
+
+fn resolve_max_wait_secs(raw: Option<u64>, cluster_name: &str) -> Result<u64> {
+    match raw {
+        None => Ok(DEFAULT_ATHENA_MAX_WAIT_SECS),
+        Some(n) if n >= 1 => Ok(n),
+        Some(_) => Err(QueryFluxError::Engine(format!(
+            "cluster '{cluster_name}': maxWaitSecs must be a positive integer"
+        ))),
+    }
 }
 
 impl crate::EngineConfigParseable for AthenaConfig {
@@ -65,6 +96,7 @@ impl crate::EngineConfigParseable for AthenaConfig {
             s3_output_location,
             workgroup: json_str(json, "workgroup"),
             catalog: json_str(json, "catalog"),
+            max_wait_secs: parse_max_wait_secs_from_json(json, cluster_name)?,
             auth,
         })
     }
@@ -96,6 +128,7 @@ impl crate::EngineConfigParseable for AthenaConfig {
             s3_output_location,
             workgroup: cfg.workgroup.clone(),
             catalog: cfg.catalog.clone(),
+            max_wait_secs: resolve_max_wait_secs(cfg.max_wait_secs, cluster_name)?,
             auth,
         })
     }
@@ -121,12 +154,6 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
-/// Upper bound for Athena `GetQueryExecution` polling in the proxy.
-/// Workgroup query timeouts still apply server-side; this prevents an unbounded
-/// local loop if the execution never reaches a terminal state.
-const ATHENA_MAX_WAIT: Duration = Duration::from_secs(12 * 60 * 60);
-const ATHENA_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
 /// Amazon Athena adapter.
 ///
 /// Submits queries via `StartQueryExecution`, polls `GetQueryExecution` until complete,
@@ -147,6 +174,8 @@ pub struct AthenaAdapter {
     workgroup: String,
     /// Default Glue catalog. Defaults to `AwsDataCatalog`.
     catalog: String,
+    /// Proxy-side max wait for completion (`maxWaitSecs`).
+    max_wait: Duration,
 }
 
 impl AthenaAdapter {
@@ -233,40 +262,72 @@ impl AthenaAdapter {
             catalog: config
                 .catalog
                 .unwrap_or_else(|| "AwsDataCatalog".to_string()),
+            max_wait: Duration::from_secs(config.max_wait_secs),
         })
+    }
+
+    async fn stop_query_best_effort(&self, execution_id: &str) {
+        let stop = self
+            .client
+            .stop_query_execution()
+            .query_execution_id(execution_id)
+            .send();
+        match tokio::time::timeout(ATHENA_STOP_TIMEOUT, stop).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => {
+                warn!(
+                    execution_id = %execution_id,
+                    error = %aws_err(&e),
+                    "Athena StopQueryExecution failed (ignored)"
+                );
+            }
+            Err(_) => {
+                warn!(
+                    execution_id = %execution_id,
+                    "Athena StopQueryExecution timed out (ignored)"
+                );
+            }
+        }
     }
 
     /// Poll until the given query execution reaches a terminal state.
     /// Returns `Ok(())` on success, `Err` on failure, cancellation, or timeout.
     ///
-    /// Athena workgroups may enforce their own runtime limits; this bound also
-    /// stops the proxy from looping forever if status stays non-terminal, and
-    /// issues `StopQueryExecution` on timeout.
+    /// Athena workgroups may enforce their own runtime limits; `maxWaitSecs`
+    /// also stops the proxy from looping forever if status stays non-terminal,
+    /// and issues `StopQueryExecution` on timeout.
     async fn wait_for_completion(&self, execution_id: &str) -> Result<()> {
-        let deadline = tokio::time::Instant::now() + ATHENA_MAX_WAIT;
+        let deadline = tokio::time::Instant::now() + self.max_wait;
         loop {
             if tokio::time::Instant::now() >= deadline {
-                let _ = self
-                    .client
-                    .stop_query_execution()
-                    .query_execution_id(execution_id)
-                    .send()
-                    .await;
+                self.stop_query_best_effort(execution_id).await;
                 return Err(QueryFluxError::Engine(format!(
                     "Athena query {execution_id} exceeded max wait of {}s",
-                    ATHENA_MAX_WAIT.as_secs()
+                    self.max_wait.as_secs()
                 )));
             }
 
-            let resp = self
+            let get = self
                 .client
                 .get_query_execution()
                 .query_execution_id(execution_id)
-                .send()
-                .await
-                .map_err(|e| {
-                    QueryFluxError::Engine(format!("Athena GetQueryExecution: {}", aws_err(&e)))
-                })?;
+                .send();
+            let resp = match tokio::time::timeout_at(deadline, get).await {
+                Ok(Ok(resp)) => resp,
+                Ok(Err(e)) => {
+                    return Err(QueryFluxError::Engine(format!(
+                        "Athena GetQueryExecution: {}",
+                        aws_err(&e)
+                    )));
+                }
+                Err(_) => {
+                    self.stop_query_best_effort(execution_id).await;
+                    return Err(QueryFluxError::Engine(format!(
+                        "Athena query {execution_id} exceeded max wait of {}s",
+                        self.max_wait.as_secs()
+                    )));
+                }
+            };
 
             let state = resp
                 .query_execution()
@@ -794,6 +855,14 @@ impl AthenaAdapter {
                     example: Some("AwsDataCatalog"),
                 },
                 ConfigField {
+                    key: "maxWaitSecs",
+                    label: "Max wait (seconds)",
+                    description: "Max seconds QueryFlux polls Athena before cancelling the query. Defaults to 600 (10 minutes).",
+                    field_type: FieldType::Number,
+                    required: false,
+                    example: Some("600"),
+                },
+                ConfigField {
                     key: "auth.type",
                     label: "Auth type",
                     description: "Use 'accessKey' for static credentials. Omit to use the default AWS credential chain.",
@@ -924,9 +993,50 @@ mod tests {
     }
 
     #[test]
-    fn wait_for_completion_bound_is_finite() {
-        assert_eq!(ATHENA_MAX_WAIT, Duration::from_secs(12 * 60 * 60));
+    fn wait_for_completion_bound_defaults_to_ten_minutes() {
+        assert_eq!(DEFAULT_ATHENA_MAX_WAIT_SECS, 600);
         assert_eq!(ATHENA_POLL_INTERVAL, Duration::from_millis(500));
-        assert!(ATHENA_POLL_INTERVAL < ATHENA_MAX_WAIT);
+        assert!(ATHENA_POLL_INTERVAL < Duration::from_secs(DEFAULT_ATHENA_MAX_WAIT_SECS));
+    }
+
+    #[test]
+    fn max_wait_secs_parses_from_json() {
+        use crate::EngineConfigParseable;
+        use serde_json::json;
+
+        let cfg = AthenaConfig::from_json(
+            &json!({
+                "region": "us-east-1",
+                "s3OutputLocation": "s3://bucket/results/"
+            }),
+            "athena-1",
+        )
+        .expect("defaults");
+        assert_eq!(cfg.max_wait_secs, DEFAULT_ATHENA_MAX_WAIT_SECS);
+
+        let cfg = AthenaConfig::from_json(
+            &json!({
+                "region": "us-east-1",
+                "s3OutputLocation": "s3://bucket/results/",
+                "maxWaitSecs": 120
+            }),
+            "athena-1",
+        )
+        .expect("override");
+        assert_eq!(cfg.max_wait_secs, 120);
+
+        for bad in [json!(0), json!(-1), json!("600"), json!(null)] {
+            let err = AthenaConfig::from_json(
+                &json!({
+                    "region": "us-east-1",
+                    "s3OutputLocation": "s3://bucket/results/",
+                    "maxWaitSecs": bad
+                }),
+                "athena-1",
+            )
+            .map(|_| ())
+            .unwrap_err();
+            assert!(err.to_string().contains("maxWaitSecs"));
+        }
     }
 }

--- a/crates/queryflux-engine-adapters/src/athena/mod.rs
+++ b/crates/queryflux-engine-adapters/src/athena/mod.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use aws_sdk_sts;
-
 use arrow::array::{
     ArrayRef, BooleanBuilder, Float32Builder, Float64Builder, Int64Builder, StringBuilder,
 };
@@ -123,6 +121,12 @@ use queryflux_core::engine_registry::{
     AuthType, ConfigField, ConnectionType, EngineDescriptor, FieldType,
 };
 
+/// Upper bound for Athena `GetQueryExecution` polling in the proxy.
+/// Workgroup query timeouts still apply server-side; this prevents an unbounded
+/// local loop if the execution never reaches a terminal state.
+const ATHENA_MAX_WAIT: Duration = Duration::from_secs(12 * 60 * 60);
+const ATHENA_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
 /// Amazon Athena adapter.
 ///
 /// Submits queries via `StartQueryExecution`, polls `GetQueryExecution` until complete,
@@ -132,7 +136,8 @@ use queryflux_core::engine_registry::{
 ///
 /// Auth: set `auth.type: accessKey` for static credentials. When omitted the default
 /// AWS credential chain is used (env vars `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`,
-/// ECS task role, EC2 instance profile, etc.).
+/// ECS task role, EC2 instance profile, etc.). RoleArn auth uses a refreshing
+/// `AssumeRoleProvider` so temporary STS credentials renew before expiry.
 pub struct AthenaAdapter {
     pub cluster_name: ClusterName,
     pub group_name: ClusterGroupName,
@@ -181,37 +186,23 @@ impl AthenaAdapter {
                 role_arn,
                 external_id,
             }) => {
-                // First load the base config from the default credential chain,
-                // then use STS AssumeRole to obtain temporary credentials.
+                // Refreshing AssumeRole provider: temporary STS credentials expire
+                // (default 1h). A one-shot AssumeRole left the Athena client with
+                // static creds that never refreshed.
                 let base_config = aws_config::defaults(BehaviorVersion::latest())
                     .region(aws_region.clone())
                     .load()
                     .await;
-                let sts_client = aws_sdk_sts::Client::new(&base_config);
-                let mut assume = sts_client
-                    .assume_role()
-                    .role_arn(&role_arn)
-                    .role_session_name("queryflux-session");
+                let mut role_builder = aws_config::sts::AssumeRoleProvider::builder(&role_arn)
+                    .session_name("queryflux-session")
+                    .configure(&base_config);
                 if let Some(eid) = external_id {
-                    assume = assume.external_id(eid);
+                    role_builder = role_builder.external_id(eid);
                 }
-                let resp = assume
-                    .send()
-                    .await
-                    .map_err(|e| QueryFluxError::Engine(format!("STS AssumeRole failed: {e}")))?;
-                let creds_resp = resp.credentials().ok_or_else(|| {
-                    QueryFluxError::Engine("STS returned no credentials".to_string())
-                })?;
-                let creds = Credentials::new(
-                    creds_resp.access_key_id(),
-                    creds_resp.secret_access_key(),
-                    Some(creds_resp.session_token().to_string()),
-                    None,
-                    "queryflux-role-arn",
-                );
+                let provider = role_builder.build().await;
                 aws_config::defaults(BehaviorVersion::latest())
                     .region(aws_region.clone())
-                    .credentials_provider(creds)
+                    .credentials_provider(provider)
                     .load()
                     .await
             }
@@ -246,9 +237,27 @@ impl AthenaAdapter {
     }
 
     /// Poll until the given query execution reaches a terminal state.
-    /// Returns `Ok(())` on success, `Err` on failure or cancellation.
+    /// Returns `Ok(())` on success, `Err` on failure, cancellation, or timeout.
+    ///
+    /// Athena workgroups may enforce their own runtime limits; this bound also
+    /// stops the proxy from looping forever if status stays non-terminal, and
+    /// issues `StopQueryExecution` on timeout.
     async fn wait_for_completion(&self, execution_id: &str) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + ATHENA_MAX_WAIT;
         loop {
+            if tokio::time::Instant::now() >= deadline {
+                let _ = self
+                    .client
+                    .stop_query_execution()
+                    .query_execution_id(execution_id)
+                    .send()
+                    .await;
+                return Err(QueryFluxError::Engine(format!(
+                    "Athena query {execution_id} exceeded max wait of {}s",
+                    ATHENA_MAX_WAIT.as_secs()
+                )));
+            }
+
             let resp = self
                 .client
                 .get_query_execution()
@@ -284,7 +293,14 @@ impl AthenaAdapter {
                         "Athena query was cancelled".to_string(),
                     ));
                 }
-                _ => tokio::time::sleep(Duration::from_millis(500)).await,
+                _ => {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    let sleep_for = ATHENA_POLL_INTERVAL.min(remaining);
+                    if sleep_for.is_zero() {
+                        continue;
+                    }
+                    tokio::time::sleep(sleep_for).await;
+                }
             }
         }
     }
@@ -905,5 +921,12 @@ mod tests {
     #[test]
     fn null_emits_null_string() {
         assert_eq!(query_param_to_athena_string(&QueryParam::Null), "NULL");
+    }
+
+    #[test]
+    fn wait_for_completion_bound_is_finite() {
+        assert_eq!(ATHENA_MAX_WAIT, Duration::from_secs(12 * 60 * 60));
+        assert_eq!(ATHENA_POLL_INTERVAL, Duration::from_millis(500));
+        assert!(ATHENA_POLL_INTERVAL < ATHENA_MAX_WAIT);
     }
 }

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -832,6 +832,7 @@ mod tests {
             workgroup: None,
             catalog: None,
             tls: None,
+            max_wait_secs: None,
             max_result_buffer_bytes: None,
             auth: None,
             query_auth: None,


### PR DESCRIPTION
## Summary
- Cap Athena `wait_for_completion` at 12h and call `StopQueryExecution` on timeout (P0-13).
- Replace one-shot STS AssumeRole with refreshing `AssumeRoleProvider` for RoleArn auth (P0-14).
- Drop unused direct `aws-sdk-sts` dependency; enable `aws-config` `rt-tokio` for the provider.

## Test plan
- [x] `cargo test -p queryflux-engine-adapters --lib wait_for_completion_bound`
- [x] Clippy on `queryflux-engine-adapters` with `-D warnings`

Part of P0 Reliability (async wait timeout + cloud credential refresh).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS role-based authentication by automatically refreshing credentials.
  * Added a 12-hour maximum wait for Athena queries.
  * Timed-out queries are now stopped and reported with a clear timeout error.
  * Prevented unnecessary waiting after a query has completed or timed out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->