### PR TITLE
fix: count config reload and auth rebuild failures

### DIFF
--- a/crates/queryflux-metrics/src/lib.rs
+++ b/crates/queryflux-metrics/src/lib.rs
@@ -58,6 +58,12 @@ impl MetricsStore for MultiMetricsStore {
         }
     }
 
+    fn on_config_reload_failure(&self, stage: &str) {
+        for s in &self.stores {
+            s.on_config_reload_failure(stage);
+        }
+    }
+
     fn on_queue_full(&self, cluster_group: &str) {
         for s in &self.stores {
             s.on_queue_full(cluster_group);

--- a/crates/queryflux-metrics/src/prometheus_store.rs
+++ b/crates/queryflux-metrics/src/prometheus_store.rs
@@ -40,6 +40,8 @@ pub struct PrometheusMetrics {
     capacity_degraded_total: CounterVec,
     /// queryflux_auth_failures_total{protocol}
     auth_failures_total: CounterVec,
+    /// queryflux_config_reload_failures_total{stage}
+    config_reload_failures_total: CounterVec,
     /// queryflux_queue_rejections_total{cluster_group}
     queue_rejections_total: CounterVec,
     /// queryflux_queue_duration_seconds{cluster_group}
@@ -136,6 +138,14 @@ impl PrometheusMetrics {
             &["protocol"],
         )?;
 
+        let config_reload_failures_total = CounterVec::new(
+            Opts::new(
+                "queryflux_config_reload_failures_total",
+                "Config / auth / guard hot-reload soft-failures that kept last-good config",
+            ),
+            &["stage"],
+        )?;
+
         let queue_rejections_total = CounterVec::new(
             Opts::new(
                 "queryflux_queue_rejections_total",
@@ -180,6 +190,7 @@ impl PrometheusMetrics {
         registry.register(Box::new(coordination_failures_total.clone()))?;
         registry.register(Box::new(capacity_degraded_total.clone()))?;
         registry.register(Box::new(auth_failures_total.clone()))?;
+        registry.register(Box::new(config_reload_failures_total.clone()))?;
         registry.register(Box::new(queue_rejections_total.clone()))?;
         registry.register(Box::new(queue_duration_seconds.clone()))?;
         registry.register(Box::new(cache_hits_total.clone()))?;
@@ -197,6 +208,7 @@ impl PrometheusMetrics {
             coordination_failures_total,
             capacity_degraded_total,
             auth_failures_total,
+            config_reload_failures_total,
             queue_rejections_total,
             queue_duration_seconds,
             cache_hits_total,
@@ -256,6 +268,12 @@ impl MetricsStore for PrometheusMetrics {
     fn on_auth_failure(&self, protocol: &str) {
         self.auth_failures_total
             .with_label_values(&[protocol])
+            .inc();
+    }
+
+    fn on_config_reload_failure(&self, stage: &str) {
+        self.config_reload_failures_total
+            .with_label_values(&[stage])
             .inc();
     }
 
@@ -336,5 +354,31 @@ impl MetricsStore for PrometheusMetrics {
             .set(snapshot.queued_queries as f64);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_persistence::MetricsStore;
+
+    #[test]
+    fn config_reload_failure_increments_counter() {
+        let metrics = PrometheusMetrics::new().expect("prometheus init");
+        metrics.on_config_reload_failure("auth_rebuild");
+        metrics.on_config_reload_failure("auth_rebuild");
+        let text = metrics.gather_text();
+        assert!(
+            text.contains("queryflux_config_reload_failures_total"),
+            "missing metric in scrape:\n{text}"
+        );
+        assert!(
+            text.contains("stage=\"auth_rebuild\""),
+            "missing stage label in scrape:\n{text}"
+        );
+        assert!(
+            text.contains('2') || text.contains("2\n"),
+            "expected counter value 2 in scrape:\n{text}"
+        );
     }
 }

--- a/crates/queryflux-persistence/src/metrics_store.rs
+++ b/crates/queryflux-persistence/src/metrics_store.rs
@@ -138,6 +138,11 @@ pub trait MetricsStore: Send + Sync {
     /// A sustained spike can indicate a credential-stuffing attack.
     fn on_auth_failure(&self, _protocol: &str) {}
 
+    /// Called when a hot-reload soft-fails and last-good config is retained.
+    /// `stage` is a low-cardinality label such as `reload`, `auth_rebuild`,
+    /// `authz_rebuild`, or `guard_reload`.
+    fn on_config_reload_failure(&self, _stage: &str) {}
+
     /// Called when a queue admission is rejected because `maxQueuedQueries` was reached.
     fn on_queue_full(&self, _cluster_group: &str) {}
 

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1310,6 +1310,7 @@ async fn main() -> Result<()> {
         let cache = adapter_reload_cache.clone();
         let notify = config_reload_notify.clone();
         let admin_for_reload = admin_store_for_reload;
+        let metrics = app_state.metrics.clone();
         let periodic_secs = config.queryflux.periodic_config_reload_interval_secs();
 
         // Subscribe to distributed config revision changes (push where the
@@ -1335,6 +1336,7 @@ async fn main() -> Result<()> {
                 backend: &Arc<dyn BackendStore>,
                 cache: &tokio::sync::Mutex<AdapterReloadCache>,
                 live: &Arc<tokio::sync::RwLock<LiveConfig>>,
+                metrics: &Arc<dyn MetricsStore>,
             ) {
                 let mut cache_guard = cache.lock().await;
                 // Snapshot the pieces a reload must never silently weaken; the
@@ -1348,18 +1350,22 @@ async fn main() -> Result<()> {
                         group_guard_chains: l.group_guard_chains.clone(),
                     }
                 };
-                match reload_live_config(backend, &mut cache_guard, &prev).await {
+                match reload_live_config(backend, &mut cache_guard, &prev, metrics).await {
                     Ok(new_live) => {
                         *live.write().await = new_live;
                         tracing::info!("Live config reloaded from backend");
                     }
-                    Err(e) => tracing::warn!("Config reload failed: {e}"),
+                    Err(e) => {
+                        metrics.on_config_reload_failure("reload");
+                        tracing::warn!("Config reload failed: {e}");
+                    }
                 }
             }
 
             async fn reload_guard_chain_from_admin(
                 admin: &Option<Arc<dyn AdminStore>>,
                 live: &Arc<tokio::sync::RwLock<LiveConfig>>,
+                metrics: &Arc<dyn MetricsStore>,
             ) {
                 if let Some(store) = admin {
                     let guard_script_bodies =
@@ -1377,7 +1383,10 @@ async fn main() -> Result<()> {
                             w.guard_chain = None;
                             w.group_guard_chains = HashMap::new();
                         }
-                        Err(e) => tracing::warn!("Guard chain reload failed: {e}"),
+                        Err(e) => {
+                            metrics.on_config_reload_failure("guard_reload");
+                            tracing::warn!("Guard chain reload failed: {e}");
+                        }
                     }
                 }
             }
@@ -1387,16 +1396,17 @@ async fn main() -> Result<()> {
                 cache: &tokio::sync::Mutex<AdapterReloadCache>,
                 live: &Arc<tokio::sync::RwLock<LiveConfig>>,
                 admin: &Option<Arc<dyn AdminStore>>,
+                metrics: &Arc<dyn MetricsStore>,
             ) {
                 if let Some(backend) = backend {
-                    do_reload(backend, cache, live).await;
+                    do_reload(backend, cache, live, metrics).await;
                 } else {
                     // YAML-mode reload contract: without a Postgres backend, routing rules,
                     // cluster configs, and adapters are fixed at startup from the YAML file
                     // and cannot change at runtime. Only guard chains (stored in the admin
                     // store) can be hot-reloaded via the admin API. Routing or cluster
                     // changes in YAML require a process restart.
-                    reload_guard_chain_from_admin(admin, live).await;
+                    reload_guard_chain_from_admin(admin, live, metrics).await;
                 }
             }
 
@@ -1447,7 +1457,7 @@ async fn main() -> Result<()> {
                         }
                     }
                     coalesce_revisions(&mut revision_rx).await;
-                    do_reload_or_guard(&backend, &cache, &live, &admin_for_reload).await;
+                    do_reload_or_guard(&backend, &cache, &live, &admin_for_reload, &metrics).await;
                 },
                 Some(interval_secs) => {
                     let mut interval =
@@ -1464,7 +1474,8 @@ async fn main() -> Result<()> {
                             }
                         }
                         coalesce_revisions(&mut revision_rx).await;
-                        do_reload_or_guard(&backend, &cache, &live, &admin_for_reload).await;
+                        do_reload_or_guard(&backend, &cache, &live, &admin_for_reload, &metrics)
+                            .await;
                     }
                 }
             }
@@ -2286,6 +2297,7 @@ async fn reload_live_config(
     pg: &Arc<dyn BackendStore>,
     cache: &mut AdapterReloadCache,
     prev: &PreservedLive,
+    metrics: &Arc<dyn MetricsStore>,
 ) -> Result<LiveConfig> {
     let cluster_records = pg
         .list_cluster_configs()
@@ -2374,6 +2386,7 @@ async fn reload_live_config(
         }
         Ok(None) => {}
         Err(e) => {
+            metrics.on_config_reload_failure("guard_reload");
             tracing::warn!("Reload: guardrails_config read failed; keeping previous chains: {e}")
         }
     }
@@ -2389,11 +2402,15 @@ async fn reload_live_config(
             match auth_cfg.as_ref().map(|cfg| build_auth_provider(cfg)) {
                 Some(Ok(provider)) => live.auth_provider = provider,
                 Some(Err(e)) => {
+                    metrics.on_config_reload_failure("auth_rebuild");
                     tracing::warn!("Reload: failed to rebuild auth provider; keeping previous: {e}")
                 }
-                None => tracing::warn!(
-                    "Reload: security_config has no recognizable auth section; keeping previous"
-                ),
+                None => {
+                    metrics.on_config_reload_failure("auth_rebuild");
+                    tracing::warn!(
+                        "Reload: security_config has no recognizable auth section; keeping previous"
+                    );
+                }
             }
             match auth_cfg {
                 Some(auth) => {
@@ -2402,16 +2419,21 @@ async fn reload_live_config(
                     {
                         Some(Ok(checker)) => live.authorization = checker,
                         Some(Err(e)) => {
+                            metrics.on_config_reload_failure("authz_rebuild");
                             tracing::warn!(
                                 "Reload: failed to rebuild authorization; keeping previous: {e}"
                             )
                         }
-                        None => tracing::warn!(
+                        None => {
+                            metrics.on_config_reload_failure("authz_rebuild");
+                            tracing::warn!(
                             "Reload: security_config has no recognizable authorization section; keeping previous"
-                        ),
+                        );
+                        }
                     }
                 }
                 None if authz_cfg.is_some() => {
+                    metrics.on_config_reload_failure("authz_rebuild");
                     tracing::warn!(
                         "Reload: security_config has authorization but no auth section; keeping previous authorization (operator policy unchanged)"
                     );
@@ -2421,6 +2443,7 @@ async fn reload_live_config(
         }
         Ok(None) => {}
         Err(e) => {
+            metrics.on_config_reload_failure("auth_rebuild");
             tracing::warn!("Reload: security_config read failed; keeping previous auth: {e}")
         }
     }


### PR DESCRIPTION
## Summary
- Add `MetricsStore::on_config_reload_failure(stage)` and Prometheus `queryflux_config_reload_failures_total{stage}`.
- Increment at existing soft-fail warn sites for full reload, auth/authz rebuild, and guard reload while keeping last-good config.

## Test plan
- [ ] Unit test `config_reload_failure_increments_counter` passes
- [ ] Force a bad `security_config` rebuild and confirm scrape shows `stage="auth_rebuild"`
- [ ] Successful reload does not increment the counter


Made with [Cursor](https://cursor.com)