### PR TITLE
fix(helm): reject empty NetworkPolicy that would lock out traffic

### DIFF
--- a/charts/queryflux/README.md
+++ b/charts/queryflux/README.md
@@ -86,7 +86,7 @@ existingSecret:
 - `ingress.enabled`: expose the Trino HTTP frontend through an ingress controller.
 - `autoscaling.enabled`: create an HPA.
 - `pdb.enabled`: create a PodDisruptionBudget.
-- `networkPolicy.enabled`: create a NetworkPolicy. The default policy body is empty so operators can define provider-specific ingress and egress rules.
+- `networkPolicy.enabled`: create a NetworkPolicy. Defaults to `false`. Enabling with empty `ingress`/`egress` while `policyTypes` lists Ingress/Egress **denies all traffic**; the chart **fails install** in that case. Copy and tighten rules from `examples/networkpolicy-values.yaml` or `examples/production-values.yaml`.
 - `serviceMonitor.enabled`: create a Prometheus Operator ServiceMonitor for `/metrics` on the admin port.
 - `startupProbe`: HTTP check on `/readyz` (admin port) so liveness does not kill slow startups.
 - `terminationGracePeriodSeconds`: default `45`. Keep this ≥ `queryflux.shutdownDrainTimeoutSecs` (default `30`) plus a buffer so Kubernetes does not SIGKILL mid-drain.
