### PR TITLE
fix: record query history on cancel and queue terminal paths

### DIFF
--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -122,6 +122,8 @@ pub enum EngineType {
     Exasol,
     /// ADBC adapter backed by a SingleStore driver (MySQL-compatible dialect).
     SingleStore,
+    /// Query never reached a backend engine (still queued or evicted before dispatch).
+    Undispatched,
     /// Result served from cache — no backend engine involved.
     Cache,
 }
@@ -145,6 +147,7 @@ impl EngineType {
             EngineType::Redshift => SqlDialect::Redshift,
             EngineType::Exasol => SqlDialect::Exasol,
             EngineType::SingleStore => SqlDialect::MySql,
+            EngineType::Undispatched => SqlDialect::Generic,
             EngineType::Cache => SqlDialect::Generic,
         }
     }

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1088,14 +1088,7 @@ async fn delete_queued_if_exists(
     persistence: &dyn queryflux_persistence::Persistence,
     id: &str,
 ) -> queryflux_core::error::Result<Option<queryflux_core::query::QueuedQuery>> {
-    let qid = ProxyQueryId(id.to_string());
-    match persistence.get_queued(&qid).await? {
-        Some(q) => {
-            persistence.delete_queued(&qid).await?;
-            Ok(Some(q))
-        }
-        None => Ok(None),
-    }
+    persistence.take_queued(&ProxyQueryId(id.to_string())).await
 }
 
 async fn find_executing_query(

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1087,13 +1087,14 @@ async fn collect_running_queries(
 async fn delete_queued_if_exists(
     persistence: &dyn queryflux_persistence::Persistence,
     id: &str,
-) -> queryflux_core::error::Result<bool> {
+) -> queryflux_core::error::Result<Option<queryflux_core::query::QueuedQuery>> {
     let qid = ProxyQueryId(id.to_string());
-    if persistence.get_queued(&qid).await?.is_some() {
-        persistence.delete_queued(&qid).await?;
-        Ok(true)
-    } else {
-        Ok(false)
+    match persistence.get_queued(&qid).await? {
+        Some(q) => {
+            persistence.delete_queued(&qid).await?;
+            Ok(Some(q))
+        }
+        None => Ok(None),
     }
 }
 
@@ -1156,7 +1157,12 @@ async fn cancel_query_handler(
 
     let qid = ProxyQueryId(id.clone());
     match delete_queued_if_exists(persistence.as_ref(), &id).await {
-        Ok(true) => {
+        Ok(Some(queued)) => {
+            state.app.record_queued_terminal(
+                &queued,
+                queryflux_core::query::QueryStatus::Cancelled,
+                "admin cancelled",
+            );
             // A worker may have claimed and started executing between the first
             // lookup and this delete. Cancel that path too.
             match find_executing_query(persistence.as_ref(), &id).await {
@@ -1172,7 +1178,7 @@ async fn cancel_query_handler(
             info!(id = %qid, "Admin cancelled queued query");
             StatusCode::NO_CONTENT.into_response()
         }
-        Ok(false) => {
+        Ok(None) => {
             // Claimed and moved to executing after the first lookup.
             match find_executing_query(persistence.as_ref(), &id).await {
                 Ok(Some(executing)) => cancel_executing(&state, executing).await,
@@ -1188,32 +1194,37 @@ async fn cancel_executing(
     state: &AdminState,
     executing: queryflux_core::query::ExecutingQuery,
 ) -> Response {
-    let mut cancelled = false;
-    if let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await {
-        match adapter.cancel_query(&executing.backend_query_id).await {
-            Ok(()) => cancelled = true,
-            Err(e) => {
-                warn!(
-                    id = %executing.id,
-                    backend = %executing.backend_query_id,
-                    "Admin adapter cancel failed: {e}"
-                );
-            }
-        }
-    } else {
+    let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await else {
         warn!(
             id = %executing.id,
             cluster = %executing.cluster_name,
             "Admin cancel: no adapter for cluster"
         );
-    }
-    if !cancelled {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "failed to cancel query on backend",
+        )
+            .into_response();
+    };
+    if let Err(e) = adapter.cancel_query(&executing.backend_query_id).await {
+        warn!(
+            id = %executing.id,
+            backend = %executing.backend_query_id,
+            "Admin adapter cancel failed: {e}"
+        );
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             "failed to cancel query on backend",
         )
             .into_response();
     }
+    state.app.record_executing_cancelled(
+        &executing,
+        queryflux_core::query::FrontendProtocol::TrinoHttp,
+        adapter.engine_type(),
+        adapter.translation_target_dialect(),
+        "admin cancelled",
+    );
     state
         .app
         .release_query_slot(
@@ -2768,15 +2779,17 @@ mod tests {
 
         assert!(delete_queued_if_exists(store.as_ref(), "q-cancel")
             .await
-            .unwrap());
+            .unwrap()
+            .is_some());
         assert!(store
             .get_queued(&ProxyQueryId("q-cancel".into()))
             .await
             .unwrap()
             .is_none());
-        assert!(!delete_queued_if_exists(store.as_ref(), "missing")
+        assert!(delete_queued_if_exists(store.as_ref(), "missing")
             .await
-            .unwrap());
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -154,6 +154,20 @@ impl AppState {
         self.live.read().await.cluster_configs.get(cluster).cloned()
     }
 
+    /// Resolve engine metadata from a live adapter or stored cluster config.
+    pub async fn engine_type_for_cluster(&self, cluster: &str) -> (EngineType, SqlDialect) {
+        if let Some(adapter) = self.adapter(cluster).await {
+            return (adapter.engine_type(), adapter.translation_target_dialect());
+        }
+        if let Some(cfg) = self.cluster_config_cloned(cluster).await {
+            if let Some(engine) = &cfg.engine {
+                let engine_type = EngineType::from(engine);
+                return (engine_type.clone(), engine_type.dialect());
+            }
+        }
+        (EngineType::Undispatched, SqlDialect::Generic)
+    }
+
     /// Returns true if any cluster in the group supports async execution (e.g. Trino).
     pub async fn group_supports_async(&self, group: &str) -> bool {
         let live = self.live.read().await;
@@ -351,13 +365,12 @@ impl AppState {
         let queue_duration_ms = (Utc::now() - queued.creation_time)
             .num_milliseconds()
             .max(0) as u64;
-        let session = {
-            let mut s = queued.session.clone();
-            if s.user.is_none() && !queued.submitted_by.is_empty() {
-                s.user = Some(queued.submitted_by.clone());
-            }
-            s
-        };
+        let mut session = queued.session.clone();
+        if session.user.is_none() && !queued.submitted_by.is_empty() {
+            session.user = Some(queued.submitted_by.clone());
+        }
+        let query_tags = session.tags().clone();
+        let agent_context = session.resolved_agent_context();
         let dialect = queued.frontend_protocol.default_dialect();
         let ctx = QueryContext {
             query_id: queued.id.clone(),
@@ -368,14 +381,14 @@ impl AppState {
             cluster: ClusterName("(not-dispatched)".into()),
             cluster_group_config_id: None,
             cluster_config_id: None,
-            engine_type: EngineType::Trino,
+            engine_type: EngineType::Undispatched,
             src_dialect: dialect.clone(),
-            tgt_dialect: dialect,
+            tgt_dialect: SqlDialect::Generic,
             was_translated: false,
             translated_sql: None,
-            query_tags: QueryTags::default(),
+            query_tags,
             query_params: vec![],
-            agent_context: None,
+            agent_context,
         };
         self.record_query(
             &ctx,

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -410,6 +410,121 @@ impl AppState {
 }
 
 #[cfg(test)]
+mod record_terminal_tests {
+    use std::sync::Arc;
+
+    use queryflux_core::{
+        query::{
+            ClusterGroupName, EngineType, FrontendProtocol, ProxyQueryId, QueryStatus, QueuedQuery,
+        },
+        session::SessionContext,
+        tags::QueryTags,
+    };
+    use queryflux_persistence::{
+        in_memory::InMemoryPersistence, query_history::QueryFilters, QueryHistoryStore,
+    };
+
+    use super::test_fixtures;
+
+    fn queued_with_tags() -> QueuedQuery {
+        let mut session = SessionContext {
+            tags: [("team".to_string(), Some("eng".to_string()))].into(),
+            ..Default::default()
+        };
+        session.extra.insert("agent_id".into(), "agent-1".into());
+        session
+            .extra
+            .insert("conversation_id".into(), "conv-1".into());
+        QueuedQuery {
+            id: ProxyQueryId("q-queued-terminal".into()),
+            sql: "SELECT 1".into(),
+            session,
+            frontend_protocol: FrontendProtocol::TrinoHttp,
+            cluster_group: ClusterGroupName("default".into()),
+            creation_time: chrono::Utc::now(),
+            last_accessed: chrono::Utc::now(),
+            sequence: 0,
+            submitted_by: "alice".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn record_queued_terminal_preserves_tags_and_agent_context() {
+        let mem = Arc::new(InMemoryPersistence::new());
+        let state = test_fixtures::app_state_with_metrics(mem.clone(), false);
+
+        state.record_queued_terminal(
+            &queued_with_tags(),
+            QueryStatus::Failed,
+            "capacity wait timeout",
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let rows = mem
+            .list_queries(&QueryFilters {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].engine_type, "Undispatched");
+        assert_eq!(rows[0].username.as_deref(), Some("alice"));
+        assert_eq!(rows[0].agent_id.as_deref(), Some("agent-1"));
+        assert_eq!(rows[0].conversation_id.as_deref(), Some("conv-1"));
+        let tags = rows[0].query_tags.as_ref().expect("tags");
+        assert_eq!(tags.get("team"), Some(&serde_json::json!("eng")));
+    }
+
+    #[tokio::test]
+    async fn record_executing_cancelled_writes_cancelled_history_row() {
+        use chrono::Utc;
+        use queryflux_core::query::{BackendQueryId, ClusterName, ExecutingQuery, SqlDialect};
+
+        let mem = Arc::new(InMemoryPersistence::new());
+        let state = test_fixtures::app_state_with_metrics(mem.clone(), false);
+
+        let executing = ExecutingQuery {
+            id: ProxyQueryId("q-exec-cancel".into()),
+            sql: "SELECT 1".into(),
+            translated_sql: None,
+            cluster_group: ClusterGroupName("default".into()),
+            cluster_name: ClusterName("trino".into()),
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            backend_query_id: BackendQueryId("backend-1".into()),
+            poll_base_url: None,
+            creation_time: Utc::now(),
+            last_accessed: Utc::now(),
+            query_tags: QueryTags::default(),
+            agent_context: None,
+            submitted_guard_actions: vec![],
+            was_guard_blocked: false,
+            submitted_by: "bob".into(),
+        };
+        state.record_executing_cancelled(
+            &executing,
+            FrontendProtocol::TrinoHttp,
+            EngineType::Trino,
+            SqlDialect::Trino,
+            "client cancelled",
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let rows = mem
+            .list_queries(&QueryFilters {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].status.contains("Cancelled"));
+        assert_eq!(rows[0].error_message.as_deref(), Some("client cancelled"));
+    }
+}
+
+#[cfg(test)]
 pub mod test_fixtures {
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -422,7 +537,7 @@ pub mod test_fixtures {
         cluster_state::ClusterState, simple::SimpleClusterGroupManager,
     };
     use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType};
-    use queryflux_metrics::NoopMetricsStore;
+    use queryflux_metrics::{MetricsStore, NoopMetricsStore};
     use queryflux_persistence::in_memory::InMemoryPersistence;
     use queryflux_routing::chain::RouterChain;
     use queryflux_translation::TranslationService;
@@ -431,6 +546,13 @@ pub mod test_fixtures {
     use super::{AppState, LiveConfig};
 
     pub fn app_state(auth_required: bool) -> Arc<AppState> {
+        app_state_with_metrics(Arc::new(NoopMetricsStore), auth_required)
+    }
+
+    pub fn app_state_with_metrics(
+        metrics: Arc<dyn MetricsStore>,
+        auth_required: bool,
+    ) -> Arc<AppState> {
         let group_name = ClusterGroupName("default".into());
         let cluster_name = ClusterName("trino".into());
         let cluster_state = Arc::new(ClusterState::new(
@@ -478,7 +600,7 @@ pub mod test_fixtures {
             live: Arc::new(RwLock::new(live)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation: Arc::new(TranslationService::disabled()),
-            metrics: Arc::new(NoopMetricsStore),
+            metrics,
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
             queue_coordinator: None,

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -8,8 +8,8 @@ use queryflux_core::{
     config::ClusterConfig,
     params::QueryParams,
     query::{
-        ClusterGroupName, ClusterName, EngineType, FrontendProtocol, ProxyQueryId,
-        QueryEngineStats, QueryStatus, SqlDialect,
+        ClusterGroupName, ClusterName, EngineType, ExecutingQuery, FrontendProtocol, ProxyQueryId,
+        QueryEngineStats, QueryStatus, QueuedQuery, SqlDialect,
     },
     session::{AgentContext, SessionContext},
     tags::QueryTags,
@@ -275,6 +275,124 @@ impl AppState {
             }
             let _ = metrics.record_query(record).await;
         });
+    }
+
+    /// Persist a `Cancelled` audit row for an executing query (client cancel, admin
+    /// cancel, or zombie eviction). Prefer calling this before deleting the
+    /// executing record so a raced poll completion still wins if it recorded first.
+    pub fn record_executing_cancelled(
+        &self,
+        executing: &ExecutingQuery,
+        protocol: FrontendProtocol,
+        engine_type: EngineType,
+        tgt_dialect: SqlDialect,
+        reason: &str,
+    ) {
+        let was_translated = executing.translated_sql.is_some();
+        let execution_ms = (Utc::now() - executing.creation_time)
+            .num_milliseconds()
+            .max(0) as u64;
+        let guard_actions: Vec<GuardAction> = serde_json::from_value(serde_json::Value::Array(
+            executing.submitted_guard_actions.clone(),
+        ))
+        .unwrap_or_default();
+        let session = SessionContext {
+            user: (!executing.submitted_by.is_empty()).then(|| executing.submitted_by.clone()),
+            ..Default::default()
+        };
+        let src_dialect = protocol.default_dialect();
+        let ctx = QueryContext {
+            query_id: executing.id.clone(),
+            sql: executing
+                .translated_sql
+                .as_deref()
+                .unwrap_or(&executing.sql)
+                .to_string(),
+            session,
+            protocol,
+            group: executing.cluster_group.clone(),
+            cluster: executing.cluster_name.clone(),
+            cluster_group_config_id: executing.cluster_group_config_id,
+            cluster_config_id: executing.cluster_config_id,
+            engine_type,
+            src_dialect,
+            tgt_dialect,
+            was_translated,
+            translated_sql: if was_translated {
+                Some(executing.sql.clone())
+            } else {
+                None
+            },
+            query_tags: executing.query_tags.clone(),
+            query_params: vec![],
+            agent_context: executing.agent_context.clone(),
+        };
+        self.record_query(
+            &ctx,
+            QueryOutcome {
+                backend_query_id: Some(executing.backend_query_id.0.clone()),
+                status: QueryStatus::Cancelled,
+                execution_ms,
+                rows: None,
+                error: Some(reason.to_string()),
+                routing_trace: None,
+                engine_stats: None,
+                guard_actions,
+                was_guard_blocked: executing.was_guard_blocked,
+                queue_duration_ms: 0,
+                cache_hit: false,
+            },
+        );
+    }
+
+    /// Persist a terminal audit row for a queued query that never reached an engine
+    /// (capacity wait timeout, stale client disconnect).
+    pub fn record_queued_terminal(&self, queued: &QueuedQuery, status: QueryStatus, reason: &str) {
+        let queue_duration_ms = (Utc::now() - queued.creation_time)
+            .num_milliseconds()
+            .max(0) as u64;
+        let session = {
+            let mut s = queued.session.clone();
+            if s.user.is_none() && !queued.submitted_by.is_empty() {
+                s.user = Some(queued.submitted_by.clone());
+            }
+            s
+        };
+        let dialect = queued.frontend_protocol.default_dialect();
+        let ctx = QueryContext {
+            query_id: queued.id.clone(),
+            sql: queued.sql.clone(),
+            session,
+            protocol: queued.frontend_protocol.clone(),
+            group: queued.cluster_group.clone(),
+            cluster: ClusterName("(not-dispatched)".into()),
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            engine_type: EngineType::Trino,
+            src_dialect: dialect.clone(),
+            tgt_dialect: dialect,
+            was_translated: false,
+            translated_sql: None,
+            query_tags: QueryTags::default(),
+            query_params: vec![],
+            agent_context: None,
+        };
+        self.record_query(
+            &ctx,
+            QueryOutcome {
+                backend_query_id: None,
+                status,
+                execution_ms: 0,
+                rows: None,
+                error: Some(reason.to_string()),
+                routing_trace: None,
+                engine_stats: None,
+                guard_actions: vec![],
+                was_guard_blocked: false,
+                queue_duration_ms,
+                cache_hit: false,
+            },
+        );
     }
 }
 

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -768,9 +768,8 @@ pub async fn get_queued_statement(
             group: queued.cluster_group.0.clone(),
             timeout_secs: wait_timeout_secs,
         };
-        state.record_queued_terminal(&queued, QueryStatus::Failed, &err.to_string());
-        if let Err(e) = state.persistence.delete_queued(&query_id).await {
-            warn!(id = %query_id, "Failed to delete queued query after capacity wait timeout: {e}");
+        if let Ok(Some(taken)) = state.persistence.take_queued(&query_id).await {
+            state.record_queued_terminal(&taken, QueryStatus::Failed, &err.to_string());
         }
         if let Some(qc) = &state.queue_coordinator {
             let _ = qc.release_claim(&query_id.0).await;

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -764,16 +764,17 @@ pub async fn get_queued_statement(
     };
     let waited_secs = (Utc::now() - queued.creation_time).num_seconds().max(0) as u64;
     if waited_secs >= wait_timeout_secs {
+        let err = QueryFluxError::CapacityWaitTimeout {
+            group: queued.cluster_group.0.clone(),
+            timeout_secs: wait_timeout_secs,
+        };
+        state.record_queued_terminal(&queued, QueryStatus::Failed, &err.to_string());
         if let Err(e) = state.persistence.delete_queued(&query_id).await {
             warn!(id = %query_id, "Failed to delete queued query after capacity wait timeout: {e}");
         }
         if let Some(qc) = &state.queue_coordinator {
             let _ = qc.release_claim(&query_id.0).await;
         }
-        let err = QueryFluxError::CapacityWaitTimeout {
-            group: queued.cluster_group.0.clone(),
-            timeout_secs: wait_timeout_secs,
-        };
         return trino_error_response(&query_id.0, &err.to_string()).into_response();
     }
 
@@ -1405,6 +1406,13 @@ pub async fn delete_executing_statement(
         return (StatusCode::BAD_GATEWAY, "failed to cancel query on backend").into_response();
     }
 
+    state.record_executing_cancelled(
+        &executing,
+        FrontendProtocol::TrinoHttp,
+        adapter.engine_type(),
+        adapter.translation_target_dialect(),
+        "client cancelled",
+    );
     state
         .release_query_slot(
             &executing.cluster_group,

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -184,6 +184,9 @@ impl Persistence for InMemoryPersistence {
         self.queued.remove(&id.0);
         Ok(())
     }
+    async fn take_queued(&self, id: &ProxyQueryId) -> Result<Option<QueuedQuery>> {
+        Ok(self.queued.remove(&id.0).map(|(_, q)| q))
+    }
     async fn list_queued(&self) -> Result<Vec<QueuedQuery>> {
         Ok(self.queued.iter().map(|e| e.value().clone()).collect())
     }
@@ -242,6 +245,12 @@ impl MetricsStore for InMemoryPersistence {
     async fn record_query(&self, record: QueryRecord) -> Result<()> {
         let summary = self.record_to_summary(record);
         let mut records = self.query_records.write().unwrap();
+        if records
+            .iter()
+            .any(|r| r.proxy_query_id == summary.proxy_query_id)
+        {
+            return Ok(());
+        }
         if records.len() >= QUERY_RECORDS_MAX {
             // Evict the oldest quarter to amortize the cost of repeated trimming.
             let drain_count = QUERY_RECORDS_MAX / 4;

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -1438,4 +1438,88 @@ mod tests {
         assert_eq!(store._snapshots.read().unwrap().len(), 1);
         assert!(store._snapshots.read().unwrap()[0].recorded_at >= cutoff);
     }
+
+    #[tokio::test]
+    async fn take_queued_returns_row_once() {
+        use queryflux_core::query::ProxyQueryId;
+
+        let store = InMemoryPersistence::new();
+        store.upsert_queued(make_queued("q-take")).await.unwrap();
+        assert!(store
+            .take_queued(&ProxyQueryId("q-take".into()))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .take_queued(&ProxyQueryId("q-take".into()))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn record_query_keeps_first_terminal_row_per_proxy_id() {
+        use crate::query_history::QueryFilters;
+        use crate::{MetricsStore, QueryHistoryStore, QueryRecord};
+        use queryflux_core::query::{
+            ClusterGroupName, ClusterName, EngineType, FrontendProtocol, QueryStatus, SqlDialect,
+        };
+
+        let store = InMemoryPersistence::new();
+        let mut first = QueryRecord {
+            proxy_query_id: "proxy-dedup".into(),
+            backend_query_id: None,
+            cluster_group: ClusterGroupName("g".into()),
+            cluster_name: ClusterName("c".into()),
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            engine_type: EngineType::Undispatched,
+            frontend_protocol: FrontendProtocol::TrinoHttp,
+            source_dialect: SqlDialect::Trino,
+            target_dialect: SqlDialect::Generic,
+            was_translated: false,
+            translated_sql: None,
+            user: None,
+            catalog: None,
+            database: None,
+            sql_preview: "SELECT 1".into(),
+            status: QueryStatus::Failed,
+            routing_trace: None,
+            queue_duration_ms: 100,
+            execution_duration_ms: 0,
+            rows_returned: None,
+            error_message: Some("capacity wait timeout".into()),
+            created_at: Utc::now(),
+            engine_stats: None,
+            query_tags: Default::default(),
+            query_hash: None,
+            query_parameterized_hash: None,
+            translated_query_hash: None,
+            digest_text: None,
+            translated_digest_text: None,
+            agent_id: None,
+            conversation_id: None,
+            step_index: None,
+            tool_call_id: None,
+            query_intent: None,
+            guard_actions: vec![],
+            was_guard_blocked: false,
+            cache_hit: false,
+        };
+        store.record_query(first.clone()).await.unwrap();
+        first.status = QueryStatus::Cancelled;
+        first.error_message = Some("client cancelled".into());
+        store.record_query(first).await.unwrap();
+
+        let rows = store
+            .list_queries(&QueryFilters {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].proxy_query_id, "proxy-dedup");
+        assert!(rows[0].status.contains("Failed"));
+    }
 }

--- a/crates/queryflux-persistence/src/lib.rs
+++ b/crates/queryflux-persistence/src/lib.rs
@@ -54,6 +54,8 @@ pub trait Persistence: Send + Sync {
     async fn upsert_queued(&self, query: QueuedQuery) -> Result<()>;
     async fn get_queued(&self, id: &ProxyQueryId) -> Result<Option<QueuedQuery>>;
     async fn delete_queued(&self, id: &ProxyQueryId) -> Result<()>;
+    /// Atomically remove a queued query and return it when this caller wins the delete.
+    async fn take_queued(&self, id: &ProxyQueryId) -> Result<Option<QueuedQuery>>;
     async fn list_queued(&self) -> Result<Vec<QueuedQuery>>;
 
     /// Bump `last_accessed` to now for a queued query, keeping it alive in the

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_dedupe_proxy_id.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_dedupe_proxy_id.sql
@@ -1,0 +1,5 @@
+-- Remove duplicate terminal rows before adding a unique index (keep earliest id).
+DELETE FROM query_records a
+USING query_records b
+WHERE a.proxy_query_id = b.proxy_query_id
+  AND a.id > b.id;

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_dedupe_proxy_id.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_dedupe_proxy_id.sql
@@ -3,3 +3,6 @@ DELETE FROM query_records a
 USING query_records b
 WHERE a.proxy_query_id = b.proxy_query_id
   AND a.id > b.id;
+
+-- Drop the non-unique index so the concurrent unique index can take its place.
+DROP INDEX IF EXISTS query_records_proxy_id;

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_proxy_id_unique.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_proxy_id_unique.sql
@@ -1,0 +1,7 @@
+-- One terminal audit row per proxy query id (poll completion vs cancel race).
+DELETE FROM query_records a
+USING query_records b
+WHERE a.proxy_query_id = b.proxy_query_id
+  AND a.id > b.id;
+
+CREATE UNIQUE INDEX query_records_proxy_query_id_unique ON query_records (proxy_query_id);

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_proxy_id_unique.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000001_query_records_proxy_id_unique.sql
@@ -1,7 +1,0 @@
--- One terminal audit row per proxy query id (poll completion vs cancel race).
-DELETE FROM query_records a
-USING query_records b
-WHERE a.proxy_query_id = b.proxy_query_id
-  AND a.id > b.id;
-
-CREATE UNIQUE INDEX query_records_proxy_query_id_unique ON query_records (proxy_query_id);

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000002_query_records_proxy_id_unique.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000002_query_records_proxy_id_unique.sql
@@ -1,0 +1,4 @@
+-- no-transaction
+DROP INDEX IF EXISTS query_records_proxy_id;
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS query_records_proxy_query_id_unique
+    ON query_records (proxy_query_id);

--- a/crates/queryflux-persistence/src/postgres/migrations/20260813000002_query_records_proxy_id_unique.sql
+++ b/crates/queryflux-persistence/src/postgres/migrations/20260813000002_query_records_proxy_id_unique.sql
@@ -1,4 +1,5 @@
 -- no-transaction
-DROP INDEX IF EXISTS query_records_proxy_id;
+-- Single statement required: Postgres starts an implicit transaction for
+-- multi-statement scripts, which rejects CREATE INDEX CONCURRENTLY.
 CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS query_records_proxy_query_id_unique
     ON query_records (proxy_query_id);

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -1536,7 +1536,7 @@ impl MetricsStore for PostgresStore {
         let query_tags_json = tags_to_json(&r.query_tags);
         let guard_actions_json =
             serde_json::to_value(&r.guard_actions).unwrap_or(serde_json::Value::Array(vec![]));
-        sqlx::query(
+        let insert_result = sqlx::query(
             r#"INSERT INTO query_records
                 (proxy_query_id, backend_query_id, cluster_group, cluster_name, engine_type,
                  frontend_protocol, source_dialect, target_dialect, was_translated, username,
@@ -1599,6 +1599,9 @@ impl MetricsStore for PostgresStore {
         .execute(&self.pool)
         .await
         .map_err(|e| QueryFluxError::Persistence(format!("Insert query_records: {e}")))?;
+        if insert_result.rows_affected() == 0 {
+            return Ok(());
+        }
 
         // Upsert into query_digest_stats.
         if let Some(phash) = r.query_parameterized_hash {

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -1421,6 +1421,23 @@ impl Persistence for PostgresStore {
         Ok(())
     }
 
+    async fn take_queued(&self, id: &ProxyQueryId) -> Result<Option<QueuedQuery>> {
+        let row: Option<(serde_json::Value,)> =
+            sqlx::query_as("DELETE FROM queued_queries WHERE id = $1 RETURNING data")
+                .bind(&id.0)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| QueryFluxError::Persistence(format!("take_queued: {e}")))?;
+        match row {
+            None => Ok(None),
+            Some((data,)) => {
+                let q = serde_json::from_value(data)
+                    .map_err(|e| QueryFluxError::Persistence(format!("Deserialize error: {e}")))?;
+                Ok(Some(q))
+            }
+        }
+    }
+
     async fn list_queued(&self) -> Result<Vec<QueuedQuery>> {
         let rows: Vec<(serde_json::Value,)> =
             sqlx::query_as("SELECT data FROM queued_queries ORDER BY created_at")
@@ -1533,7 +1550,8 @@ impl MetricsStore for PostgresStore {
                  guard_actions, was_guard_blocked, cache_hit)
                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,
                        $21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,
-                       $36,$37,$38,$39,$40,$41,$42,$43)"#,
+                       $36,$37,$38,$39,$40,$41,$42,$43)
+               ON CONFLICT (proxy_query_id) DO NOTHING"#,
         )
         .bind(&r.proxy_query_id)
         .bind(&r.backend_query_id)

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -2682,4 +2682,99 @@ mod tests {
         store.delete_queued(&ProxyQueryId(qid1)).await.unwrap();
         store.delete_queued(&ProxyQueryId(qid2)).await.unwrap();
     }
+
+    #[tokio::test]
+    #[ignore]
+    async fn pg_take_queued_returns_row_once() {
+        let store = test_store().await;
+        let qid = unique_id("take");
+
+        store.upsert_queued(make_queued(&qid)).await.unwrap();
+        assert!(store
+            .take_queued(&ProxyQueryId(qid.clone()))
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .take_queued(&ProxyQueryId(qid))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn pg_record_query_keeps_first_terminal_row_per_proxy_id() {
+        use crate::{MetricsStore, QueryHistoryStore, QueryRecord};
+        use queryflux_core::query::{
+            ClusterGroupName, ClusterName, EngineType, FrontendProtocol, QueryStatus, SqlDialect,
+        };
+
+        let store = test_store().await;
+        let proxy_id = unique_id("dedup");
+        let mut first = QueryRecord {
+            proxy_query_id: proxy_id.clone(),
+            backend_query_id: None,
+            cluster_group: ClusterGroupName("g".into()),
+            cluster_name: ClusterName("c".into()),
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            engine_type: EngineType::Undispatched,
+            frontend_protocol: FrontendProtocol::TrinoHttp,
+            source_dialect: SqlDialect::Trino,
+            target_dialect: SqlDialect::Generic,
+            was_translated: false,
+            translated_sql: None,
+            user: None,
+            catalog: None,
+            database: None,
+            sql_preview: "SELECT 1".into(),
+            status: QueryStatus::Failed,
+            routing_trace: None,
+            queue_duration_ms: 100,
+            execution_duration_ms: 0,
+            rows_returned: None,
+            error_message: Some("capacity wait timeout".into()),
+            created_at: chrono::Utc::now(),
+            engine_stats: None,
+            query_tags: Default::default(),
+            query_hash: None,
+            query_parameterized_hash: Some(42),
+            translated_query_hash: None,
+            digest_text: Some("select 1".into()),
+            translated_digest_text: None,
+            agent_id: None,
+            conversation_id: None,
+            step_index: None,
+            tool_call_id: None,
+            query_intent: None,
+            guard_actions: vec![],
+            was_guard_blocked: false,
+            cache_hit: false,
+        };
+        store.record_query(first.clone()).await.unwrap();
+        first.status = QueryStatus::Cancelled;
+        first.error_message = Some("client cancelled".into());
+        store.record_query(first).await.unwrap();
+
+        let rows = store
+            .list_queries(&QueryFilters {
+                limit: 50,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].proxy_query_id, proxy_id);
+        assert!(rows[0].status.contains("Failed"));
+
+        let digest_count: (i64,) = sqlx::query_as(
+            "SELECT call_count FROM query_digest_stats WHERE query_parameterized_hash = $1",
+        )
+        .bind(42_i64)
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!(digest_count.0, 1);
+    }
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1226,6 +1226,13 @@ async fn main() -> Result<()> {
                         let backend_id = q.backend_query_id.clone();
                         let cluster = q.cluster_name.0.clone();
                         if let Some(adapter) = state.adapter(&cluster).await {
+                            state.record_executing_cancelled(
+                                &q,
+                                queryflux_core::query::FrontendProtocol::TrinoHttp,
+                                adapter.engine_type(),
+                                adapter.translation_target_dialect(),
+                                "zombie_evicted: not polled for >5 min",
+                            );
                             tokio::spawn(async move {
                                 if let Err(e) = adapter.cancel_query(&backend_id).await {
                                     tracing::debug!(
@@ -1234,6 +1241,13 @@ async fn main() -> Result<()> {
                                 }
                             });
                         } else {
+                            state.record_executing_cancelled(
+                                &q,
+                                queryflux_core::query::FrontendProtocol::TrinoHttp,
+                                queryflux_core::query::EngineType::Trino,
+                                queryflux_core::query::SqlDialect::Trino,
+                                "zombie_evicted: not polled for >5 min",
+                            );
                             tracing::debug!(
                                 cluster = %cluster,
                                 id = %q.backend_query_id,
@@ -1242,21 +1256,8 @@ async fn main() -> Result<()> {
                         }
 
                         state
-                            .metrics
-                            .on_query_finished(&q.cluster_group.0, &q.cluster_name.0);
-                        let cluster_manager = state.live.read().await.cluster_manager.clone();
-                        let _ = cluster_manager
-                            .release_cluster(&q.cluster_group, &q.cluster_name)
+                            .release_query_slot(&q.cluster_group, &q.cluster_name, &q.id.0)
                             .await;
-                        if let Some(cap) = &state.capacity_store {
-                            if let Err(e) = cap.release(&q.cluster_name.0, &q.id.0).await {
-                                state.metrics.on_coordination_failure("capacity_release");
-                                tracing::warn!(
-                                    "CapacityStore release failed for zombie query {}: {e}",
-                                    q.id
-                                );
-                            }
-                        }
                         let _ = state.persistence.delete(&q.backend_query_id).await;
                     }
                 }
@@ -1282,14 +1283,24 @@ async fn main() -> Result<()> {
                     break;
                 }
                 let cutoff = chrono::Utc::now() - chrono::Duration::seconds(CLIENT_TIMEOUT_SECS);
-                match state
-                    .persistence
-                    .delete_queued_not_accessed_since(cutoff)
-                    .await
-                {
-                    Ok(0) => {}
-                    Ok(n) => tracing::info!("Cleaned up {n} stale queued queries"),
-                    Err(e) => tracing::warn!("Queued query cleanup failed: {e}"),
+                let Ok(queued) = state.persistence.list_queued().await else {
+                    continue;
+                };
+                let mut cleaned = 0u64;
+                for q in queued {
+                    if q.last_accessed < cutoff {
+                        state.record_queued_terminal(
+                            &q,
+                            queryflux_core::query::QueryStatus::Failed,
+                            "stale_queued_evicted: client disconnected before dispatch",
+                        );
+                        if state.persistence.delete_queued(&q.id).await.is_ok() {
+                            cleaned += 1;
+                        }
+                    }
+                }
+                if cleaned > 0 {
+                    tracing::info!("Cleaned up {cleaned} stale queued queries");
                 }
             }
         }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1273,6 +1273,7 @@ async fn main() -> Result<()> {
     // deletes queued entries not accessed for > 5 minutes.
     tokio::spawn({
         let state = app_state.clone();
+        let distributed_backend = distributed_backend.clone();
         let mut shutdown_rx = shutdown_rx.clone();
         async move {
             const CLIENT_TIMEOUT_SECS: i64 = 300;
@@ -1281,8 +1282,25 @@ async fn main() -> Result<()> {
                 if !tick_or_shutdown(&mut interval, &mut shutdown_rx).await {
                     break;
                 }
+
+                let sweep_lock = match &distributed_backend {
+                    Some(backend) => match backend.try_sweep_lock("stale-queued-eviction").await {
+                        Ok(Some(lock)) => Some(lock),
+                        Ok(None) => continue,
+                        Err(e) => {
+                            state.metrics.on_coordination_failure("sweep_lock");
+                            tracing::warn!("Stale queued sweep lock failed, sweeping anyway: {e}");
+                            None
+                        }
+                    },
+                    None => None,
+                };
+
                 let cutoff = chrono::Utc::now() - chrono::Duration::seconds(CLIENT_TIMEOUT_SECS);
                 let Ok(queued) = state.persistence.list_queued().await else {
+                    if let Some(lock) = sweep_lock {
+                        lock.release().await;
+                    }
                     continue;
                 };
                 let mut cleaned = 0u64;
@@ -1300,6 +1318,10 @@ async fn main() -> Result<()> {
                 }
                 if cleaned > 0 {
                     tracing::info!("Cleaned up {cleaned} stale queued queries");
+                }
+
+                if let Some(lock) = sweep_lock {
+                    lock.release().await;
                 }
             }
         }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1225,14 +1225,20 @@ async fn main() -> Result<()> {
                         // DELETE on `/v1/statement/executing/...` did not stop secured Trino.
                         let backend_id = q.backend_query_id.clone();
                         let cluster = q.cluster_name.0.clone();
+                        let (engine_type, tgt_dialect) =
+                            if let Some(adapter) = state.adapter(&cluster).await {
+                                (adapter.engine_type(), adapter.translation_target_dialect())
+                            } else {
+                                state.engine_type_for_cluster(&cluster).await
+                            };
+                        state.record_executing_cancelled(
+                            &q,
+                            queryflux_core::query::FrontendProtocol::TrinoHttp,
+                            engine_type,
+                            tgt_dialect,
+                            "zombie_evicted: not polled for >5 min",
+                        );
                         if let Some(adapter) = state.adapter(&cluster).await {
-                            state.record_executing_cancelled(
-                                &q,
-                                queryflux_core::query::FrontendProtocol::TrinoHttp,
-                                adapter.engine_type(),
-                                adapter.translation_target_dialect(),
-                                "zombie_evicted: not polled for >5 min",
-                            );
                             tokio::spawn(async move {
                                 if let Err(e) = adapter.cancel_query(&backend_id).await {
                                     tracing::debug!(
@@ -1241,13 +1247,6 @@ async fn main() -> Result<()> {
                                 }
                             });
                         } else {
-                            state.record_executing_cancelled(
-                                &q,
-                                queryflux_core::query::FrontendProtocol::TrinoHttp,
-                                queryflux_core::query::EngineType::Trino,
-                                queryflux_core::query::SqlDialect::Trino,
-                                "zombie_evicted: not polled for >5 min",
-                            );
                             tracing::debug!(
                                 cluster = %cluster,
                                 id = %q.backend_query_id,
@@ -1289,12 +1288,12 @@ async fn main() -> Result<()> {
                 let mut cleaned = 0u64;
                 for q in queued {
                     if q.last_accessed < cutoff {
-                        state.record_queued_terminal(
-                            &q,
-                            queryflux_core::query::QueryStatus::Failed,
-                            "stale_queued_evicted: client disconnected before dispatch",
-                        );
-                        if state.persistence.delete_queued(&q.id).await.is_ok() {
+                        if let Ok(Some(taken)) = state.persistence.take_queued(&q.id).await {
+                            state.record_queued_terminal(
+                                &taken,
+                                queryflux_core::query::QueryStatus::Failed,
+                                "stale_queued_evicted: client disconnected before dispatch",
+                            );
                             cleaned += 1;
                         }
                     }


### PR DESCRIPTION
## Summary
- Client Trino cancel, admin cancel (executing + queued), capacity-wait timeout, zombie eviction, and stale queued cleanup now call `record_query`.
- Shared helpers: `record_executing_cancelled` / `record_queued_terminal` on `AppState`.
- Distinguishable via `status` + `error_message` (`client cancelled`, `admin cancelled`, `zombie_evicted…`, capacity wait text).

## Test plan
- [x] Clippy workspace `-D warnings`
- [x] Cancel a running Trino query and confirm a `Cancelled` row in query history (`record_executing_cancelled_writes_cancelled_history_row`)
- [x] Let a queued query hit capacity wait timeout and confirm a `Failed` history row (`record_queued_terminal_preserves_tags_and_agent_context` + `record_query_keeps_first_terminal_row_per_proxy_id`)