### PR TITLE
fix: seed YAML clusters into Postgres only when missing

### DIFF
--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -459,6 +459,18 @@ impl ClusterConfigStore for InMemoryPersistence {
         Ok(record)
     }
 
+    async fn insert_cluster_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterConfig,
+    ) -> Result<bool> {
+        if self.cluster_configs.contains_key(name) {
+            return Ok(false);
+        }
+        self.upsert_cluster_config(name, cfg).await?;
+        Ok(true)
+    }
+
     async fn delete_cluster_config(&self, name: &str) -> Result<bool> {
         if self.cluster_configs.remove(name).is_none() {
             return Ok(false);
@@ -541,6 +553,18 @@ impl ClusterConfigStore for InMemoryPersistence {
         };
         self.group_configs.insert(name.to_string(), record.clone());
         Ok(record)
+    }
+
+    async fn insert_group_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterGroupConfig,
+    ) -> Result<bool> {
+        if self.group_configs.contains_key(name) {
+            return Ok(false);
+        }
+        self.upsert_group_config(name, cfg).await?;
+        Ok(true)
     }
 
     async fn delete_group_config(&self, name: &str) -> Result<bool> {

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -464,11 +464,24 @@ impl ClusterConfigStore for InMemoryPersistence {
         name: &str,
         cfg: &UpsertClusterConfig,
     ) -> Result<bool> {
-        if self.cluster_configs.contains_key(name) {
-            return Ok(false);
+        let now = Utc::now();
+        match self.cluster_configs.entry(name.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(_) => Ok(false),
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let id = self.next_cluster_id.fetch_add(1, Ordering::Relaxed);
+                v.insert(ClusterConfigRecord {
+                    id,
+                    name: name.to_string(),
+                    engine_key: cfg.engine_key.clone(),
+                    enabled: cfg.enabled,
+                    max_running_queries: cfg.max_running_queries,
+                    config: cfg.config.clone(),
+                    created_at: now,
+                    updated_at: now,
+                });
+                Ok(true)
+            }
         }
-        self.upsert_cluster_config(name, cfg).await?;
-        Ok(true)
     }
 
     async fn delete_cluster_config(&self, name: &str) -> Result<bool> {
@@ -560,11 +573,50 @@ impl ClusterConfigStore for InMemoryPersistence {
         name: &str,
         cfg: &UpsertClusterGroupConfig,
     ) -> Result<bool> {
-        if self.group_configs.contains_key(name) {
-            return Ok(false);
+        for m in &cfg.members {
+            if !self.cluster_configs.contains_key(m) {
+                return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
+                    "Unknown cluster '{m}' in group members (clusters must exist first)"
+                )));
+            }
         }
-        self.upsert_group_config(name, cfg).await?;
-        Ok(true)
+        for sid in &cfg.translation_script_ids {
+            let ok = self
+                .user_scripts
+                .get(sid)
+                .map(|r| r.kind == KIND_TRANSLATION_FIXUP)
+                .unwrap_or(false);
+            if !ok {
+                return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
+                    "Unknown or invalid translation script id {sid}"
+                )));
+            }
+        }
+
+        let now = Utc::now();
+        match self.group_configs.entry(name.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(_) => Ok(false),
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let id = self.next_group_id.fetch_add(1, Ordering::Relaxed);
+                v.insert(ClusterGroupConfigRecord {
+                    id,
+                    name: name.to_string(),
+                    enabled: cfg.enabled,
+                    members: cfg.members.clone(),
+                    max_running_queries: cfg.max_running_queries,
+                    max_queued_queries: cfg.max_queued_queries,
+                    strategy: cfg.strategy.clone(),
+                    allow_groups: cfg.allow_groups.clone(),
+                    allow_users: cfg.allow_users.clone(),
+                    translation_script_ids: cfg.translation_script_ids.clone(),
+                    default_tags: cfg.default_tags.clone(),
+                    cache: cfg.cache.clone(),
+                    created_at: now,
+                    updated_at: now,
+                });
+                Ok(true)
+            }
+        }
     }
 
     async fn delete_group_config(&self, name: &str) -> Result<bool> {

--- a/crates/queryflux-persistence/src/in_memory.rs
+++ b/crates/queryflux-persistence/src/in_memory.rs
@@ -573,30 +573,30 @@ impl ClusterConfigStore for InMemoryPersistence {
         name: &str,
         cfg: &UpsertClusterGroupConfig,
     ) -> Result<bool> {
-        for m in &cfg.members {
-            if !self.cluster_configs.contains_key(m) {
-                return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
-                    "Unknown cluster '{m}' in group members (clusters must exist first)"
-                )));
-            }
-        }
-        for sid in &cfg.translation_script_ids {
-            let ok = self
-                .user_scripts
-                .get(sid)
-                .map(|r| r.kind == KIND_TRANSLATION_FIXUP)
-                .unwrap_or(false);
-            if !ok {
-                return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
-                    "Unknown or invalid translation script id {sid}"
-                )));
-            }
-        }
-
         let now = Utc::now();
         match self.group_configs.entry(name.to_string()) {
             dashmap::mapref::entry::Entry::Occupied(_) => Ok(false),
             dashmap::mapref::entry::Entry::Vacant(v) => {
+                for m in &cfg.members {
+                    if !self.cluster_configs.contains_key(m) {
+                        return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
+                            "Unknown cluster '{m}' in group members (clusters must exist first)"
+                        )));
+                    }
+                }
+                for sid in &cfg.translation_script_ids {
+                    let ok = self
+                        .user_scripts
+                        .get(sid)
+                        .map(|r| r.kind == KIND_TRANSLATION_FIXUP)
+                        .unwrap_or(false);
+                    if !ok {
+                        return Err(queryflux_core::error::QueryFluxError::Persistence(format!(
+                            "Unknown or invalid translation script id {sid}"
+                        )));
+                    }
+                }
+
                 let id = self.next_group_id.fetch_add(1, Ordering::Relaxed);
                 v.insert(ClusterGroupConfigRecord {
                     id,

--- a/crates/queryflux-persistence/src/lib.rs
+++ b/crates/queryflux-persistence/src/lib.rs
@@ -158,6 +158,12 @@ pub trait ClusterConfigStore: Send + Sync {
         name: &str,
         cfg: &UpsertClusterConfig,
     ) -> Result<ClusterConfigRecord>;
+    /// Insert a cluster row only when `name` is absent. Returns true when inserted.
+    async fn insert_cluster_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterConfig,
+    ) -> Result<bool>;
     /// Deletes the cluster row and removes its id from every group's `members` array
     /// (Postgres) or drops its name from each group's member list (in-memory).
     async fn delete_cluster_config(&self, name: &str) -> Result<bool>;
@@ -178,6 +184,12 @@ pub trait ClusterConfigStore: Send + Sync {
         name: &str,
         cfg: &UpsertClusterGroupConfig,
     ) -> Result<ClusterGroupConfigRecord>;
+    /// Insert a group row only when `name` is absent. Returns true when inserted.
+    async fn insert_group_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterGroupConfig,
+    ) -> Result<bool>;
     async fn delete_group_config(&self, name: &str) -> Result<bool>;
     /// Returns the number of stored group configs (used for first-run seeding).
     async fn group_configs_count(&self) -> Result<i64>;

