### PR TITLE
fix: bound capacity wait with capacityWaitTimeoutSecs

### DIFF
--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -811,6 +811,9 @@ impl Default for AdminApiConfig {
 
 // --- Cluster groups ---
 
+/// Default proxy-side wait for cluster capacity (`capacityWaitTimeoutSecs`).
+pub const DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS: u64 = 300;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterGroupConfig {
@@ -825,6 +828,10 @@ pub struct ClusterGroupConfig {
     pub max_running_queries: u64,
     #[serde(default)]
     pub max_queued_queries: Option<u64>,
+    /// Max seconds a query may wait for capacity (sync spin or async queue).
+    /// Defaults to [`DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS`] when omitted.
+    #[serde(default)]
+    pub capacity_wait_timeout_secs: Option<u64>,
     /// Simple authorization policy (used when `authorization.provider: none`).
     /// If both lists are empty/absent, all authenticated users are allowed.
     #[serde(default)]
@@ -837,6 +844,16 @@ pub struct ClusterGroupConfig {
     /// Query result cache configuration for this group. Omit to disable caching.
     #[serde(default)]
     pub cache: Option<GroupCacheConfig>,
+}
+
+impl ClusterGroupConfig {
+    /// Resolved capacity wait timeout; omitted / zero → [`DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS`].
+    pub fn capacity_wait_timeout_secs_or_default(&self) -> u64 {
+        match self.capacity_wait_timeout_secs {
+            Some(n) if n > 0 => n,
+            _ => DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS,
+        }
+    }
 }
 
 /// Simple allow-list authorization for a cluster group.

--- a/crates/queryflux-core/src/error.rs
+++ b/crates/queryflux-core/src/error.rs
@@ -48,6 +48,12 @@ pub enum QueryFluxError {
         limit: u64,
     },
 
+    /// No cluster capacity within `capacityWaitTimeoutSecs`.
+    #[error(
+        "Capacity wait timed out for group '{group}' after {timeout_secs}s — no slot available"
+    )]
+    CapacityWaitTimeout { group: String, timeout_secs: u64 },
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -107,6 +113,18 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("analytics"), "{msg}");
         assert!(msg.contains("5/5"), "{msg}");
