### PR TITLE
fix: cancel zombie/admin queries through adapters with cluster credentials

### DIFF
--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1190,37 +1190,22 @@ async fn cancel_executing(
 ) -> Response {
     let mut cancelled = false;
     if let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await {
-        if let Some(async_adapter) = adapter.as_async() {
-            if async_adapter
-                .cancel_query(&executing.backend_query_id)
-                .await
-                .is_ok()
-            {
-                cancelled = true;
-            } else {
+        match adapter.cancel_query(&executing.backend_query_id).await {
+            Ok(()) => cancelled = true,
+            Err(e) => {
                 warn!(
                     id = %executing.id,
                     backend = %executing.backend_query_id,
-                    "Admin adapter cancel failed"
+                    "Admin adapter cancel failed: {e}"
                 );
             }
         }
-    }
-    if let Some(base) = executing.poll_base_url.as_deref() {
-        let url = format!(
-            "{}/v1/statement/executing/{}/0",
-            base.trim_end_matches('/'),
-            executing.backend_query_id.0
+    } else {
+        warn!(
+            id = %executing.id,
+            cluster = %executing.cluster_name,
+            "Admin cancel: no adapter for cluster"
         );
-        match state.app.http_client.delete(&url).send().await {
-            Ok(resp) if resp.status().is_success() => cancelled = true,
-            Ok(resp) => warn!(
-                id = %executing.id,
-                status = %resp.status(),
-                "Admin HTTP cancel returned non-success"
-            ),
-            Err(e) => warn!(id = %executing.id, "Admin HTTP cancel failed: {e}"),
-        }
     }
     if !cancelled {
         return (

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1174,19 +1174,25 @@ async fn main() -> Result<()> {
                             "Evicting zombie executing query — not polled for >5 min"
                         );
 
-                        // Best-effort cancel on the backend engine so the query
-                        // doesn't keep consuming cluster resources.
-                        if let Some(base_url) = &q.poll_base_url {
-                            let cancel_url =
-                                format!("{base_url}/v1/statement/executing/{}", q.backend_query_id);
-                            let client = state.http_client.clone();
+                        // Best-effort cancel on the backend with cluster credentials
+                        // (same path as client/admin cancel). The previous unauthenticated
+                        // DELETE on `/v1/statement/executing/...` did not stop secured Trino.
+                        let backend_id = q.backend_query_id.clone();
+                        let cluster = q.cluster_name.0.clone();
+                        if let Some(adapter) = state.adapter(&cluster).await {
                             tokio::spawn(async move {
-                                if let Err(e) = client.delete(&cancel_url).send().await {
+                                if let Err(e) = adapter.cancel_query(&backend_id).await {
                                     tracing::debug!(
                                         "Zombie cancel request failed (best-effort): {e}"
                                     );
                                 }
                             });
+                        } else {
+                            tracing::debug!(
+                                cluster = %cluster,
+                                id = %q.backend_query_id,
+                                "No adapter available for zombie cancel"
+                            );
                         }
 
                         state


### PR DESCRIPTION
## Summary
- Zombie eviction (>5 min unpolled) now cancels via `AdapterKind::cancel_query` (cluster credentials), matching client cancel (#131).
- Admin `DELETE /admin/queries/{id}` uses the same adapter path for sync and async engines; remove the unauthenticated Trino HTTP DELETE fallback.
- Closes the remaining disconnect gap for Trino HTTP clients that drop without DELETE (slot + backend cancelled by the sweep).

## Test plan
- [x] Clippy on `queryflux` + `queryflux-frontend` with `-D warnings`
- [ ] Manual: leave a Trino HTTP query unpolled >5 min with cluster Bearer auth; confirm backend query is cancelled and slot released

Part of P0 Reliability / [#111](https://github.com/lakeops-org/queryflux/issues/111) (client disconnect cancel completeness).

Made with [Cursor](https://cursor.com)