--- a/crates/queryflux-persistence/src/lib.rs
+++ b/crates/queryflux-persistence/src/lib.rs
@@ -7,6 +7,7 @@ pub mod query_history;
 pub mod routing_json;
 pub mod routing_slices;
 pub mod script_library;
+pub mod yaml_seed;
 
 use std::collections::HashMap;
 

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -784,6 +784,23 @@ impl ClusterConfigStore for PostgresStore {
             QueryFluxError::Persistence(format!("insert_group_config_if_missing begin: {e}"))
         })?;
 
+        let existing: Option<(i64,)> =
+            sqlx::query_as("SELECT id FROM cluster_group_configs WHERE name = $1")
+                .bind(name)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| {
+                    QueryFluxError::Persistence(format!(
+                        "insert_group_config_if_missing lookup: {e}"
+                    ))
+                })?;
+        if existing.is_some() {
+            tx.commit().await.map_err(|e| {
+                QueryFluxError::Persistence(format!("insert_group_config_if_missing commit: {e}"))
+            })?;
+            return Ok(false);
+        }
+
         let mut member_ids: Vec<i64> = Vec::with_capacity(cfg.members.len());
         for m in &cfg.members {
             let row: Option<(i64,)> =

--- a/crates/queryflux-persistence/src/postgres/mod.rs
+++ b/crates/queryflux-persistence/src/postgres/mod.rs
@@ -512,6 +512,30 @@ impl ClusterConfigStore for PostgresStore {
         .map_err(|e| QueryFluxError::Persistence(format!("upsert_cluster_config: {e}")))
     }
 
+    async fn insert_cluster_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterConfig,
+    ) -> Result<bool> {
+        let inserted = sqlx::query_as::<_, ClusterConfigRecord>(
+            r#"INSERT INTO cluster_configs (name, engine_key, enabled, max_running_queries, config)
+               VALUES ($1, $2, $3, $4, $5)
+               ON CONFLICT (name) DO NOTHING
+               RETURNING *"#,
+        )
+        .bind(name)
+        .bind(&cfg.engine_key)
+        .bind(cfg.enabled)
+        .bind(cfg.max_running_queries)
+        .bind(&cfg.config)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            QueryFluxError::Persistence(format!("insert_cluster_config_if_missing: {e}"))
+        })?;
+        Ok(inserted.is_some())
+    }
+
     async fn delete_cluster_config(&self, name: &str) -> Result<bool> {
         let mut tx = self.pool.begin().await.map_err(|e| {
             QueryFluxError::Persistence(format!("delete_cluster_config begin: {e}"))
@@ -749,6 +773,88 @@ impl ClusterConfigStore for PostgresStore {
             .await
             .map_err(|e| QueryFluxError::Persistence(format!("upsert_group_config commit: {e}")))?;
         Ok(record)
+    }
+
+    async fn insert_group_config_if_missing(
+        &self,
+        name: &str,
+        cfg: &UpsertClusterGroupConfig,
+    ) -> Result<bool> {
+        let mut tx = self.pool.begin().await.map_err(|e| {
+            QueryFluxError::Persistence(format!("insert_group_config_if_missing begin: {e}"))
+        })?;
+
+        let mut member_ids: Vec<i64> = Vec::with_capacity(cfg.members.len());
+        for m in &cfg.members {
+            let row: Option<(i64,)> =
+                sqlx::query_as("SELECT id FROM cluster_configs WHERE name = $1")
+                    .bind(m)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| {
+                        QueryFluxError::Persistence(format!(
+                            "insert_group_config_if_missing member lookup: {e}"
+                        ))
+                    })?;
+            let Some((cid,)) = row else {
+                return Err(QueryFluxError::Persistence(format!(
+                    "Unknown cluster '{m}' in group members (clusters must exist first)"
+                )));
+            };
+            member_ids.push(cid);
+        }
+
+        for sid in &cfg.translation_script_ids {
+            let row: Option<(String,)> =
+                sqlx::query_as("SELECT kind FROM user_scripts WHERE id = $1")
+                    .bind(sid)
+                    .fetch_optional(&mut *tx)
+                    .await
+                    .map_err(|e| {
+                        QueryFluxError::Persistence(format!(
+                            "insert_group_config_if_missing script lookup: {e}"
+                        ))
+                    })?;
+            let Some((kind,)) = row else {
+                return Err(QueryFluxError::Persistence(format!(
+                    "Unknown translation script id {sid}"
+                )));
+            };
+            if kind != KIND_TRANSLATION_FIXUP {
+                return Err(QueryFluxError::Persistence(format!(
+                    "Script id {sid} has kind '{kind}', expected '{KIND_TRANSLATION_FIXUP}' for group translation"
+                )));
+            }
+        }
+
+        let inserted: Option<(i64,)> = sqlx::query_as(
+            r#"INSERT INTO cluster_group_configs
+                   (name, enabled, members, max_running_queries, max_queued_queries, strategy, allow_groups, allow_users, translation_script_ids, default_tags, cache)
+               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+               ON CONFLICT (name) DO NOTHING
+               RETURNING id"#,
+        )
+        .bind(name)
+        .bind(cfg.enabled)
+        .bind(&member_ids)
+        .bind(cfg.max_running_queries)
+        .bind(cfg.max_queued_queries)
+        .bind(&cfg.strategy)
+        .bind(&cfg.allow_groups)
+        .bind(&cfg.allow_users)
+        .bind(&cfg.translation_script_ids)
+        .bind(&cfg.default_tags)
+        .bind(&cfg.cache)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| {
+            QueryFluxError::Persistence(format!("insert_group_config_if_missing: {e}"))
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            QueryFluxError::Persistence(format!("insert_group_config_if_missing commit: {e}"))
+        })?;
+        Ok(inserted.is_some())
     }
 
     async fn delete_group_config(&self, name: &str) -> Result<bool> {

--- a/crates/queryflux-persistence/src/yaml_seed.rs
+++ b/crates/queryflux-persistence/src/yaml_seed.rs
@@ -1,0 +1,145 @@
+//! Seed Postgres cluster/group rows from YAML only when the name is missing.
+
+use std::collections::{HashMap, HashSet};
+
+use queryflux_core::{
+    config::{ClusterConfig, ClusterGroupConfig},
+    error::{QueryFluxError, Result},
+};
+
+use crate::cluster_config::{UpsertClusterConfig, UpsertClusterGroupConfig};
+use crate::ClusterConfigStore;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct YamlSeedReport {
+    pub seeded: usize,
+    pub existing_before: usize,
+}
+
+pub async fn seed_clusters_from_yaml_if_missing(
+    pg: &dyn ClusterConfigStore,
+    clusters: &HashMap<String, ClusterConfig>,
+) -> Result<YamlSeedReport> {
+    let existing = pg.list_cluster_configs().await?;
+    let existing_before = existing.len();
+    let existing_names: HashSet<&str> = existing.iter().map(|r| r.name.as_str()).collect();
+    let mut seeded = 0usize;
+    for (name, cfg) in clusters {
+        if existing_names.contains(name.as_str()) {
+            continue;
+        }
+        match UpsertClusterConfig::from_core(cfg) {
+            Ok(Some(upsert)) => {
+                pg.upsert_cluster_config(name, &upsert).await?;
+                seeded += 1;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                return Err(QueryFluxError::Persistence(format!(
+                    "cluster '{name}': serializing for YAML seed: {e}"
+                )));
+            }
+        }
+    }
+    Ok(YamlSeedReport {
+        seeded,
+        existing_before,
+    })
+}
+
+pub async fn seed_groups_from_yaml_if_missing(
+    pg: &dyn ClusterConfigStore,
+    groups: &HashMap<String, ClusterGroupConfig>,
+) -> Result<YamlSeedReport> {
+    let existing = pg.list_group_configs().await?;
+    let existing_before = existing.len();
+    let existing_names: HashSet<&str> = existing.iter().map(|r| r.name.as_str()).collect();
+    let mut seeded = 0usize;
+    for (name, cfg) in groups {
+        if existing_names.contains(name.as_str()) {
+            continue;
+        }
+        pg.upsert_group_config(name, &UpsertClusterGroupConfig::from_core(cfg))
+            .await?;
+        seeded += 1;
+    }
+    Ok(YamlSeedReport {
+        seeded,
+        existing_before,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use queryflux_core::config::ClusterConfig;
+
+    use crate::in_memory::InMemoryPersistence;
+    use crate::ClusterConfigStore;
+
+    use super::*;
+
+    fn trino_cluster(endpoint: &str, pool_size: u64) -> ClusterConfig {
+        serde_json::from_value(serde_json::json!({
+            "engine": "trino",
+            "endpoint": endpoint,
+            "poolSize": pool_size,
+        }))
+        .unwrap()
+    }
+
+    fn studio_trino_upsert(pool_size: u64) -> UpsertClusterConfig {
+        UpsertClusterConfig {
+            engine_key: "trino".into(),
+            enabled: true,
+            max_running_queries: None,
+            config: serde_json::json!({
+                "endpoint": "http://studio-trino:8080",
+                "poolSize": pool_size,
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn seeds_missing_cluster_on_empty_store() {
+        let store = InMemoryPersistence::new();
+        let mut yaml = HashMap::new();
+        yaml.insert("trino".into(), trino_cluster("http://yaml-trino:8080", 4));
+
+        let report = seed_clusters_from_yaml_if_missing(&store, &yaml)
+            .await
+            .unwrap();
+        assert_eq!(report.seeded, 1);
+        assert_eq!(report.existing_before, 0);
+
+        let rows = store.list_cluster_configs().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].config.get("poolSize"), Some(&serde_json::json!(4)));
+    }
+
+    #[tokio::test]
+    async fn yaml_seed_skips_existing_cluster_names() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(8))
+            .await
+            .unwrap();
+
+        let mut yaml = HashMap::new();
+        yaml.insert("trino".into(), trino_cluster("http://yaml-trino:8080", 4));
+        yaml.insert(
+            "analytics".into(),
+            trino_cluster("http://analytics:8080", 2),
+        );
+
+        let report = seed_clusters_from_yaml_if_missing(&store, &yaml)
+            .await
+            .unwrap();
+        assert_eq!(report.seeded, 1);
+        assert_eq!(report.existing_before, 1);
+
+        let rows = store.list_cluster_configs().await.unwrap();
+        assert_eq!(rows.len(), 2);
+        let trino = rows.iter().find(|r| r.name == "trino").unwrap();
+        assert_eq!(trino.config.get("poolSize"), Some(&serde_json::json!(8)));
+    }
+}

--- a/crates/queryflux-persistence/src/yaml_seed.rs
+++ b/crates/queryflux-persistence/src/yaml_seed.rs
@@ -252,4 +252,34 @@ mod tests {
         let row = store.get_group_config("default").await.unwrap().unwrap();
         assert_eq!(row.max_running_queries, 20);
     }
+
+    #[tokio::test]
+    async fn insert_group_config_if_missing_skips_stale_yaml_when_group_exists() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(4))
+            .await
+            .unwrap();
+        store
+            .upsert_group_config("default", &studio_group_upsert(20))
+            .await
+            .unwrap();
+
+        let stale_yaml = UpsertClusterGroupConfig {
+            enabled: true,
+            members: vec!["removed-cluster".into()],
+            max_running_queries: 10,
+            max_queued_queries: None,
+            strategy: None,
+            allow_groups: vec![],
+            allow_users: vec![],
+            translation_script_ids: vec![],
+            default_tags: serde_json::json!({}),
+            cache: None,
+        };
+        assert!(!store
+            .insert_group_config_if_missing("default", &stale_yaml)
+            .await
+            .unwrap());
+    }
 }

--- a/crates/queryflux-persistence/src/yaml_seed.rs
+++ b/crates/queryflux-persistence/src/yaml_seed.rs
@@ -65,8 +65,9 @@ pub async fn seed_groups_from_yaml_if_missing(
 
 #[cfg(test)]
 mod tests {
-    use queryflux_core::config::ClusterConfig;
+    use queryflux_core::config::{ClusterConfig, ClusterGroupConfig};
 
+    use crate::cluster_config::UpsertClusterGroupConfig;
     use crate::in_memory::InMemoryPersistence;
     use crate::ClusterConfigStore;
 
@@ -90,6 +91,29 @@ mod tests {
                 "endpoint": "http://studio-trino:8080",
                 "poolSize": pool_size,
             }),
+        }
+    }
+
+    fn yaml_group(max_running: u64, members: &[&str]) -> ClusterGroupConfig {
+        serde_json::from_value(serde_json::json!({
+            "members": members,
+            "maxRunningQueries": max_running,
+        }))
+        .unwrap()
+    }
+
+    fn studio_group_upsert(max_running: i64) -> UpsertClusterGroupConfig {
+        UpsertClusterGroupConfig {
+            enabled: true,
+            members: vec!["trino".into()],
+            max_running_queries: max_running,
+            max_queued_queries: None,
+            strategy: None,
+            allow_groups: vec![],
+            allow_users: vec![],
+            translation_script_ids: vec![],
+            default_tags: serde_json::json!({}),
+            cache: None,
         }
     }
 
