### PR TITLE
fix: enforce maxQueuedQueries from LiveConfig

### DIFF
--- a/crates/queryflux-core/src/error.rs
+++ b/crates/queryflux-core/src/error.rs
@@ -40,6 +40,14 @@ pub enum QueryFluxError {
     #[error("Cluster {0} requires Arrow execution path")]
     SyncEngineRequired(String),
 
+    /// The cluster group's `maxQueuedQueries` limit has been reached.
+    #[error("Queue full for group '{group}': {count}/{limit} queued queries")]
+    QueueFull {
+        group: String,
+        count: u64,
+        limit: u64,
+    },
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -82,5 +90,23 @@ impl QueryFluxError {
             // misses, config errors, not-found, etc.
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryFluxError;
+
+    #[test]
+    fn queue_full_display_includes_counts() {
+        let err = QueryFluxError::QueueFull {
+            group: "analytics".into(),
+            count: 5,
+            limit: 5,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("analytics"), "{msg}");
+        assert!(msg.contains("5/5"), "{msg}");
+        assert!(!err.is_transient());
     }
 }

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -328,6 +328,7 @@ impl TestHarness {
             group_order,
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
@@ -567,6 +568,7 @@ impl WireTestHarness {
             group_order: vec![GROUP_DUCKDB.to_string()],
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
@@ -701,6 +703,7 @@ impl WireTestHarness {
             group_order: vec![GROUP_STARROCKS.to_string()],
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -132,9 +132,6 @@ pub async fn dispatch_query(
         guard_chain,
         group_guard_chain,
         cluster_cfg,
-        // TODO: plumb max_queued_queries through LiveConfig. Add a field like
-        // `group_max_queued_queries: HashMap<String, Option<u64>>` to LiveConfig,
-        // populated from ClusterGroupConfig.max_queued_queries during reload.
         max_queued_queries,
     ) = {
         let live = state.live.read().await;
@@ -154,7 +151,10 @@ pub async fn dispatch_query(
             // cluster_cfg resolved after cluster selection below; captured here
             // so credential resolution uses the same config generation.
             live.cluster_configs.clone(),
-            None::<u64>,
+            live.group_max_queued_queries
+                .get(&group.0)
+                .copied()
+                .flatten(),
         )
     };
 
@@ -757,27 +757,31 @@ async fn persist_queued_query(
     session: SessionContext,
     protocol: FrontendProtocol,
     group: ClusterGroupName,
-    _already_stored: bool,
+    already_stored: bool,
     sequence: u64,
     max_queued_queries: Option<u64>,
     auth_ctx: &AuthContext,
 ) -> Result<String> {
     // Enforce queue depth limit before admitting to the queue.
-    if let Some(limit) = max_queued_queries {
-        if limit > 0 {
-            let active_after = Utc::now() - chrono::Duration::seconds(QUEUE_ACTIVE_WINDOW_SECS);
-            let count = state
-                .persistence
-                .count_active_queued_before(&group.0, None, active_after)
-                .await
-                .unwrap_or(0);
-            if count >= limit {
-                return Err(QueryFluxError::Other(anyhow::anyhow!(
-                    "Queue full for group '{}': {}/{} queued queries",
-                    group.0,
-                    count,
-                    limit
-                )));
+    // Skip when re-persisting an already-queued query so a waiter cannot
+    // self-reject by counting itself against the limit.
+    if !already_stored {
+        if let Some(limit) = max_queued_queries {
+            if limit > 0 {
+                let active_after = Utc::now() - chrono::Duration::seconds(QUEUE_ACTIVE_WINDOW_SECS);
+                let count = state
+                    .persistence
+                    .count_active_queued_before(&group.0, None, active_after)
+                    .await
+                    .unwrap_or(0);
+                if count >= limit {
+                    state.metrics.on_queue_full(&group.0);
+                    return Err(QueryFluxError::QueueFull {
+                        group: group.0.clone(),
+                        count,
+                        limit,
+                    });
+                }
             }
         }
     }
@@ -2006,4 +2010,197 @@ async fn execute_to_sink_inner(
     state.record_query(&setup.ctx, final_outcome);
 
     sink_result
+}
+
+#[cfg(test)]
+mod queue_limit_tests {
+    use super::persist_queued_query;
+    use crate::state::test_fixtures::app_state;
+    use queryflux_auth::AuthContext;
+    use queryflux_core::error::QueryFluxError;
+    use queryflux_core::query::{ClusterGroupName, FrontendProtocol, ProxyQueryId};
+    use queryflux_core::session::SessionContext;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn persist_queued_rejects_when_at_limit() {
+        let state = app_state(false);
+        let auth = AuthContext {
+            user: "alice".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let group = ClusterGroupName("default".into());
+
+        persist_queued_query(
+            &state,
+            ProxyQueryId::new(),
+            "SELECT 1".into(),
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group.clone(),
+            false,
+            0,
+            Some(1),
+            &auth,
+        )
+        .await
+        .expect("first enqueue");
+
+        let err = persist_queued_query(
+            &state,
+            ProxyQueryId::new(),
+            "SELECT 2".into(),
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group.clone(),
+            false,
+            0,
+            Some(1),
+            &auth,
+        )
+        .await
+        .expect_err("second enqueue must fail");
+        match err {
+            QueryFluxError::QueueFull {
+                group: g,
+                count,
+                limit,
+            } => {
+                assert_eq!(g, "default");
+                assert_eq!(count, 1);
+                assert_eq!(limit, 1);
+            }
+            other => panic!("expected QueueFull, got {other}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn already_stored_skips_limit_check() {
+        let state = app_state(false);
+        let auth = AuthContext {
+            user: "alice".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let group = ClusterGroupName("default".into());
+        let id = ProxyQueryId::new();
+
+        persist_queued_query(
+            &state,
+            id.clone(),
+            "SELECT 1".into(),
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group.clone(),
+            false,
+            0,
+            Some(1),
+            &auth,
+        )
+        .await
+        .expect("first enqueue");
+
+        persist_queued_query(
+            &state,
+            id,
+            "SELECT 1".into(),
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group,
+            true,
+            1,
+            Some(1),
+            &auth,
+        )
+        .await
+        .expect("already_stored must bypass limit");
+    }
+
+    #[tokio::test]
+    async fn dispatch_reads_limit_from_live_config() {
+        use super::dispatch_query;
+        use queryflux_cluster_manager::cluster_state::ClusterState;
+        use queryflux_cluster_manager::simple::SimpleClusterGroupManager;
+        use queryflux_core::query::{ClusterName, EngineType};
+        use std::sync::Arc;
+
+        let state = app_state(false);
+        {
+            let mut live = state.live.write().await;
+            live.group_max_queued_queries
+                .insert("default".into(), Some(1));
+            let group = ClusterGroupName("default".into());
+            let cluster = ClusterName("trino".into());
+            let cluster_state = Arc::new(ClusterState::new(
+                cluster.clone(),
+                group.clone(),
+                None,
+                None,
+                EngineType::Trino,
+                Some("http://trino.test:8080".into()),
+                0,
+                true,
+            ));
+            let mut groups = HashMap::new();
+            groups.insert(
+                group.clone(),
+                (
+                    vec![cluster_state],
+                    Arc::new(queryflux_cluster_manager::strategy::RoundRobinStrategy::new())
+                        as Arc<dyn queryflux_cluster_manager::strategy::ClusterSelectionStrategy>,
+                ),
+            );
+            live.cluster_manager = Arc::new(SimpleClusterGroupManager::new(groups));
+        }
+
+        let auth = AuthContext {
+            user: "alice".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let group = ClusterGroupName("default".into());
+
+        dispatch_query(
+            &state,
+            ProxyQueryId::new(),
+            "SELECT 1".into(),
+            vec![],
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group.clone(),
+            false,
+            None,
+            0,
+            &auth,
+        )
+        .await
+        .expect("first should queue");
+
+        let err = match dispatch_query(
+            &state,
+            ProxyQueryId::new(),
+            "SELECT 2".into(),
+            vec![],
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            group,
+            false,
+            None,
+            0,
+            &auth,
+        )
+        .await
+        {
+            Ok(_) => panic!("second should hit QueueFull"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, QueryFluxError::QueueFull { limit: 1, .. }),
+            "got {err}"
+        );
+    }
 }

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -54,6 +54,10 @@ pub struct LiveConfig {
     /// group_name → default tags configured on the group.
     /// Merged with session tags at dispatch time; session tags win on key conflicts.
     pub group_default_tags: HashMap<String, QueryTags>,
+    /// group_name → optional `maxQueuedQueries` from ClusterGroupConfig.
+    /// `None` / missing entry means unlimited. `Some(0)` is treated as unlimited
+    /// (same as the enforce check requiring `limit > 0`).
+    pub group_max_queued_queries: HashMap<String, Option<u64>>,
     /// group_name → cache settings for groups that have caching enabled.
     pub group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig>,
     /// Verifies client identity — hot-reloaded when security config changes via admin API.
@@ -329,6 +333,7 @@ pub mod test_fixtures {
             group_order: vec![group_name.0.clone()],
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(auth_required)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -157,7 +157,8 @@ fn client_safe_message(e: &QueryFluxError) -> &'static str {
         Engine(_) => "Backend engine error",
         Routing(_) | NoClusterGroupAvailable(_) => "Query routing failed",
         Config(_) => "Configuration error",
-        Auth(_) | Unauthorized(_) | QueryNotFound(_) | ClusterNotFound(_) => "",
+        // Empty → caller forwards Display (includes group/count/limit for QueueFull).
+        Auth(_) | Unauthorized(_) | QueryNotFound(_) | ClusterNotFound(_) | QueueFull { .. } => "",
         _ => "Internal error",
     }
 }
@@ -1540,6 +1541,7 @@ mod cancel_executing_statement_tests {
             group_order: vec![group_name.0.clone()],
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -725,6 +725,12 @@ async fn main() -> Result<()> {
         .filter(|(_, g)| !g.default_tags.is_empty())
         .map(|(name, g)| (name.clone(), g.default_tags.clone()))
         .collect();
+    let group_max_queued_queries: HashMap<String, Option<u64>> = config
+        .cluster_groups
+        .iter()
+        .filter(|(_, g)| g.max_queued_queries.is_some())
+        .map(|(name, g)| (name.clone(), g.max_queued_queries))
+        .collect();
     let group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig> = config
         .cluster_groups
         .iter()
@@ -747,6 +753,7 @@ async fn main() -> Result<()> {
         group_order,
         group_translation_scripts,
         group_default_tags,
+        group_max_queued_queries,
         group_cache_settings,
         auth_provider,
         authorization,
@@ -2217,6 +2224,12 @@ async fn build_live_config(
         .map(|(name, g)| (name.clone(), g.default_tags.clone()))
         .collect();
 
+    let group_max_queued_queries: HashMap<String, Option<u64>> = cluster_groups
+        .iter()
+        .filter(|(_, g)| g.max_queued_queries.is_some())
+        .map(|(name, g)| (name.clone(), g.max_queued_queries))
+        .collect();
+
     let group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig> =
         cluster_groups
             .iter()
@@ -2261,6 +2274,7 @@ async fn build_live_config(
         group_order,
         group_translation_scripts,
         group_default_tags,
+        group_max_queued_queries,
         group_cache_settings,
         auth_provider: Arc::new(NoneAuthProvider::new(false)),
         authorization: Arc::new(AllowAllAuthorization::default()),


### PR DESCRIPTION
## Summary
- Populate `LiveConfig.group_max_queued_queries` from cluster group config at startup and reload.
- Reject new queue admissions with `QueryFluxError::QueueFull` and increment `on_queue_full`.
- Skip the depth check when re-persisting an already-queued query; surface QueueFull to Trino clients.

## Test plan
- [x] `cargo test -p queryflux-core --lib queue_full`
- [x] `cargo test -p queryflux-frontend --lib queue_limit`
- [x] Clippy on touched crates with `-D warnings`

Part of P1 admission (P1-21 / enforce maxQueuedQueries).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable per-group limits for queued queries.
  - Queue limits now apply to newly queued queries and update during configuration reloads.
  - Added clear queue-full errors showing the affected group and queue limit.

- **Bug Fixes**
  - Existing queued queries can be persisted without being blocked by newly configured limits.
  - Queue-full responses now display an informative error message and are tracked in metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->