### PR TITLE
fix(helm): startupProbe, terminationGracePeriod, and appVersion 0.2.0

### DIFF
--- a/charts/queryflux/Chart.yaml
+++ b/charts/queryflux/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: queryflux
 description: Universal SQL multi-engine query router and proxy.
 type: application
-version: 0.1.0
-appVersion: "0.1.2"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://queryflux.dev/
 sources:
   - https://github.com/lakeops-org/queryflux

--- a/charts/queryflux/README.md
+++ b/charts/queryflux/README.md
@@ -88,6 +88,8 @@ existingSecret:
 - `pdb.enabled`: create a PodDisruptionBudget.
 - `networkPolicy.enabled`: create a NetworkPolicy. The default policy body is empty so operators can define provider-specific ingress and egress rules.
 - `serviceMonitor.enabled`: create a Prometheus Operator ServiceMonitor for `/metrics` on the admin port.
+- `startupProbe`: HTTP check on `/readyz` (admin port) so liveness does not kill slow startups.
+- `terminationGracePeriodSeconds`: default `45`. Keep this ≥ `queryflux.shutdownDrainTimeoutSecs` (default `30`) plus a buffer so Kubernetes does not SIGKILL mid-drain.
 
 The chart also supports `env`, `envFrom`, `extraVolumes`, `extraVolumeMounts`, `extraContainers`, `nodeSelector`, `tolerations`, `affinity`, and `topologySpreadConstraints` for platform-specific integration.
 

--- a/charts/queryflux/examples/production-values.yaml
+++ b/charts/queryflux/examples/production-values.yaml
@@ -117,6 +117,9 @@ resources:
   limits:
     memory: 2Gi
 
+# Keep ≥ queryflux.shutdownDrainTimeoutSecs (default 30) + buffer.
+terminationGracePeriodSeconds: 45
+
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: kubernetes.io/hostname

--- a/charts/queryflux/templates/deployment.yaml
+++ b/charts/queryflux/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "queryflux.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -76,6 +79,10 @@ spec:
               protocol: {{ $port.protocol }}
             {{- end }}
             {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/queryflux/values.yaml
+++ b/charts/queryflux/values.yaml
@@ -180,6 +180,16 @@ livenessProbe:
   timeoutSeconds: 2
   failureThreshold: 6
 
+# Delays liveness/readiness until the process is ready (e.g. slow startup with
+# large configs). Default allows up to ~5 minutes (periodSeconds * failureThreshold).
+startupProbe:
+  httpGet:
+    path: /readyz
+    port: admin
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 60
+
 readinessProbe:
   httpGet:
     path: /readyz
@@ -188,6 +198,10 @@ readinessProbe:
   periodSeconds: 5
   timeoutSeconds: 2
   failureThreshold: 6
+
+# Must be ≥ queryflux.shutdownDrainTimeoutSecs (default 30) plus a buffer so
+# Kubernetes does not SIGKILL mid-drain.
+terminationGracePeriodSeconds: 45
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Summary
- Set `terminationGracePeriodSeconds: 45` (must stay ≥ `shutdownDrainTimeoutSecs` + buffer).
- Add `startupProbe` on admin `/readyz` (5s period, failureThreshold 60).
- Bump chart `version` / `appVersion` to `0.2.0`; document in README and production-values.

## Test plan
- [ ] `scripts/check-helm-chart.sh` / `make helm-check` passes
- [ ] Rendered Deployment includes `startupProbe` and `terminationGracePeriodSeconds: 45`
- [ ] Image tag defaults to `0.2.0` when `image.tag` is empty


Made with [Cursor](https://cursor.com)