### PR TITLE
fix: stream StarRocks/MySQL-native results (P1-17)

### DIFF
--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -14,7 +14,6 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
-use futures::stream;
 use mysql_async::{consts::ColumnType, prelude::Queryable, Pool, Row, Value};
 use queryflux_auth::QueryCredentials;
 use queryflux_core::{
@@ -24,6 +23,7 @@ use queryflux_core::{
     session::SessionContext,
     tags::{tags_to_json, QueryTags},
 };
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{BackendQueryIdSlot, NativeExecution};
 
@@ -100,14 +100,8 @@ impl InflightConnGuard {
 /// Execute `sql` against `pool` and return a stream of `NativeResultChunk`s.
 ///
 /// The connection is acquired, session is set up (USE database, @query_tag), the query
-/// is executed, and rows are batched into `NativeResultChunk`s of up to `BATCH_SIZE` rows.
-/// The first chunk carries column metadata; subsequent chunks carry rows only.
-///
-/// # Streaming note
-/// This implementation collects all rows into memory before yielding chunks — the same
-/// behaviour as the current Arrow path. The in-memory constraint is removed in a follow-up
-/// by switching to `query_iter` + a spawned task, which requires working around
-/// `mysql_async::QueryResult`'s borrow-based lifetime constraints.
+/// is executed via `query_iter`/`exec_iter`, and rows are batched into chunks of up to
+/// `BATCH_SIZE` without materializing the full result set in memory first.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute(
     pool: &Pool,
@@ -125,20 +119,39 @@ pub async fn execute(
         .map_err(|e| QueryFluxError::Engine(format!("mysql_native: connection failed: {e}")))?;
     let conn_id = conn.id();
     id_slot.publish(conn_id.to_string());
-    let mut claim = inflight.claim(conn_id);
 
-    let result = execute_on_conn(&mut conn, sql, session, tags, params).await;
-    claim.finish();
-    result
+    let (chunk_tx, chunk_rx) = tokio::sync::mpsc::channel::<Result<NativeResultChunk>>(32);
+    let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
+    let inflight = inflight.clone();
+    let sql = sql.to_string();
+    let session = session.clone();
+    let tags = tags.clone();
+    let params = params.to_vec();
+
+    tokio::spawn(async move {
+        let mut claim = inflight.claim(conn_id);
+        if let Err(e) = stream_on_conn(&mut conn, &sql, &session, &tags, &params, &chunk_tx).await {
+            let _ = chunk_tx.send(Err(e)).await;
+        }
+        claim.finish();
+        drop(conn);
+        let _ = stats_tx.send(None);
+    });
+
+    Ok(NativeExecution {
+        stream: Box::pin(ReceiverStream::new(chunk_rx)),
+        stats: stats_rx,
+    })
 }
 
-async fn execute_on_conn(
+async fn stream_on_conn(
     conn: &mut mysql_async::Conn,
     sql: &str,
     session: &SessionContext,
     tags: &QueryTags,
     params: &QueryParams,
-) -> Result<NativeExecution> {
+    chunk_tx: &tokio::sync::mpsc::Sender<Result<NativeResultChunk>>,
+) -> Result<()> {
     if let Some(db) = session.database() {
         let use_sql = format!("USE `{}`", db.replace('`', "``"));
         conn.query_drop(&use_sql)
@@ -155,31 +168,19 @@ async fn execute_on_conn(
         })?;
     }
 
-    let rows: Vec<Row> = if params.is_empty() {
-        conn.query::<Row, _>(sql)
-            .await
-            .map_err(|e| QueryFluxError::Engine(format!("mysql_native: query failed: {e}")))?
+    let mysql_params = if params.is_empty() {
+        mysql_async::Params::Empty
     } else {
-        let mysql_params = mysql_async::Params::Positional(
+        mysql_async::Params::Positional(
             params.iter().map(query_param_to_mysql_value).collect(),
-        );
-        conn.exec::<Row, _, _>(sql, mysql_params)
-            .await
-            .map_err(|e| QueryFluxError::Engine(format!("mysql_native: exec failed: {e}")))?
+        )
     };
+    let mut query_result = conn
+        .exec_iter(sql, mysql_params)
+        .await
+        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: exec failed: {e}")))?;
 
-    let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
-
-    if rows.is_empty() {
-        let _ = stats_tx.send(None);
-        return Ok(NativeExecution {
-            stream: Box::pin(stream::empty()),
-            stats: stats_rx,
-        });
-    }
-
-    // Build column metadata from the first row's column descriptors.
-    let columns: Vec<NativeColumn> = rows[0]
+    let columns: Vec<NativeColumn> = query_result
         .columns_ref()
         .iter()
         .map(|c| NativeColumn {
@@ -188,32 +189,50 @@ async fn execute_on_conn(
             nullable: true,
         })
         .collect();
+    let num_cols = columns.len();
 
-    let num_cols = rows[0].len();
+    let mut batch: Vec<NativeRow> = Vec::with_capacity(BATCH_SIZE);
+    let mut first_chunk = true;
 
-    // Convert all rows to NativeRows first, then batch them.
-    let native_rows: Vec<NativeRow> = rows
-        .into_iter()
-        .map(|row| row_to_native(row, num_cols))
-        .collect();
+    while let Some(row) = query_result
+        .next()
+        .await
+        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: read row failed: {e}")))?
+    {
+        batch.push(row_to_native(row, num_cols));
+        if batch.len() >= BATCH_SIZE {
+            let chunk = NativeResultChunk {
+                columns: if first_chunk {
+                    Some(columns.clone())
+                } else {
+                    None
+                },
+                rows: std::mem::take(&mut batch),
+            };
+            first_chunk = false;
+            if chunk_tx.send(Ok(chunk)).await.is_err() {
+                query_result.drop_result().await.ok();
+                return Ok(());
+            }
+        }
+    }
 
-    // Produce NativeResultChunks: columns present only on the first chunk.
-    let chunks: Vec<Result<NativeResultChunk>> = native_rows
-        .chunks(BATCH_SIZE)
-        .enumerate()
-        .map(|(i, batch)| {
-            Ok(NativeResultChunk {
-                columns: if i == 0 { Some(columns.clone()) } else { None },
-                rows: batch.to_vec(),
-            })
-        })
-        .collect();
+    if !batch.is_empty() || first_chunk {
+        let chunk = NativeResultChunk {
+            columns: if first_chunk { Some(columns) } else { None },
+            rows: batch,
+        };
+        if chunk_tx.send(Ok(chunk)).await.is_err() {
+            query_result.drop_result().await.ok();
+            return Ok(());
+        }
+    }
 
-    let _ = stats_tx.send(None);
-    Ok(NativeExecution {
-        stream: Box::pin(stream::iter(chunks)),
-        stats: stats_rx,
-    })
+    query_result
+        .drop_result()
+        .await
+        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: drop_result failed: {e}")))?;
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -416,6 +435,16 @@ mod tests {
     #[test]
     fn null_maps_to_null() {
         assert_eq!(query_param_to_mysql_value(&QueryParam::Null), Value::NULL);
+    }
+
+    #[test]
+    fn batch_rows_splits_into_chunks() {
+        let rows: Vec<u32> = (0..2500).collect();
+        let batches: Vec<_> = rows.chunks(BATCH_SIZE).collect();
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0].len(), BATCH_SIZE);
+        assert_eq!(batches[1].len(), BATCH_SIZE);
+        assert_eq!(batches[2].len(), 500);
     }
 
     // ── value_to_bytes ────────────────────────────────────────────────────────

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -171,9 +171,7 @@ async fn stream_on_conn(
     let mysql_params = if params.is_empty() {
         mysql_async::Params::Empty
     } else {
-        mysql_async::Params::Positional(
-            params.iter().map(query_param_to_mysql_value).collect(),
-        )
+        mysql_async::Params::Positional(params.iter().map(query_param_to_mysql_value).collect())
     };
     let mut query_result = conn
         .exec_iter(sql, mysql_params)

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -168,16 +168,29 @@ async fn stream_on_conn(
         })?;
     }
 
-    let mysql_params = if params.is_empty() {
-        mysql_async::Params::Empty
+    if params.is_empty() {
+        // Text protocol — required for SHOW/DDL that StarRocks rejects via prepared statements.
+        let query_result = conn
+            .query_iter(sql)
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("mysql_native: query failed: {e}")))?;
+        stream_mysql_query_result(query_result, chunk_tx).await
     } else {
-        mysql_async::Params::Positional(params.iter().map(query_param_to_mysql_value).collect())
-    };
-    let mut query_result = conn
-        .exec_iter(sql, mysql_params)
-        .await
-        .map_err(|e| QueryFluxError::Engine(format!("mysql_native: exec failed: {e}")))?;
+        let mysql_params = mysql_async::Params::Positional(
+            params.iter().map(query_param_to_mysql_value).collect(),
+        );
+        let query_result = conn
+            .exec_iter(sql, mysql_params)
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("mysql_native: exec failed: {e}")))?;
+        stream_mysql_query_result(query_result, chunk_tx).await
+    }
+}
 