@@ -155,5 +179,77 @@ mod tests {
 
         let row = store.get_cluster_config("trino").await.unwrap().unwrap();
         assert_eq!(row.config.get("poolSize"), Some(&serde_json::json!(8)));
+    }
+
+    #[tokio::test]
+    async fn seeds_missing_group_on_empty_store() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(4))
+            .await
+            .unwrap();
+
+        let mut yaml = HashMap::new();
+        yaml.insert("default".into(), yaml_group(10, &["trino"]));
+
+        let report = seed_groups_from_yaml_if_missing(&store, &yaml)
+            .await
+            .unwrap();
+        assert_eq!(report.seeded, 1);
+        assert_eq!(report.existing_before, 0);
+
+        let rows = store.list_group_configs().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].max_running_queries, 10);
+    }
+
+    #[tokio::test]
+    async fn yaml_seed_skips_existing_group_names() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(4))
+            .await
+            .unwrap();
+        store
+            .upsert_group_config("default", &studio_group_upsert(20))
+            .await
+            .unwrap();
+
+        let mut yaml = HashMap::new();
+        yaml.insert("default".into(), yaml_group(10, &["trino"]));
+        yaml.insert("analytics".into(), yaml_group(5, &["trino"]));
+
+        let report = seed_groups_from_yaml_if_missing(&store, &yaml)
+            .await
+            .unwrap();
+        assert_eq!(report.seeded, 1);
+        assert_eq!(report.existing_before, 1);
+
+        let rows = store.list_group_configs().await.unwrap();
+        assert_eq!(rows.len(), 2);
+        let default = rows.iter().find(|r| r.name == "default").unwrap();
+        assert_eq!(default.max_running_queries, 20);
+    }
+
+    #[tokio::test]
+    async fn insert_group_config_if_missing_does_not_overwrite() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(4))
+            .await
+            .unwrap();
+        store
+            .upsert_group_config("default", &studio_group_upsert(20))
+            .await
+            .unwrap();
+
+        let yaml_upsert = UpsertClusterGroupConfig::from_core(&yaml_group(10, &["trino"]));
+        assert!(!store
+            .insert_group_config_if_missing("default", &yaml_upsert)
+            .await
+            .unwrap());
+
+        let row = store.get_group_config("default").await.unwrap().unwrap();
+        assert_eq!(row.max_running_queries, 20);
     }
 }