+        assert!(!err.is_transient());
+    }
+
+    #[test]
+    fn capacity_wait_timeout_display() {
+        let err = QueryFluxError::CapacityWaitTimeout {
+            group: "analytics".into(),
+            timeout_secs: 300,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("analytics"), "{msg}");
+        assert!(msg.contains("300"), "{msg}");
         assert!(!err.is_transient());
     }
 }

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -329,6 +329,7 @@ impl TestHarness {
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
             group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
@@ -569,6 +570,7 @@ impl WireTestHarness {
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
             group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
@@ -704,6 +706,7 @@ impl WireTestHarness {
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
             group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -1169,8 +1169,13 @@ async fn setup_sync_query(
 ) -> Result<SyncQuerySetup> {
     let query_id = ProxyQueryId::new();
 
-    let (cluster_manager, group_fixups, group_default_tags, cluster_configs) = {
+    let (cluster_manager, group_fixups, group_default_tags, cluster_configs, wait_timeout_secs) = {
         let live = state.live.read().await;
+        let wait_timeout_secs = live
+            .group_capacity_wait_timeout_secs
+            .get(&group.0)
+            .copied()
+            .unwrap_or(queryflux_core::config::DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS);
         (
             live.cluster_manager.clone(),
             live.group_translation_scripts
@@ -1182,6 +1187,7 @@ async fn setup_sync_query(
                 .cloned()
                 .unwrap_or_default(),
             live.cluster_configs.clone(),
+            wait_timeout_secs,
         )
     };
     let effective_tags: QueryTags = merge_tags(&group_default_tags, &session.tags().clone());
@@ -1189,9 +1195,17 @@ async fn setup_sync_query(
     // Queue loop: spin until a cluster slot is available (both local and global).
     // `wait_start` is this query's place in line for the fairness gate: queued
     // queries enqueued before it (and still polling) get freed slots first.
+    // Bound by `capacityWaitTimeoutSecs` so clients cannot wait forever.
     let wait_start = Utc::now();
+    let deadline = wait_start + chrono::Duration::seconds(wait_timeout_secs as i64);
     let mut seq: u64 = 0;
     let (cluster_name, adapter) = loop {
+        if Utc::now() >= deadline {
+            return Err(QueryFluxError::CapacityWaitTimeout {
+                group: group.0.clone(),
+                timeout_secs: wait_timeout_secs,
+            });
+        }
         if should_yield_to_older_queued(state, &cluster_manager, &group, Some(wait_start)).await {
             queued_backoff_delay(seq).await;
             seq += 1;
@@ -2202,5 +2216,90 @@ mod queue_limit_tests {
             matches!(err, QueryFluxError::QueueFull { limit: 1, .. }),
             "got {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod capacity_wait_tests {
+    use super::setup_sync_query;
+    use crate::state::test_fixtures::app_state;
+    use queryflux_auth::AuthContext;
+    use queryflux_cluster_manager::cluster_state::ClusterState;
+    use queryflux_cluster_manager::simple::SimpleClusterGroupManager;
+    use queryflux_core::error::QueryFluxError;
+    use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType, FrontendProtocol};
+    use queryflux_core::session::SessionContext;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn sync_setup_times_out_when_no_capacity() {
+        let state = app_state(false);
+        {
+            let mut live = state.live.write().await;
+            live.group_capacity_wait_timeout_secs
+                .insert("default".into(), 1);
+            let group = ClusterGroupName("default".into());
+            let cluster = ClusterName("trino".into());
+            // max_running_queries = 0 → acquire_cluster always returns None.
+            let cluster_state = Arc::new(ClusterState::new(
+                cluster.clone(),
+                group.clone(),
+                None,
+                None,
+                EngineType::Trino,
+                Some("http://trino.test:8080".into()),
+                0,
+                true,
+            ));
+            let mut groups = HashMap::new();
+            groups.insert(
+                group.clone(),
+                (
+                    vec![cluster_state],
+                    Arc::new(queryflux_cluster_manager::strategy::RoundRobinStrategy::new())
+                        as Arc<dyn queryflux_cluster_manager::strategy::ClusterSelectionStrategy>,
+                ),
+            );
+            live.cluster_manager = Arc::new(SimpleClusterGroupManager::new(groups));
+        }
+
+        let auth = AuthContext {
+            user: "alice".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let started = Instant::now();
+        let result = setup_sync_query(
+            &state,
+            "SELECT 1".into(),
+            vec![],
+            SessionContext::default(),
+            FrontendProtocol::TrinoHttp,
+            ClusterGroupName("default".into()),
+            &auth,
+        )
+        .await;
+        assert!(
+            started.elapsed().as_secs() < 10,
+            "timeout should fire near 1s, got {:?}",
+            started.elapsed()
+        );
+        let err = match result {
+            Ok(_) => panic!("must time out waiting for capacity"),
+            Err(e) => e,
+        };
+        match err {
+            QueryFluxError::CapacityWaitTimeout {
+                group,
+                timeout_secs,
+            } => {
+                assert_eq!(group, "default");
+                assert_eq!(timeout_secs, 1);
+            }
+            other => panic!("expected CapacityWaitTimeout, got {other}"),
+        }
     }
 }

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -58,6 +58,8 @@ pub struct LiveConfig {
     /// `None` / missing entry means unlimited. `Some(0)` is treated as unlimited
     /// (same as the enforce check requiring `limit > 0`).
     pub group_max_queued_queries: HashMap<String, Option<u64>>,
+    /// group_name → resolved capacity wait timeout in seconds (default 300).
+    pub group_capacity_wait_timeout_secs: HashMap<String, u64>,
     /// group_name → cache settings for groups that have caching enabled.
     pub group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig>,
     /// Verifies client identity — hot-reloaded when security config changes via admin API.
@@ -334,6 +336,7 @@ pub mod test_fixtures {
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
             group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(auth_required)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -157,8 +157,13 @@ fn client_safe_message(e: &QueryFluxError) -> &'static str {
         Engine(_) => "Backend engine error",
         Routing(_) | NoClusterGroupAvailable(_) => "Query routing failed",
         Config(_) => "Configuration error",
-        // Empty → caller forwards Display (includes group/count/limit for QueueFull).
-        Auth(_) | Unauthorized(_) | QueryNotFound(_) | ClusterNotFound(_) | QueueFull { .. } => "",
+        // Empty → caller forwards Display (QueueFull / CapacityWaitTimeout detail).
+        Auth(_)
+        | Unauthorized(_)
+        | QueryNotFound(_)
+        | ClusterNotFound(_)
+        | QueueFull { .. }
+        | CapacityWaitTimeout { .. } => "",
         _ => "Internal error",
     }
 }
@@ -741,6 +746,30 @@ pub async fn get_queued_statement(
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };
+
+    // Fail on wall-clock wait from enqueue (`creation_time`), not `last_accessed`
+    // (polls refresh last_accessed and would otherwise wait forever).
+    let wait_timeout_secs = {
+        let live = state.live.read().await;
+        live.group_capacity_wait_timeout_secs
+            .get(&queued.cluster_group.0)
+            .copied()
+            .unwrap_or(queryflux_core::config::DEFAULT_CAPACITY_WAIT_TIMEOUT_SECS)
+    };
+    let waited_secs = (Utc::now() - queued.creation_time).num_seconds().max(0) as u64;
+    if waited_secs >= wait_timeout_secs {
+        if let Err(e) = state.persistence.delete_queued(&query_id).await {
+            warn!(id = %query_id, "Failed to delete queued query after capacity wait timeout: {e}");
+        }
+        if let Some(qc) = &state.queue_coordinator {
+            let _ = qc.release_claim(&query_id.0).await;
+        }
+        let err = QueryFluxError::CapacityWaitTimeout {
+            group: queued.cluster_group.0.clone(),
+            timeout_secs: wait_timeout_secs,
+        };
+        return trino_error_response(&query_id.0, &err.to_string()).into_response();
+    }
 
     if let Some(resp) = allow_query_action_or_forbid(
         &state,
@@ -1542,6 +1571,7 @@ mod cancel_executing_statement_tests {
             group_translation_scripts: HashMap::new(),
             group_default_tags: HashMap::new(),
             group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
             group_cache_settings: HashMap::new(),
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())

--- a/crates/queryflux-persistence/src/cluster_config.rs
+++ b/crates/queryflux-persistence/src/cluster_config.rs
@@ -301,6 +301,8 @@ impl ClusterGroupConfigRecord {
             strategy,
             max_running_queries: self.max_running_queries as u64,
             max_queued_queries: self.max_queued_queries.map(|v| v as u64),
+            // Not persisted in Postgres yet; YAML LiveConfig path supplies the value.
+            capacity_wait_timeout_secs: None,
             authorization: queryflux_core::config::ClusterGroupAuthorizationConfig {
                 allow_groups: self.allow_groups.clone(),
                 allow_users: self.allow_users.clone(),
@@ -351,6 +353,7 @@ mod tests {
             strategy: None,
             max_running_queries: 10,
             max_queued_queries: None,
+            capacity_wait_timeout_secs: None,
             authorization: queryflux_core::config::ClusterGroupAuthorizationConfig {
                 allow_groups: vec![],
                 allow_users: vec![],

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -731,6 +731,11 @@ async fn main() -> Result<()> {
         .filter(|(_, g)| g.max_queued_queries.is_some())
         .map(|(name, g)| (name.clone(), g.max_queued_queries))
         .collect();
+    let group_capacity_wait_timeout_secs: HashMap<String, u64> = config
+        .cluster_groups
+        .iter()
+        .map(|(name, g)| (name.clone(), g.capacity_wait_timeout_secs_or_default()))
+        .collect();
     let group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig> = config
         .cluster_groups
         .iter()
@@ -754,6 +759,7 @@ async fn main() -> Result<()> {
         group_translation_scripts,
         group_default_tags,
         group_max_queued_queries,
+        group_capacity_wait_timeout_secs,
         group_cache_settings,
         auth_provider,
         authorization,
@@ -2230,6 +2236,11 @@ async fn build_live_config(
         .map(|(name, g)| (name.clone(), g.max_queued_queries))
         .collect();
 
+    let group_capacity_wait_timeout_secs: HashMap<String, u64> = cluster_groups
+        .iter()
+        .map(|(name, g)| (name.clone(), g.capacity_wait_timeout_secs_or_default()))
+        .collect();
+
     let group_cache_settings: HashMap<String, queryflux_core::config::GroupCacheConfig> =
         cluster_groups
             .iter()
@@ -2275,6 +2286,7 @@ async fn build_live_config(
         group_translation_scripts,
         group_default_tags,
         group_max_queued_queries,
+        group_capacity_wait_timeout_secs,
         group_cache_settings,
         auth_provider: Arc::new(NoneAuthProvider::new(false)),
         authorization: Arc::new(AllowAllAuthorization::default()),


### PR DESCRIPTION
## Summary
- Add `capacityWaitTimeoutSecs` on cluster groups (default **300**) via LiveConfig.
- Sync `setup_sync_query` stops spinning when the deadline expires (`CapacityWaitTimeout`).
- Async Trino queued poll fails (and deletes the row) when wait since **creation_time** exceeds the timeout.

## Test plan
- [ ] `dispatch::capacity_wait_tests::sync_setup_times_out_when_no_capacity` passes
- [ ] Group with `maxRunningQueries: 0` and short timeout returns CapacityWaitTimeout for sync clients
- [ ] Queued query older than timeout is deleted and returns a clear Trino error on poll


Made with [Cursor](https://cursor.com)