### PR TITLE
fix: cap MySQL and Postgres wire message sizes before allocate

### DIFF
--- a/crates/queryflux-frontend/src/lib.rs
+++ b/crates/queryflux-frontend/src/lib.rs
@@ -17,6 +17,11 @@ use queryflux_core::error::Result;
 /// and drain in-flight work.
 pub type ShutdownRx = tokio::sync::watch::Receiver<bool>;
 
+/// Max accepted inbound frontend message / packet body size (MySQL + Postgres wire).
+/// Rejects before allocating so clients cannot force multi‑GiB (Postgres) or
+/// multi‑MiB DoS buffers. Kept below MySQL's 24-bit packet max (16 MiB − 1).
+pub const MAX_FRONTEND_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
+
 /// Implemented by each frontend protocol server (Trino HTTP, PG wire, MySQL wire, etc.).
 ///
 /// Each listener binds to a port, accepts connections in its native protocol,

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -42,7 +42,7 @@ use queryflux_core::{
 use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
-use crate::{FrontendListenerTrait, ShutdownRx};
+use crate::{FrontendListenerTrait, ShutdownRx, MAX_FRONTEND_MESSAGE_BYTES};
 
 // ── MySQL command bytes ───────────────────────────────────────────────────────
 
@@ -841,6 +841,12 @@ async fn read_packet<R: AsyncReadExt + Unpin>(
     reader.read_exact(&mut header).await?;
     let len = u32::from_le_bytes([header[0], header[1], header[2], 0]) as usize;
     let seq = header[3];
+    if len > MAX_FRONTEND_MESSAGE_BYTES {
+        return Err(format!(
+            "MySQL packet length {len} exceeds max allowed {MAX_FRONTEND_MESSAGE_BYTES} bytes"
+        )
+        .into());
+    }
     let mut payload = vec![0u8; len];
     if len > 0 {
         reader.read_exact(&mut payload).await?;
@@ -1743,5 +1749,20 @@ mod tests {
             buf[4], 0xff,
             "expected MySQL ERR packet when auth is required"
         );
+    }
+
+    #[tokio::test]
+    async fn read_packet_rejects_oversized_length() {
+        // 24-bit length = MAX_FRONTEND_MESSAGE_BYTES + 1, seq 0.
+        let over = (MAX_FRONTEND_MESSAGE_BYTES + 1) as u32;
+        let header = [
+            (over & 0xff) as u8,
+            ((over >> 8) & 0xff) as u8,
+            ((over >> 16) & 0xff) as u8,
+            0,
+        ];
+        let mut cursor = std::io::Cursor::new(header.to_vec());
+        let err = read_packet(&mut cursor).await.expect_err("must reject");
+        assert!(err.to_string().contains("exceeds max allowed"), "got {err}");
     }
 }

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -34,7 +34,7 @@ use queryflux_core::{
 use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
-use crate::{FrontendListenerTrait, ShutdownRx};
+use crate::{FrontendListenerTrait, ShutdownRx, MAX_FRONTEND_MESSAGE_BYTES};
 
 // ── Postgres type OIDs (text-format only in V1) ───────────────────────────────
 
@@ -132,7 +132,7 @@ async fn handle_connection(
     // ── Startup phase ────────────────────────────────────────────────────────
 
     // Read the startup message: 4-byte length + 4-byte protocol version + params.
-    let startup_len = read_i32(&mut reader).await? as usize;
+    let startup_len = checked_frontend_len(read_i32(&mut reader).await?)?;
     if startup_len < 8 {
         return Ok(());
     }
@@ -151,7 +151,7 @@ async fn handle_connection(
         writer.write_all(b"N").await?; // 'N' = no SSL
         writer.flush().await?;
         // Re-read the real startup message.
-        let real_len = read_i32(&mut reader).await? as usize;
+        let real_len = checked_frontend_len(read_i32(&mut reader).await?)?;
         if real_len < 8 {
             return Ok(());
         }
@@ -224,7 +224,7 @@ async fn handle_connection(
             Err(_) => break,
         };
 
-        let msg_len = read_i32(&mut reader).await? as usize;
+        let msg_len = checked_frontend_len(read_i32(&mut reader).await?)?;
         if msg_len < 4 {
             break;
         }
@@ -564,6 +564,23 @@ async fn read_i32<R: AsyncReadExt + Unpin>(
     Ok(i32::from_be_bytes(buf))
 }
 
+/// Validate a Postgres length-prefixed message size before allocating.
+fn checked_frontend_len(
+    len: i32,
+) -> std::result::Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+    if len <= 0 {
+        return Err(format!("invalid Postgres message length {len}").into());
+    }
+    let len = len as usize;
+    if len > MAX_FRONTEND_MESSAGE_BYTES {
+        return Err(format!(
+            "Postgres message length {len} exceeds max allowed {MAX_FRONTEND_MESSAGE_BYTES} bytes"
+        )
+        .into());
+    }
+    Ok(len)
+}
+
 // ── Startup message parsing ───────────────────────────────────────────────────
 
 /// Parse Postgres startup params: NUL-separated key=value pairs, terminated by NUL.
@@ -705,5 +722,13 @@ mod tests {
             msg_type[0], b'E',
             "expected Postgres ErrorResponse when auth is required"
         );
+    }
+
+    #[test]
+    fn checked_frontend_len_rejects_negative_and_oversized() {
+        assert!(checked_frontend_len(0).is_err());
+        assert!(checked_frontend_len(-1).is_err());
+        assert!(checked_frontend_len((MAX_FRONTEND_MESSAGE_BYTES + 1) as i32).is_err());
+        assert_eq!(checked_frontend_len(8).unwrap(), 8);
     }
 }


### PR DESCRIPTION
## Summary
- Add `MAX_FRONTEND_MESSAGE_BYTES` (8 MiB) and reject MySQL packets / Postgres length-prefixed messages before `vec!` allocation.
- Reject non-positive Postgres lengths (avoids `i32 as usize` wrap).
- Unit tests for oversize MySQL header and Postgres length checks.

## Test plan
- [ ] `read_packet_rejects_oversized_length` and `checked_frontend_len_rejects_*` pass
- [ ] Normal small SQL over MySQL/Postgres wire still works
- [ ] Trino HTTP unchanged (axum Bytes 2 MiB default remains)


Made with [Cursor](https://cursor.com)