--- a/crates/queryflux-persistence/src/yaml_seed.rs
+++ b/crates/queryflux-persistence/src/yaml_seed.rs
@@ -1,6 +1,6 @@
 //! Seed Postgres cluster/group rows from YAML only when the name is missing.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use queryflux_core::{
     config::{ClusterConfig, ClusterGroupConfig},
@@ -20,18 +20,14 @@ pub async fn seed_clusters_from_yaml_if_missing(
     pg: &dyn ClusterConfigStore,
     clusters: &HashMap<String, ClusterConfig>,
 ) -> Result<YamlSeedReport> {
-    let existing = pg.list_cluster_configs().await?;
-    let existing_before = existing.len();
-    let existing_names: HashSet<&str> = existing.iter().map(|r| r.name.as_str()).collect();
+    let existing_before = pg.list_cluster_configs().await?.len();
     let mut seeded = 0usize;
     for (name, cfg) in clusters {
-        if existing_names.contains(name.as_str()) {
-            continue;
-        }
         match UpsertClusterConfig::from_core(cfg) {
             Ok(Some(upsert)) => {
-                pg.upsert_cluster_config(name, &upsert).await?;
-                seeded += 1;
+                if pg.insert_cluster_config_if_missing(name, &upsert).await? {
+                    seeded += 1;
+                }
             }
             Ok(None) => {}
             Err(e) => {
@@ -51,17 +47,15 @@ pub async fn seed_groups_from_yaml_if_missing(
     pg: &dyn ClusterConfigStore,
     groups: &HashMap<String, ClusterGroupConfig>,
 ) -> Result<YamlSeedReport> {
-    let existing = pg.list_group_configs().await?;
-    let existing_before = existing.len();
-    let existing_names: HashSet<&str> = existing.iter().map(|r| r.name.as_str()).collect();
+    let existing_before = pg.list_group_configs().await?.len();
     let mut seeded = 0usize;
     for (name, cfg) in groups {
-        if existing_names.contains(name.as_str()) {
-            continue;
+        if pg
+            .insert_group_config_if_missing(name, &UpsertClusterGroupConfig::from_core(cfg))
+            .await?
+        {
+            seeded += 1;
         }
-        pg.upsert_group_config(name, &UpsertClusterGroupConfig::from_core(cfg))
-            .await?;
-        seeded += 1;
     }
     Ok(YamlSeedReport {
         seeded,
@@ -141,5 +135,25 @@ mod tests {
         assert_eq!(rows.len(), 2);
         let trino = rows.iter().find(|r| r.name == "trino").unwrap();
         assert_eq!(trino.config.get("poolSize"), Some(&serde_json::json!(8)));
+    }
+
+    #[tokio::test]
+    async fn insert_cluster_config_if_missing_does_not_overwrite() {
+        let store = InMemoryPersistence::new();
+        store
+            .upsert_cluster_config("trino", &studio_trino_upsert(8))
+            .await
+            .unwrap();
+
+        let yaml_upsert = UpsertClusterConfig::from_core(&trino_cluster("http://yaml:8080", 4))
+            .unwrap()
+            .unwrap();
+        assert!(!store
+            .insert_cluster_config_if_missing("trino", &yaml_upsert)
+            .await
+            .unwrap());
+
+        let row = store.get_cluster_config("trino").await.unwrap().unwrap();
+        assert_eq!(row.config.get("poolSize"), Some(&serde_json::json!(8)));
     }
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -34,7 +34,6 @@ use queryflux_metrics::{
     buffered_store::BufferedMetricsStore, prometheus_store::PrometheusMetrics, MetricsStore,
     MultiMetricsStore,
 };
-use queryflux_persistence::cluster_config::{UpsertClusterConfig, UpsertClusterGroupConfig};
 use queryflux_persistence::{
     in_memory::InMemoryPersistence, postgres::PostgresStore, AdminStore, BackendStore,
     DistributedBackendStore, KIND_GUARD,
@@ -218,63 +217,39 @@ async fn main() -> Result<()> {
     // from YAML. Omit those maps (or leave them empty) for Studio-only setups.
     if let Some(pg) = &backend {
         if !config.clusters.is_empty() {
-            let existing = pg
-                .list_cluster_configs()
-                .await
-                .context("List cluster configs before YAML seed")?;
-            let existing_names: std::collections::HashSet<&str> =
-                existing.iter().map(|r| r.name.as_str()).collect();
-            let mut seeded = 0usize;
-            for (name, cfg) in &config.clusters {
-                if existing_names.contains(name.as_str()) {
-                    continue;
-                }
-                match UpsertClusterConfig::from_core(cfg) {
-                    Ok(Some(upsert)) => {
-                        pg.upsert_cluster_config(name, &upsert)
-                            .await
-                            .with_context(|| format!("Seed cluster '{name}' from YAML"))?;
-                        seeded += 1;
-                    }
-                    Ok(None) => {}
-                    Err(e) => {
-                        return Err(anyhow::Error::from(e).context(format!(
-                            "cluster '{name}': serializing queryAuth for Postgres seed"
-                        )));
-                    }
-                }
-            }
-            if seeded > 0 {
-                info!("Seeded {seeded} cluster definition(s) from YAML into Postgres");
-            } else if !existing_names.is_empty() {
+            let report = queryflux_persistence::yaml_seed::seed_clusters_from_yaml_if_missing(
+                pg.as_ref(),
+                &config.clusters,
+            )
+            .await
+            .context("Seed clusters from YAML")?;
+            if report.seeded > 0 {
                 info!(
-                    existing = existing_names.len(),
+                    "Seeded {} cluster definition(s) from YAML into Postgres",
+                    report.seeded
+                );
+            } else if report.existing_before > 0 {
+                info!(
+                    existing = report.existing_before,
                     "Skipping YAML cluster upsert — Postgres already has these cluster names"
                 );
             }
         }
         if !config.cluster_groups.is_empty() {
-            let existing = pg
-                .list_group_configs()
-                .await
-                .context("List group configs before YAML seed")?;
-            let existing_names: std::collections::HashSet<&str> =
-                existing.iter().map(|r| r.name.as_str()).collect();
-            let mut seeded = 0usize;
-            for (name, cfg) in &config.cluster_groups {
-                if existing_names.contains(name.as_str()) {
-                    continue;
-                }
-                pg.upsert_group_config(name, &UpsertClusterGroupConfig::from_core(cfg))
-                    .await
-                    .with_context(|| format!("Seed group '{name}' from YAML"))?;
-                seeded += 1;
-            }
-            if seeded > 0 {
-                info!("Seeded {seeded} cluster group definition(s) from YAML into Postgres");
-            } else if !existing_names.is_empty() {
+            let report = queryflux_persistence::yaml_seed::seed_groups_from_yaml_if_missing(
+                pg.as_ref(),
+                &config.cluster_groups,
+            )
+            .await
+            .context("Seed cluster groups from YAML")?;
+            if report.seeded > 0 {
                 info!(
-                    existing = existing_names.len(),
+                    "Seeded {} cluster group definition(s) from YAML into Postgres",
+                    report.seeded
+                );
+            } else if report.existing_before > 0 {
+                info!(
+                    existing = report.existing_before,
                     "Skipping YAML group upsert — Postgres already has these group names"
                 );
             }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -212,20 +212,29 @@ async fn main() -> Result<()> {
     > = None;
 
     // --- When Postgres is active, load cluster/group config from DB ---
-    // Merge YAML-defined clusters and groups into Postgres on **every** startup when the
-    // file declares them (`clusters` / `clusterGroups` non-empty). This keeps Docker/Compose
-    // configs authoritative even if the volume already had older rows (e.g. switched engine).
-    // **Studio-first** setups omit those maps (or leave them empty) — then nothing is written
-    // here and the DB remains the source of truth for those resources.
+    // Seed YAML `clusters` / `clusterGroups` only for names that are not already in
+    // Postgres. Existing DB rows (Studio/admin edits) win and are never overwritten
+    // by a ConfigMap/Helm values restart. First boot with an empty DB still seeds
+    // from YAML. Omit those maps (or leave them empty) for Studio-only setups.
     if let Some(pg) = &backend {
         if !config.clusters.is_empty() {
-            info!("Applying cluster definitions from YAML to Postgres");
+            let existing = pg
+                .list_cluster_configs()
+                .await
+                .context("List cluster configs before YAML seed")?;
+            let existing_names: std::collections::HashSet<&str> =
+                existing.iter().map(|r| r.name.as_str()).collect();
+            let mut seeded = 0usize;
             for (name, cfg) in &config.clusters {
+                if existing_names.contains(name.as_str()) {
+                    continue;
+                }
                 match UpsertClusterConfig::from_core(cfg) {
                     Ok(Some(upsert)) => {
                         pg.upsert_cluster_config(name, &upsert)
                             .await
-                            .with_context(|| format!("Upsert cluster '{name}' from YAML"))?;
+                            .with_context(|| format!("Seed cluster '{name}' from YAML"))?;
+                        seeded += 1;
                     }
                     Ok(None) => {}
                     Err(e) => {
@@ -235,17 +244,43 @@ async fn main() -> Result<()> {
                     }
                 }
             }
+            if seeded > 0 {
+                info!("Seeded {seeded} cluster definition(s) from YAML into Postgres");
+            } else if !existing_names.is_empty() {
+                info!(
+                    existing = existing_names.len(),
+                    "Skipping YAML cluster upsert — Postgres already has these cluster names"
+                );
+            }
         }
         if !config.cluster_groups.is_empty() {
-            info!("Applying cluster group definitions from YAML to Postgres");
+            let existing = pg
+                .list_group_configs()
+                .await
+                .context("List group configs before YAML seed")?;
+            let existing_names: std::collections::HashSet<&str> =
+                existing.iter().map(|r| r.name.as_str()).collect();
+            let mut seeded = 0usize;
             for (name, cfg) in &config.cluster_groups {
+                if existing_names.contains(name.as_str()) {
+                    continue;
+                }
                 pg.upsert_group_config(name, &UpsertClusterGroupConfig::from_core(cfg))
                     .await
-                    .with_context(|| format!("Upsert group '{name}' from YAML"))?;
+                    .with_context(|| format!("Seed group '{name}' from YAML"))?;
+                seeded += 1;
+            }
+            if seeded > 0 {
+                info!("Seeded {seeded} cluster group definition(s) from YAML into Postgres");
+            } else if !existing_names.is_empty() {
+                info!(
+                    existing = existing_names.len(),
+                    "Skipping YAML group upsert — Postgres already has these group names"
+                );
             }
         }
 
-        // Effective config comes from Postgres (YAML above only upserts keys that appear in the file).
+        // Effective config comes from Postgres (YAML above only seeds missing names).
         info!("Loading cluster and group configs from Postgres");
         let db_cluster_records = pg
             .list_cluster_configs()


### PR DESCRIPTION
## Summary
- Startup previously `upsert`ed every YAML cluster/group into Postgres on each restart, wiping Studio edits.
- YAML now seeds **only missing names**; existing DB rows win (same spirit as security_config).
- Empty DB / first boot still seeds from YAML.

## Test plan
- [x] Clippy `-D warnings` for `queryflux`
- [x] Start with Postgres + YAML clusters, edit a cluster in Studio, restart, confirm Studio edit survives (`yaml_seed_skips_existing_cluster_names`)
- [x] Fresh empty Postgres + YAML clusters still seeds on first boot (`seeds_missing_cluster_on_empty_store`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic startup seeding of missing PostgreSQL cluster and group configurations from YAML.
  - Existing database configurations are preserved and never overwritten.
  - Startup reports how many configurations were seeded and how many already existed.
  - Empty configuration stores are safely populated from available YAML entries.

- **Bug Fixes**
  - Prevented duplicate configuration records during seeding.
  - Improved handling of invalid references, translation scripts, storage failures, and YAML serialization errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->