@@ -97,6 +97,7 @@ The chart also supports `env`, `envFrom`, `extraVolumes`, `extraVolumeMounts`, `
 
 - `examples/external-config-values.yaml`: use a pre-created ConfigMap and Secret, and run the server-only image.
 - `examples/production-values.yaml`: shows ingress, TLS, HPA, PDB, ServiceMonitor, NetworkPolicy, resource requests, and topology spread settings.
+- `examples/networkpolicy-values.yaml`: starter NetworkPolicy allowing clients, DNS, Postgres, and engines (tighten selectors before production).
 
 ## Validation
 

--- a/charts/queryflux/examples/networkpolicy-values.yaml
+++ b/charts/queryflux/examples/networkpolicy-values.yaml
@@ -1,0 +1,59 @@
+# Example NetworkPolicy body for QueryFlux.
+# Defaults keep networkPolicy.enabled: false. Enabling with empty ingress/egress
+# and policyTypes Ingress+Egress denies all traffic — the chart fails install in
+# that case. Copy and tighten selectors for your cluster.
+#
+# helm upgrade --install queryflux ./charts/queryflux \
+#   --values charts/queryflux/examples/networkpolicy-values.yaml \
+#   --values <your-other-values.yaml>
+
+networkPolicy:
+  enabled: true
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Clients / ingress controller / Studio / Admin API.
+    # Tighten: replace namespaceSelector: {} with matchLabels for ingress-nginx, etc.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080 # Trino HTTP
+        - protocol: TCP
+          port: 9000 # Admin (/metrics, /readyz)
+        - protocol: TCP
+          port: 3000 # Studio
+    # Optional: Prometheus scrape from a monitoring namespace only.
+    # - from:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: monitoring
+    #   ports:
+    #     - protocol: TCP
+    #       port: 9000
+  egress:
+    # Cluster DNS
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Postgres persistence (same or peer namespace — tighten selectors)
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Query engines (e.g. Trino). Add more ports/namespaces as needed.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Optional: OIDC / external HTTPS
+    # - ports:
+    #     - protocol: TCP
+    #       port: 443

--- a/charts/queryflux/examples/production-values.yaml
+++ b/charts/queryflux/examples/production-values.yaml
@@ -83,6 +83,8 @@ serviceMonitor:
     release: prometheus
 
 networkPolicy:
+  # Non-empty rules required when enabled (empty + Ingress/Egress = deny-all).
+  # Tighten namespaceSelector matchLabels for ingress, Postgres, and engines.
   enabled: true
   ingress:
     - from:

--- a/charts/queryflux/templates/NOTES.txt
+++ b/charts/queryflux/templates/NOTES.txt
@@ -37,3 +37,10 @@ config.data.queryflux.enforceSnowflakeHttpSessionAffinity: true to make
 QueryFlux refuse to start until the affinity requirement is acknowledged in
 config.
 {{- end }}
+{{- if .Values.networkPolicy.enabled }}
+
+NOTE: NetworkPolicy is enabled. Confirm ingress allows clients (and metrics
+scrape on the admin port) and egress allows DNS, Postgres, and your engines.
+Empty rule lists are rejected by the chart; see
+charts/queryflux/examples/networkpolicy-values.yaml.
+{{- end }}

--- a/charts/queryflux/templates/networkpolicy.yaml
+++ b/charts/queryflux/templates/networkpolicy.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- $types := .Values.networkPolicy.policyTypes | default (list) }}
+{{- if and (has "Ingress" $types) (empty .Values.networkPolicy.ingress) }}
+{{- fail "networkPolicy.enabled with policyTypes including Ingress requires non-empty networkPolicy.ingress (empty rules deny all traffic). Copy rules from charts/queryflux/examples/networkpolicy-values.yaml or examples/production-values.yaml" }}
+{{- end }}
+{{- if and (has "Egress" $types) (empty .Values.networkPolicy.egress) }}
+{{- fail "networkPolicy.enabled with policyTypes including Egress requires non-empty networkPolicy.egress (empty rules deny all traffic). Copy rules from charts/queryflux/examples/networkpolicy-values.yaml or examples/production-values.yaml" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/queryflux/values.yaml
+++ b/charts/queryflux/values.yaml
@@ -216,6 +216,9 @@ pdb:
   maxUnavailable: 1
 
 networkPolicy:
+  # Keep false unless you supply non-empty ingress/egress for every declared
+  # policyType. Empty rules + enabled = deny-all; the chart fails install then.
+  # See examples/networkpolicy-values.yaml.
   enabled: false
   policyTypes:
     - Ingress

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -23,6 +23,7 @@ required_files=(
   "README.md"
   "examples/external-config-values.yaml"
   "examples/production-values.yaml"
+  "examples/networkpolicy-values.yaml"
   "values.yaml"
   "values.schema.json"
   "templates/_helpers.tpl"
@@ -79,5 +80,17 @@ for values_file in "$CHART_DIR"/examples/*.yaml; do
   run_helm "helm lint --values $values_file" helm lint "$CHART_DIR" --values "$values_file"
   run_helm "helm template --values $values_file" helm template queryflux "$CHART_DIR" --values "$values_file"
 done
+
+# Enabled NetworkPolicy with empty rules must fail (deny-all lockout).
+empty_np_err=""
+if empty_np_err="$(helm template queryflux "$CHART_DIR" \
+  --set networkPolicy.enabled=true \
+  --set-json 'networkPolicy.ingress=[]' \
+  --set-json 'networkPolicy.egress=[]' 2>&1)"; then
+  fail "enabled NetworkPolicy with empty ingress/egress must fail render"
+fi
+echo "$empty_np_err" | grep -q 'non-empty networkPolicy' \
+  || fail "enabled empty NetworkPolicy must fail with a clear message:
+$empty_np_err"
 
 echo "helm chart check passed"


### PR DESCRIPTION
## Summary
- Fail Helm render when `networkPolicy.enabled` with empty `ingress`/`egress` for declared Ingress/Egress types (deny-all lockout).
- Add `examples/networkpolicy-values.yaml`, document the trap in README/values, NOTES when enabled.
- Assert the empty-rules case fails in `scripts/check-helm-chart.sh`.

## Test plan
- [ ] `scripts/check-helm-chart.sh` / `make helm-check` passes
- [ ] `helm template … --set networkPolicy.enabled=true` with empty lists fails with a clear message
- [ ] `examples/production-values.yaml` and `networkpolicy-values.yaml` still render


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ready-to-use Helm values example for enabling ingress and egress NetworkPolicy rules.
  * Added installation guidance describing required network access and configuration options.

* **Bug Fixes**
  * Helm rendering now clearly fails when enabled NetworkPolicy types have no rules, preventing unintended deny-all configurations.

* **Documentation**
  * Expanded chart configuration guidance with NetworkPolicy requirements and recommendations for tightening namespace selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->