### PR TITLE
fix: increment auth_failures_total on frontend auth errors

### DIFF
--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -197,10 +197,15 @@ impl FlightSqlService for QueryFluxFlightSql {
             ..Default::default()
         };
         let auth_provider = self.state.live.read().await.auth_provider.clone();
-        let auth_ctx = auth_provider
-            .authenticate(&creds)
-            .await
-            .map_err(|e| Status::unauthenticated(e.to_string()))?;
+        let auth_ctx = match auth_provider.authenticate(&creds).await {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                self.state
+                    .metrics
+                    .on_auth_failure(&format!("{:?}", FrontendProtocol::FlightSql));
+                return Err(Status::unauthenticated(e.to_string()));
+            }
+        };
 
         let routing_result = {
             let live = self.state.live.read().await;

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -298,6 +298,9 @@ async fn handle_com_query(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::MySqlWire));
             write_packet(writer, start_seq, &build_err(1045, &e.to_string())).await?;
             return Ok(());
         }

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -311,6 +311,9 @@ async fn handle_simple_query(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::PostgresWire));
             write_error_response(writer, "28000", &e.to_string()).await?;
             write_msg(writer, b'Z', b"I").await?;
             return Ok(());

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -53,6 +53,10 @@ pub async fn login_request(
     {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .app
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::SnowflakeHttp));
             warn!(user = %login_name, "Snowflake wire login failed: {e}");
             return (
                 StatusCode::UNAUTHORIZED,

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -321,5 +321,10 @@ async fn authenticate(
             bearer_token: bearer,
         })
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::SnowflakeSqlApi));
+            e.to_string()
+        })
 }

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -504,6 +504,9 @@ pub async fn post_statement(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::TrinoHttp));
             warn!("Authentication failed: {e}");
             return StatusCode::UNAUTHORIZED.into_response();
         }
@@ -729,6 +732,9 @@ pub async fn get_queued_statement(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::TrinoHttp));
             warn!("Queued poll auth failed: {e}");
             return StatusCode::UNAUTHORIZED.into_response();
         }
@@ -1017,6 +1023,9 @@ pub async fn get_executing_statement(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::TrinoHttp));
             warn!("Poll auth failed: {e}");
             return StatusCode::UNAUTHORIZED.into_response();
         }
@@ -1338,6 +1347,9 @@ pub async fn delete_executing_statement(
     let auth_ctx = match auth_provider.authenticate(&creds).await {
         Ok(ctx) => ctx,
         Err(e) => {
+            state
+                .metrics
+                .on_auth_failure(&format!("{:?}", FrontendProtocol::TrinoHttp));
             warn!("Cancel auth failed: {e}");
             return StatusCode::UNAUTHORIZED.into_response();
         }


### PR DESCRIPTION
## Summary
- Call `MetricsStore::on_auth_failure` with `FrontendProtocol` Debug labels on AuthProvider `Err` paths for Trino HTTP (submit/poll/queued/cancel), Postgres wire, MySQL wire, Flight SQL, Snowflake login, and Snowflake SQL API.
- Leaves Admin Basic auth out of scope for this change.

## Test plan
- [ ] Auth required + bad credentials on Trino `/v1/statement` increments `queryflux_auth_failures_total{protocol="TrinoHttp"}`
- [ ] Same for Postgres/MySQL wire and Snowflake login paths
- [ ] Successful auth does not increment the counter


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Monitoring**
  * Authentication failures across Flight SQL, MySQL, PostgreSQL, Snowflake, and Trino interfaces are now captured in frontend metrics.
  * Metrics identify the protocol where the failure occurred, improving visibility into authentication issues.

* **Behavior**
  * Existing authentication error responses and request handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->