### PR TITLE
fix: install UserGroup router from config

### DIFF
--- a/crates/queryflux-routing/src/implementations/mod.rs
+++ b/crates/queryflux-routing/src/implementations/mod.rs
@@ -4,3 +4,4 @@ pub mod protocol_based;
 pub mod python_script;
 pub mod query_regex;
 pub mod tags;
+pub mod user_group;

--- a/crates/queryflux-routing/src/implementations/user_group.rs
+++ b/crates/queryflux-routing/src/implementations/user_group.rs
@@ -1,0 +1,123 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use queryflux_core::{
+    error::Result,
+    query::{ClusterGroupName, FrontendProtocol},
+    session::SessionContext,
+};
+
+use crate::RouterTrait;
+
+/// Routes by authenticated username → cluster group.
+///
+/// Prefers `auth_ctx.user` (verified identity). Falls back to `session.user()`
+/// only when auth context is unavailable (e.g. auth disabled).
+pub struct UserGroupRouter {
+    /// username → cluster group name
+    mapping: HashMap<String, ClusterGroupName>,
+}
+
+impl UserGroupRouter {
+    pub fn new(mapping: HashMap<String, ClusterGroupName>) -> Self {
+        Self { mapping }
+    }
+}
+
+#[async_trait]
+impl RouterTrait for UserGroupRouter {
+    fn type_name(&self) -> &'static str {
+        "UserGroup"
+    }
+
+    async fn route(
+        &self,
+        _sql: &str,
+        session: &SessionContext,
+        _frontend_protocol: &FrontendProtocol,
+        auth_ctx: Option<&queryflux_auth::AuthContext>,
+    ) -> Result<Option<ClusterGroupName>> {
+        let user = auth_ctx
+            .map(|ctx| ctx.user.as_str())
+            .or_else(|| session.user());
+        if let Some(user) = user {
+            return Ok(self.mapping.get(user).cloned());
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_auth::AuthContext;
+    use queryflux_core::query::FrontendProtocol;
+    use queryflux_core::session::SessionContext;
+
+    fn mapping() -> HashMap<String, ClusterGroupName> {
+        HashMap::from([
+            ("alice".into(), ClusterGroupName("prod".into())),
+            ("bob".into(), ClusterGroupName("dev".into())),
+        ])
+    }
+
+    #[tokio::test]
+    async fn prefers_auth_context_user() {
+        let router = UserGroupRouter::new(mapping());
+        let session = SessionContext {
+            user: Some("bob".into()),
+            ..Default::default()
+        };
+        let auth = AuthContext {
+            user: "alice".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let group = router
+            .route(
+                "SELECT 1",
+                &session,
+                &FrontendProtocol::TrinoHttp,
+                Some(&auth),
+            )
+            .await
+            .unwrap();
+        assert_eq!(group, Some(ClusterGroupName("prod".into())));
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_session_user() {
+        let router = UserGroupRouter::new(mapping());
+        let session = SessionContext {
+            user: Some("bob".into()),
+            ..Default::default()
+        };
+        let group = router
+            .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
+            .await
+            .unwrap();
+        assert_eq!(group, Some(ClusterGroupName("dev".into())));
+    }
+
+    #[tokio::test]
+    async fn unmatched_user_returns_none() {
+        let router = UserGroupRouter::new(mapping());
+        let auth = AuthContext {
+            user: "carol".into(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        };
+        let group = router
+            .route(
+                "SELECT 1",
+                &SessionContext::default(),
+                &FrontendProtocol::TrinoHttp,
+                Some(&auth),
+            )
+            .await
+            .unwrap();
+        assert_eq!(group, None);
+    }
+}

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -44,6 +44,7 @@ use queryflux_routing::{
     implementations::{
         compound::CompoundRouter, header::HeaderRouter, protocol_based::ProtocolBasedRouter,
         python_script::PythonScriptRouter, query_regex::QueryRegexRouter, tags::TagsRouter,
+        user_group::UserGroupRouter,
     },
     RouterTrait,
 };
@@ -572,6 +573,13 @@ async fn main() -> Result<()> {
                     .collect();
                 routers.push(Box::new(HeaderRouter::new(header_name.clone(), mapping)));
             }
+            RouterConfig::UserGroup { user_to_group } => {
+                let mapping = user_to_group
+                    .iter()
+                    .map(|(k, v)| (k.clone(), ClusterGroupName(v.clone())))
+                    .collect();
+                routers.push(Box::new(UserGroupRouter::new(mapping)));
+            }
             RouterConfig::QueryRegex { rules } => {
                 let pairs = rules
                     .iter()
@@ -604,9 +612,6 @@ async fn main() -> Result<()> {
                     conditions.clone(),
                     target_group.clone(),
                 )));
-            }
-            _ => {
-                tracing::warn!("Router type not yet implemented, skipping");
             }
         }
     }
@@ -2182,6 +2187,15 @@ async fn build_live_config(
                     ),
                 ));
             }
+            RouterConfig::UserGroup { user_to_group } => {
+                let mapping = user_to_group
+                    .iter()
+                    .map(|(k, v)| (k.clone(), ClusterGroupName(v.clone())))
+                    .collect();
+                routers.push(Box::new(
+                    queryflux_routing::implementations::user_group::UserGroupRouter::new(mapping),
+                ));
+            }
             RouterConfig::QueryRegex { rules } => {
                 let pairs = rules
                     .iter()
@@ -2227,9 +2241,6 @@ async fn build_live_config(
                         target_group.clone(),
                     ),
                 ));
-            }
-            _ => {
-                tracing::warn!("Reload: router type not yet implemented, skipping");
             }
         }
     }


### PR DESCRIPTION
## Summary
- `RouterConfig::UserGroup` was deserialized and validated but skipped with “not yet implemented” at YAML startup and DB reload.
- Add `UserGroupRouter`: prefer verified `auth_ctx.user`, fall back to `session.user()`, map via `userToGroup`.
- Unit tests cover auth preference, session fallback, and unmatched users.

## Test plan
- [x] `cargo test -p queryflux-routing --lib user_group`
- [x] `cargo fmt --all -- --check`
- [x] Clippy workspace `-D warnings` (exclude queryflux-bench)


Made with [Cursor](https://cursor.com)