+async fn stream_mysql_query_result<P: mysql_async::prelude::Protocol>(
+    mut query_result: mysql_async::QueryResult<'_, '_, P>,
+    chunk_tx: &tokio::sync::mpsc::Sender<Result<NativeResultChunk>>,
+) -> Result<()> {
     let columns: Vec<NativeColumn> = query_result
         .columns_ref()
         .iter()

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -274,9 +274,7 @@ impl StarRocksAdapter {
         let mysql_params = if params.is_empty() {
             mysql_async::Params::Empty
         } else {
-            mysql_async::Params::Positional(
-                params.iter().map(query_param_to_mysql_value).collect(),
-            )
+            mysql_async::Params::Positional(params.iter().map(query_param_to_mysql_value).collect())
         };
         let mut query_result = conn
             .exec_iter(sql, mysql_params)

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -8,7 +8,6 @@ use arrow::array::{
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
-use futures::stream;
 use mysql_async::{
     consts::ColumnType, prelude::Queryable, Conn, Opts, OptsBuilder, Pool, PoolConstraints,
     PoolOpts, Row, Value,
@@ -21,6 +20,7 @@ use queryflux_core::{
     session::SessionContext,
     tags::{tags_to_json, QueryTags},
 };
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{AdapterKind, BackendQueryIdSlot, SyncAdapter, SyncExecution};
 use queryflux_core::engine_registry::{
@@ -245,14 +245,16 @@ impl StarRocksAdapter {
             .collect())
     }
 
-    async fn execute_as_arrow_on_conn(
-        &self,
+    async fn stream_arrow_on_conn(
         conn: &mut Conn,
         sql: &str,
         session: &SessionContext,
         tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
-    ) -> Result<SyncExecution> {
+        batch_tx: &tokio::sync::mpsc::Sender<Result<RecordBatch>>,
+    ) -> Result<()> {
+        const BATCH_SIZE: usize = 1_000;
+
         if let Some(db) = session.database() {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
             conn.query_drop(&use_sql)
@@ -260,11 +262,8 @@ impl StarRocksAdapter {
                 .map_err(|e| QueryFluxError::Engine(format!("StarRocks USE failed: {e}")))?;
         }
 
-        // Set query tag as a session variable so StarRocks surfaces it in audit logs.
         if !tags.is_empty() {
             let tag_json = tags_to_json(tags).to_string();
-            // Use the driver's Value escaping so all MySQL string-literal special
-            // characters (\0, \n, \r, \\, ', ") are handled correctly.
             let escaped = Value::from(tag_json).as_sql(false);
             let set_sql = format!("SET @query_tag = {escaped}");
             conn.query_drop(&set_sql).await.map_err(|e| {
@@ -272,33 +271,19 @@ impl StarRocksAdapter {
             })?;
         }
 
-        let mut rows: Vec<Row> = if params.is_empty() {
-            conn.query::<Row, _>(sql)
-                .await
-                .map_err(|e| QueryFluxError::Engine(format!("StarRocks query failed: {e}")))?
+        let mysql_params = if params.is_empty() {
+            mysql_async::Params::Empty
         } else {
-            let mysql_params = mysql_async::Params::Positional(
+            mysql_async::Params::Positional(
                 params.iter().map(query_param_to_mysql_value).collect(),
-            );
-            conn.exec::<Row, _, _>(sql, mysql_params)
-                .await
-                .map_err(|e| QueryFluxError::Engine(format!("StarRocks exec failed: {e}")))?
+            )
         };
+        let mut query_result = conn
+            .exec_iter(sql, mysql_params)
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("StarRocks exec failed: {e}")))?;
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        if rows.is_empty() {
-            // StarRocks does not expose structured execution stats (CPU, bytes, etc.)
-            // via the MySQL protocol — send None and establish the pattern for future use.
-            let _ = tx.send(None);
-            return Ok(SyncExecution {
-                stream: Box::pin(stream::empty()),
-                stats: rx,
-            });
-        }
-
-        // Build Arrow schema from first row's column metadata.
-        let fields: Vec<Field> = rows[0]
+        let fields: Vec<Field> = query_result
             .columns_ref()
             .iter()
             .map(|c| {
@@ -309,26 +294,46 @@ impl StarRocksAdapter {
                 )
             })
             .collect();
-        let schema = Arc::new(ArrowSchema::new(fields));
 
-        // Build columns from rows.
-        let num_cols = schema.fields().len();
-        let mut columns: Vec<ArrayRef> = Vec::with_capacity(num_cols);
-
-        for col_idx in 0..num_cols {
-            let dt = schema.field(col_idx).data_type();
-            let col = starrocks_build_column(dt, &mut rows, col_idx)?;
-            columns.push(col);
+        if fields.is_empty() {
+            return Ok(());
         }
 
-        let batch = RecordBatch::try_new(schema, columns)
-            .map_err(|e| QueryFluxError::Engine(format!("StarRocks RecordBatch failed: {e}")))?;
+        let schema = Arc::new(ArrowSchema::new(fields));
+        let num_cols = schema.fields().len();
+        let mut batch_rows: Vec<Row> = Vec::with_capacity(BATCH_SIZE);
+        let mut sent_any = false;
 
-        let _ = tx.send(None);
-        Ok(SyncExecution {
-            stream: Box::pin(stream::iter(std::iter::once(Ok(batch)))),
-            stats: rx,
-        })
+        while let Some(row) = query_result
+            .next()
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("StarRocks read row failed: {e}")))?
+        {
+            batch_rows.push(row);
+            if batch_rows.len() >= BATCH_SIZE {
+                let batch = starrocks_rows_to_batch(&schema, &mut batch_rows, num_cols)?;
+                batch_rows.clear();
+                sent_any = true;
+                if batch_tx.send(Ok(batch)).await.is_err() {
+                    query_result.drop_result().await.ok();
+                    return Ok(());
+                }
+            }
+        }
+
+        if !batch_rows.is_empty() {
+            let batch = starrocks_rows_to_batch(&schema, &mut batch_rows, num_cols)?;
+            let _ = batch_tx.send(Ok(batch)).await;
+        } else if !sent_any {
+            let batch = RecordBatch::new_empty(Arc::clone(&schema));
+            let _ = batch_tx.send(Ok(batch)).await;
+        }
+
+        query_result
+            .drop_result()
+            .await
+            .map_err(|e| QueryFluxError::Engine(format!("StarRocks drop_result failed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -471,12 +476,33 @@ impl SyncAdapter for StarRocksAdapter {
         let mut conn = self.acquire_conn().await?;
         let conn_id = conn.id();
         id_slot.publish(conn_id.to_string());
-        let mut claim = self.inflight.claim(conn_id);
-        let result = self
-            .execute_as_arrow_on_conn(&mut conn, sql, session, tags, params)
-            .await;
-        claim.finish();
-        result
+
+        let (batch_tx, batch_rx) = tokio::sync::mpsc::channel::<Result<RecordBatch>>(32);
+        let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
+        let inflight = self.inflight.clone();
+        let sql = sql.to_string();
+        let session = session.clone();
+        let tags = tags.clone();
+        let params = params.to_vec();
+
+        tokio::spawn(async move {
+            let mut claim = inflight.claim(conn_id);
+            if let Err(e) = StarRocksAdapter::stream_arrow_on_conn(
+                &mut conn, &sql, &session, &tags, &params, &batch_tx,
+            )
+            .await
+            {
+                let _ = batch_tx.send(Err(e)).await;
+            }
+            claim.finish();
+            drop(conn);
+            let _ = stats_tx.send(None);
+        });
+
+        Ok(SyncExecution {
+            stream: Box::pin(ReceiverStream::new(batch_rx)),
+            stats: stats_rx,
+        })
     }
 
     // --- Catalog discovery ---
@@ -613,6 +639,20 @@ fn mysql_column_type_to_arrow(ct: ColumnType) -> DataType {
         ColumnType::MYSQL_TYPE_BIT => DataType::Boolean,
         _ => DataType::Utf8,
     }
+}
+
+fn starrocks_rows_to_batch(
+    schema: &Arc<ArrowSchema>,
+    rows: &mut [Row],
+    num_cols: usize,
+) -> Result<RecordBatch> {
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(num_cols);
+    for col_idx in 0..num_cols {
+        let dt = schema.field(col_idx).data_type();
+        columns.push(starrocks_build_column(dt, rows, col_idx)?);
+    }
+    RecordBatch::try_new(Arc::clone(schema), columns)
+        .map_err(|e| QueryFluxError::Engine(format!("StarRocks RecordBatch failed: {e}")))
 }
 
 fn starrocks_build_column(dt: &DataType, rows: &mut [Row], col_idx: usize) -> Result<ArrayRef> {

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -253,8 +253,6 @@ impl StarRocksAdapter {
         params: &queryflux_core::params::QueryParams,
         batch_tx: &tokio::sync::mpsc::Sender<Result<RecordBatch>>,
     ) -> Result<()> {
-        const BATCH_SIZE: usize = 1_000;
-
         if let Some(db) = session.database() {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
             conn.query_drop(&use_sql)
@@ -271,15 +269,30 @@ impl StarRocksAdapter {
             })?;
         }
 
-        let mysql_params = if params.is_empty() {
-            mysql_async::Params::Empty
+        if params.is_empty() {
+            // Text protocol — required for SHOW/DDL that StarRocks rejects via prepared statements.
+            let query_result = conn
+                .query_iter(sql)
+                .await
+                .map_err(|e| QueryFluxError::Engine(format!("StarRocks query failed: {e}")))?;
+            Self::stream_arrow_from_query_result(query_result, batch_tx).await
         } else {
-            mysql_async::Params::Positional(params.iter().map(query_param_to_mysql_value).collect())
-        };
-        let mut query_result = conn
-            .exec_iter(sql, mysql_params)
-            .await
-            .map_err(|e| QueryFluxError::Engine(format!("StarRocks exec failed: {e}")))?;
+            let mysql_params = mysql_async::Params::Positional(
+                params.iter().map(query_param_to_mysql_value).collect(),
+            );
+            let query_result = conn
+                .exec_iter(sql, mysql_params)
+                .await
+                .map_err(|e| QueryFluxError::Engine(format!("StarRocks exec failed: {e}")))?;
+            Self::stream_arrow_from_query_result(query_result, batch_tx).await
+        }
+    }
+
+    async fn stream_arrow_from_query_result<P: mysql_async::prelude::Protocol>(
+        mut query_result: mysql_async::QueryResult<'_, '_, P>,
+        batch_tx: &tokio::sync::mpsc::Sender<Result<RecordBatch>>,
+    ) -> Result<()> {
+        const BATCH_SIZE: usize = 1_000;
 
         let fields: Vec<Field> = query_result
             .columns_ref()


### PR DESCRIPTION
## Summary
- Refactor `mysql_native::execute` to spawn a task using `exec_iter` and stream `NativeResultChunk`s over `mpsc`.
- Refactor StarRocks Arrow path similarly (1000-row batches, zero-row schema batch when empty).
- Move inflight guard completion into the producer task for mid-stream cancel safety.

## Test plan
- [x] `cargo test -p queryflux-engine-adapters mysql_native::tests`
- [x] `cargo clippy -p queryflux-engine-adapters --all-targets -- -D warnings`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query results from MySQL and StarRocks are now delivered incrementally in batches.
  * Large query results can be processed with reduced memory usage.
  * Empty results include schema metadata for consistent handling.

* **Bug Fixes**
  * Improved cleanup when result processing completes, encounters an error, or the consumer disconnects.
  * Query and conversion errors are now surfaced through the result stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->