### PR TITLE
fix: cancel in-flight Snowflake HTTP and SQL API queries (P2-39)

### DIFF
--- a/crates/queryflux-e2e-tests/src/snowflake_wire_client.rs
+++ b/crates/queryflux-e2e-tests/src/snowflake_wire_client.rs
@@ -166,6 +166,50 @@ impl SnowflakeWireClient {
         })
     }
 
+    /// DELETE /queries/v1/:query_id — cancel an in-flight query.
+    pub async fn cancel(&self, query_id: &str) -> Result<u16> {
+        let token = self.token()?;
+        let resp = self
+            .client
+            .delete(format!("{}/queries/v1/{query_id}", self.base_url))
+            .header("Authorization", format!("Snowflake Token=\"{token}\""))
+            .send()
+            .await?;
+        Ok(resp.status().as_u16())
+    }
+
+    /// GET /queries/v1/query-monitoring-request — list in-flight query ids.
+    pub async fn monitoring_query_ids(&self) -> Result<Vec<String>> {
+        let token = self.token()?;
+        let resp = self
+            .client
+            .get(format!(
+                "{}/queries/v1/query-monitoring-request",
+                self.base_url
+            ))
+            .header("Authorization", format!("Snowflake Token=\"{token}\""))
+            .send()
+            .await?
+            .json::<Value>()
+            .await?;
+
+        if resp["success"].as_bool() != Some(true) {
+            bail!(
+                "monitoring failed: {}",
+                resp["message"].as_str().unwrap_or("unknown")
+            );
+        }
+
+        Ok(resp["data"]["queries"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|q| q["id"].as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
     /// POST /queries/v1/query-request — returns the raw HTTP status code.
     /// Used in auth-failure tests where we expect a 401.
     pub async fn query_raw_status(&self, sql: &str) -> Result<u16> {

--- a/crates/queryflux-e2e-tests/tests/snowflake_wire_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/snowflake_wire_tests.rs
@@ -396,6 +396,56 @@ async fn wire_and_sql_api_return_consistent_results() {
 }
 
 // ---------------------------------------------------------------------------
+// Cancel in-flight query (wire v1)
+// ---------------------------------------------------------------------------
+
+/// Heavy DuckDB query — long enough to cancel while still running.
+const LONG_RUNNING_SQL: &str = "SELECT sum(x * x) FROM generate_series(1, 500000000) AS t(x)";
+
+#[tokio::test]
+async fn cancel_in_flight_query() {
+    let h = harness().await;
+    let mut client = SnowflakeWireClient::new(&h.base_url());
+    client.login("testuser", "").await.expect("login");
+
+    let base_url = h.base_url();
+    let token = client.session_token.clone().expect("session token");
+    let http = reqwest::Client::new();
+
+    let query_task = tokio::spawn(async move {
+        http.post(format!("{base_url}/queries/v1/query-request"))
+            .header("Authorization", format!("Snowflake Token=\"{token}\""))
+            .header("Content-Type", "application/json")
+            .json(&json!({"sqlText": LONG_RUNNING_SQL}))
+            .send()
+            .await
+            .expect("query request")
+            .json::<serde_json::Value>()
+            .await
+            .expect("query json")
+    });
+
+    let query_id = loop {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let ids = client.monitoring_query_ids().await.expect("monitoring");
+        if let Some(id) = ids.into_iter().next() {
+            break id;
+        }
+    };
+
+    let cancel_status = client.cancel(&query_id).await.expect("cancel");
+    assert_eq!(cancel_status, 200, "cancel should return 200");
+
+    let resp = query_task.await.expect("query task join");
+    assert!(
+        resp["success"].as_bool() == Some(false),
+        "cancelled query should report success=false: {resp}"
+    );
+
+    client.logout().await.ok();
+}
+
+// ---------------------------------------------------------------------------
 // StarRocks backend scenarios
 //
 // These tests create a WireTestHarness backed by a real StarRocks instance and

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
@@ -1,8 +1,8 @@
 //! Snowflake HTTP wire v1 query handlers.
 //!
 //! POST /queries/v1/query-request            — execute SQL, return Arrow IPC
-//! GET  /queries/v1/query-monitoring-request — async poll stub (always empty)
-//! DELETE /queries/v1/:query_id              — cancel stub (no-op for sync execution)
+//! GET  /queries/v1/query-monitoring-request — list in-flight queries for session
+//! DELETE /queries/v1/:query_id              — cancel in-flight query
 
 use std::sync::Arc;
 
@@ -23,13 +23,14 @@ use serde_json::json;
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::ResultSink;
 use crate::snowflake::http::format::sf_query_response;
 use crate::snowflake::http::handlers::bindings::bindings_to_params;
 use crate::snowflake::http::handlers::common::{
     extract_snowflake_token, parse_snowflake_json_body,
 };
 use crate::snowflake::http::SnowflakeWireState;
+use crate::snowflake::in_flight::{CancelOutcome, SnowflakeExecParams, SpawnExecuteResult};
 
 // ---------------------------------------------------------------------------
 // SnowflakeSink — accumulates Arrow batches, serialises via sf_query_response
@@ -164,25 +165,49 @@ pub async fn query_request(
     };
 
     let query_id = Uuid::new_v4().to_string();
-    let mut sink = SnowflakeSink::new();
 
-    if let Err(e) = execute_to_sink(
-        &state.app,
+    let exec = SnowflakeExecParams {
         sql,
         params,
         session_ctx,
-        FrontendProtocol::SnowflakeHttp,
+        protocol: FrontendProtocol::SnowflakeHttp,
         group,
-        &mut sink,
-        &auth_ctx,
+        auth_ctx: auth_ctx.clone(),
+    };
+
+    match crate::snowflake::in_flight::spawn_execute(
+        &state.app,
+        &state.in_flight,
+        query_id.clone(),
+        auth_ctx.user.clone(),
+        exec,
+        SnowflakeSink::new,
     )
     .await
     {
-        warn!(query_id = %query_id, "Snowflake wire query error: {e}");
-        sink.error = Some(e.to_string());
+        SpawnExecuteResult::Completed(Ok(()), sink) => {
+            sink.into_response(&query_id, &database, &schema_name)
+        }
+        SpawnExecuteResult::Completed(Err(e), mut sink) => {
+            warn!(query_id = %query_id, "Snowflake wire query error: {e}");
+            sink.error = Some(e.to_string());
+            sink.into_response(&query_id, &database, &schema_name)
+        }
+        SpawnExecuteResult::Cancelled => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "data": null,
+                "message": "Query cancelled.",
+                "success": false,
+                "code": "000630"
+            })),
+        )
+            .into_response(),
+        SpawnExecuteResult::JoinFailed(e) => {
+            warn!(query_id = %query_id, "Snowflake wire query task failed: {e}");
+            sf_error("390000", &format!("Query execution failed: {e}"))
+        }
     }
-
-    sink.into_response(&query_id, &database, &schema_name)
 }
 
 // ---------------------------------------------------------------------------
@@ -190,13 +215,34 @@ pub async fn query_request(
 // ---------------------------------------------------------------------------
 
 pub async fn query_monitoring_request(
-    State(_state): State<SnowflakeWireState>,
-    _headers: HeaderMap,
+    State(state): State<SnowflakeWireState>,
+    headers: HeaderMap,
 ) -> Response {
+    let token = match extract_snowflake_token(&headers) {
+        Some(t) => t,
+        None => return unauthorized(),
+    };
+
+    let user = match state.sessions.validate_session(&token) {
+        Some((_, session)) => session.auth_ctx.user.clone(),
+        None => return unauthorized(),
+    };
+
+    let ids = state.in_flight.ids_for_owner(&user);
+    let queries: Vec<_> = ids
+        .into_iter()
+        .map(|id| {
+            json!({
+                "id": id,
+                "status": "RUNNING",
+            })
+        })
+        .collect();
+
     (
         StatusCode::OK,
         axum::Json(json!({
-            "data": {"queries": []},
+            "data": {"queries": queries},
             "message": null,
             "success": true,
             "code": null
@@ -210,20 +256,42 @@ pub async fn query_monitoring_request(
 // ---------------------------------------------------------------------------
 
 pub async fn cancel_query(
-    State(_state): State<SnowflakeWireState>,
-    _headers: HeaderMap,
-    Path(_query_id): Path<String>,
+    State(state): State<SnowflakeWireState>,
+    headers: HeaderMap,
+    Path(query_id): Path<String>,
 ) -> Response {
-    (
-        StatusCode::OK,
-        axum::Json(json!({
-            "data": null,
-            "message": null,
-            "success": true,
-            "code": null
-        })),
-    )
-        .into_response()
+    let token = match extract_snowflake_token(&headers) {
+        Some(t) => t,
+        None => return unauthorized(),
+    };
+
+    let auth_ctx = match state.sessions.validate_session(&token) {
+        Some((_, session)) => session.auth_ctx.clone(),
+        None => return unauthorized(),
+    };
+
+    match state.in_flight.cancel(&query_id, &auth_ctx) {
+        CancelOutcome::Aborted | CancelOutcome::NotFound => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "data": null,
+                "message": null,
+                "success": true,
+                "code": null
+            })),
+        )
+            .into_response(),
+        CancelOutcome::Forbidden => (
+            StatusCode::FORBIDDEN,
+            axum::Json(json!({
+                "data": null,
+                "message": "Query belongs to a different user.",
+                "success": false,
+                "code": "390403"
+            })),
+        )
+            .into_response(),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/queryflux-frontend/src/snowflake/http/mod.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/mod.rs
@@ -12,6 +12,7 @@ use axum::routing::{delete, get, post};
 use axum::Router;
 
 use crate::snowflake::http::session_store::SnowflakeSessionStore;
+use crate::snowflake::in_flight::SnowflakeInFlightRegistry;
 use crate::state::AppState;
 
 pub mod format;
@@ -31,6 +32,7 @@ pub mod session_store;
 pub struct SnowflakeWireState {
     pub app: Arc<AppState>,
     pub sessions: Arc<SnowflakeSessionStore>,
+    pub in_flight: Arc<SnowflakeInFlightRegistry>,
 }
 
 /// Allow Axum handlers that only need `Arc<AppState>` to extract it from

--- a/crates/queryflux-frontend/src/snowflake/in_flight.rs
+++ b/crates/queryflux-frontend/src/snowflake/in_flight.rs
@@ -1,0 +1,201 @@
+//! In-process registry of running Snowflake HTTP/SQL-API queries.
+//!
+//! Snowflake wire v1 and SQL API v2 execute synchronously on the HTTP request
+//! thread, but the work runs in a spawned task so explicit DELETE cancel (and
+//! client disconnect via task abort) can stop the backend query through
+//! [`SyncCancelGuard`](crate::dispatch::SyncCancelGuard).
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use queryflux_auth::{require_query_owner, AuthContext};
+use queryflux_core::{error::Result, query::FrontendProtocol, session::SessionContext};
+use tokio::task::AbortHandle;
+
+/// Outcome of attempting to cancel an in-flight Snowflake query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// The query was found and abort was signalled.
+    Aborted,
+    /// No in-flight query with this id (already finished or unknown id).
+    NotFound,
+    /// Authenticated user is not the query owner.
+    Forbidden,
+}
+
+/// Result of spawning a Snowflake query task.
+pub enum SpawnExecuteResult<S> {
+    Completed(Result<()>, S),
+    Cancelled,
+    JoinFailed(String),
+}
+
+/// A single in-flight Snowflake query handle.
+struct InFlightEntry {
+    owner: String,
+    abort: AbortHandle,
+}
+
+/// Process-local registry keyed by wire `queryId` / SQL API `statementHandle`.
+#[derive(Default)]
+pub struct SnowflakeInFlightRegistry {
+    entries: DashMap<String, InFlightEntry>,
+}
+
+impl SnowflakeInFlightRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            entries: DashMap::new(),
+        })
+    }
+
+    pub fn register(&self, id: String, owner: String, abort: AbortHandle) {
+        self.entries.insert(id, InFlightEntry { owner, abort });
+    }
+
+    pub fn unregister(&self, id: &str) {
+        self.entries.remove(id);
+    }
+
+    /// Abort an in-flight query when the requester owns it.
+    pub fn cancel(&self, id: &str, auth: &AuthContext) -> CancelOutcome {
+        let Some(entry) = self.entries.get(id) else {
+            return CancelOutcome::NotFound;
+        };
+        if require_query_owner(auth, &entry.owner).is_err() {
+            return CancelOutcome::Forbidden;
+        }
+        entry.abort.abort();
+        CancelOutcome::Aborted
+    }
+
+    /// In-flight query ids owned by `user` (wire monitoring / tests).
+    pub fn ids_for_owner(&self, owner: &str) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|e| e.owner == owner)
+            .map(|e| e.key().clone())
+            .collect()
+    }
+}
+
+/// Parameters shared by wire v1 and SQL API v2 synchronous execute paths.
+pub struct SnowflakeExecParams {
+    pub sql: String,
+    pub params: queryflux_core::params::QueryParams,
+    pub session_ctx: SessionContext,
+    pub protocol: FrontendProtocol,
+    pub group: queryflux_core::query::ClusterGroupName,
+    pub auth_ctx: AuthContext,
+}
+
+/// Spawn `execute_to_sink` so explicit cancel can abort the task (and trigger
+/// sync cancel on the backend).
+pub async fn spawn_execute<S, F>(
+    app: &Arc<crate::state::AppState>,
+    registry: &Arc<SnowflakeInFlightRegistry>,
+    query_id: String,
+    owner: String,
+    exec: SnowflakeExecParams,
+    make_sink: F,
+) -> SpawnExecuteResult<S>
+where
+    S: crate::dispatch::ResultSink + Send + 'static,
+    F: FnOnce() -> S + Send + 'static,
+{
+    let app = app.clone();
+    let registry = registry.clone();
+    let query_id_for_task = query_id.clone();
+
+    let join = tokio::spawn(async move {
+        let mut sink = make_sink();
+        let result = crate::dispatch::execute_to_sink(
+            &app,
+            exec.sql,
+            exec.params,
+            exec.session_ctx,
+            exec.protocol,
+            exec.group,
+            &mut sink,
+            &exec.auth_ctx,
+        )
+        .await;
+        (result, sink)
+    });
+
+    registry.register(query_id, owner, join.abort_handle());
+
+    match join.await {
+        Ok((result, sink)) => {
+            registry.unregister(&query_id_for_task);
+            SpawnExecuteResult::Completed(result, sink)
+        }
+        Err(e) if e.is_cancelled() => {
+            registry.unregister(&query_id_for_task);
+            SpawnExecuteResult::Cancelled
+        }
+        Err(e) => {
+            registry.unregister(&query_id_for_task);
+            SpawnExecuteResult::JoinFailed(e.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn ctx(user: &str) -> AuthContext {
+        AuthContext {
+            user: user.to_string(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_aborts_registered_task() {
+        let registry = SnowflakeInFlightRegistry::new();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = tokio::spawn(async move {
+            struct SignalOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
+            impl Drop for SignalOnDrop {
+                fn drop(&mut self) {
+                    if let Some(tx) = self.0.take() {
+                        let _ = tx.send(());
+                    }
+                }
+            }
+            let _guard = SignalOnDrop(Some(tx));
+            std::future::pending::<()>().await
+        });
+        registry.register("q1".to_string(), "alice".to_string(), handle.abort_handle());
+
+        assert_eq!(registry.cancel("q1", &ctx("alice")), CancelOutcome::Aborted);
+
+        let _ = tokio::time::timeout(Duration::from_secs(1), rx)
+            .await
+            .expect("task should abort");
+    }
+
+    #[tokio::test]
+    async fn cancel_rejects_other_user() {
+        let registry = SnowflakeInFlightRegistry::new();
+        let handle = tokio::spawn(async { std::future::pending::<()>().await });
+        registry.register("q1".to_string(), "alice".to_string(), handle.abort_handle());
+
+        assert_eq!(registry.cancel("q1", &ctx("bob")), CancelOutcome::Forbidden);
+        handle.abort();
+    }
+
+    #[test]
+    fn cancel_unknown_returns_not_found() {
+        let registry = SnowflakeInFlightRegistry::new();
+        assert_eq!(
+            registry.cancel("missing", &ctx("alice")),
+            CancelOutcome::NotFound
+        );
+    }
+}

--- a/crates/queryflux-frontend/src/snowflake/mod.rs
+++ b/crates/queryflux-frontend/src/snowflake/mod.rs
@@ -1,4 +1,5 @@
 pub mod http;
+pub mod in_flight;
 pub mod sql_api;
 
 use std::sync::Arc;
@@ -17,6 +18,7 @@ use http::{
     session_store::{SnowflakeHttpSessionPolicy, SnowflakeSessionStore},
     SnowflakeWireState,
 };
+use in_flight::SnowflakeInFlightRegistry;
 
 /// Snowflake frontend — serves both the HTTP wire protocol v1
 /// (`/session/v1/*`, `/queries/v1/*`) and the SQL API v2 (`/api/v2/statements`)
@@ -28,6 +30,7 @@ pub struct SnowflakeFrontend {
     state: Arc<AppState>,
     cfg: SnowflakeHttpFrontendConfig,
     sessions: Arc<SnowflakeSessionStore>,
+    in_flight: Arc<SnowflakeInFlightRegistry>,
 }
 
 impl SnowflakeFrontend {
@@ -53,10 +56,12 @@ impl SnowflakeFrontend {
             },
         };
         let sessions = Arc::new(SnowflakeSessionStore::new(policy));
+        let in_flight = SnowflakeInFlightRegistry::new();
         Self {
             state,
             cfg,
             sessions,
+            in_flight,
         }
     }
 
@@ -64,12 +69,12 @@ impl SnowflakeFrontend {
         let wire_state = SnowflakeWireState {
             app: self.state.clone(),
             sessions: self.sessions.clone(),
+            in_flight: self.in_flight.clone(),
         };
-        // Both sub-routers are resolved to Router<()> via .with_state() before merging.
-        // SQL API v2 handlers extract State<Arc<AppState>>; wire v1 handlers extract
-        // State<SnowflakeWireState>. FromRef<SnowflakeWireState> for Arc<AppState> lets
-        // the SQL API handlers work with the SnowflakeWireState directly.
-        let sql_api = sql_api::routes().with_state(wire_state.app.clone());
+        // Both sub-routers use SnowflakeWireState. SQL API v2 handlers extract
+        // State<SnowflakeWireState> (or Arc<AppState> via FromRef). Wire v1 handlers
+        // extract State<SnowflakeWireState> directly.
+        let sql_api = sql_api::routes().with_state(wire_state.clone());
         let wire = http::routes().with_state(wire_state);
         sql_api.merge(wire)
     }

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -21,11 +21,12 @@ use serde_json::{json, Value};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::dispatch::{execute_to_sink, ResultSink};
+use crate::dispatch::ResultSink;
 use crate::snowflake::http::format::schema_to_rowtype;
 use crate::snowflake::http::handlers::bindings::bindings_to_params;
 use crate::snowflake::http::handlers::common::parse_snowflake_json_body;
-use crate::state::AppState;
+use crate::snowflake::http::SnowflakeWireState;
+use crate::snowflake::in_flight::{CancelOutcome, SnowflakeExecParams, SpawnExecuteResult};
 
 // ---------------------------------------------------------------------------
 // ResultSink that accumulates Arrow batches into SQL API v2 jsonv2 format
@@ -181,7 +182,7 @@ fn sql_api_error(status: StatusCode, code: &str, message: &str) -> Response {
 
 /// POST /api/v2/statements  — submit SQL, execute synchronously, return jsonv2
 pub async fn submit_statement(
-    State(state): State<Arc<AppState>>,
+    State(state): State<SnowflakeWireState>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
@@ -204,7 +205,7 @@ pub async fn submit_statement(
     let params = bindings_to_params(body_json.get("bindings"));
 
     // Stateless auth: Bearer token in Authorization header.
-    let auth_ctx = match authenticate(&state, &headers).await {
+    let auth_ctx = match authenticate(&state.app, &headers).await {
         Ok(ctx) => ctx,
         Err(e) => return sql_api_error(StatusCode::UNAUTHORIZED, "390002", &e.to_string()),
     };
@@ -227,7 +228,7 @@ pub async fn submit_statement(
         agent_context: None,
     };
     let group = {
-        let live = state.live.read().await;
+        let live = state.app.live.read().await;
         live.router_chain
             .route(
                 &sql,
@@ -243,30 +244,52 @@ pub async fn submit_statement(
     };
 
     let handle = Uuid::new_v4().to_string();
-    let mut sink = SqlApiSink::new();
 
-    if let Err(e) = execute_to_sink(
-        &state,
+    let exec = SnowflakeExecParams {
         sql,
         params,
         session_ctx,
-        FrontendProtocol::SnowflakeSqlApi,
+        protocol: FrontendProtocol::SnowflakeSqlApi,
         group,
-        &mut sink,
-        &auth_ctx,
+        auth_ctx: auth_ctx.clone(),
+    };
+
+    match crate::snowflake::in_flight::spawn_execute(
+        &state.app,
+        &state.in_flight,
+        handle.clone(),
+        auth_ctx.user.clone(),
+        exec,
+        SqlApiSink::new,
     )
     .await
     {
-        warn!(handle = %handle, "SQL API execute_to_sink error: {e}");
-        sink.error = Some(e.to_string());
+        SpawnExecuteResult::Completed(Ok(()), sink) => sink.into_response(&handle),
+        SpawnExecuteResult::Completed(Err(e), mut sink) => {
+            warn!(handle = %handle, "SQL API execute_to_sink error: {e}");
+            sink.error = Some(e.to_string());
+            sink.into_response(&handle)
+        }
+        SpawnExecuteResult::Cancelled => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "code": "000630",
+                "message": "Statement aborted.",
+                "sqlState": "57014",
+                "statementHandle": handle
+            })),
+        )
+            .into_response(),
+        SpawnExecuteResult::JoinFailed(e) => {
+            warn!(handle = %handle, "SQL API query task failed: {e}");
+            sql_api_error(StatusCode::INTERNAL_SERVER_ERROR, "390000", &e)
+        }
     }
-
-    sink.into_response(&handle)
 }
 
 /// GET /api/v2/statements/:handle  — stub (sync execution, nothing to poll)
 pub async fn get_statement(
-    State(_state): State<Arc<AppState>>,
+    State(_state): State<SnowflakeWireState>,
     _headers: HeaderMap,
     axum::extract::Path(handle): axum::extract::Path<String>,
     _raw_query: axum::extract::RawQuery,
@@ -283,20 +306,32 @@ pub async fn get_statement(
         .into_response()
 }
 
-/// DELETE /api/v2/statements/:handle  — stub (sync execution, nothing to cancel)
+/// DELETE /api/v2/statements/:handle  — abort an in-flight statement
 pub async fn cancel_statement(
-    State(_state): State<Arc<AppState>>,
-    _headers: HeaderMap,
+    State(state): State<SnowflakeWireState>,
+    headers: HeaderMap,
     axum::extract::Path(handle): axum::extract::Path<String>,
 ) -> Response {
-    (
-        StatusCode::OK,
-        axum::Json(json!({
-            "statementHandle": handle,
-            "message": "Statement aborted.",
-        })),
-    )
-        .into_response()
+    let auth_ctx = match authenticate(&state.app, &headers).await {
+        Ok(ctx) => ctx,
+        Err(e) => return sql_api_error(StatusCode::UNAUTHORIZED, "390002", &e.to_string()),
+    };
+
+    match state.in_flight.cancel(&handle, &auth_ctx) {
+        CancelOutcome::Aborted | CancelOutcome::NotFound => (
+            StatusCode::OK,
+            axum::Json(json!({
+                "statementHandle": handle,
+                "message": "Statement aborted.",
+            })),
+        )
+            .into_response(),
+        CancelOutcome::Forbidden => sql_api_error(
+            StatusCode::FORBIDDEN,
+            "390403",
+            "Statement belongs to a different user.",
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -304,7 +339,7 @@ pub async fn cancel_statement(
 // ---------------------------------------------------------------------------
 
 async fn authenticate(
-    state: &Arc<AppState>,
+    state: &std::sync::Arc<crate::state::AppState>,
     headers: &HeaderMap,
 ) -> std::result::Result<queryflux_auth::AuthContext, String> {
     let bearer = headers

--- a/crates/queryflux-frontend/src/snowflake/sql_api/mod.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/mod.rs
@@ -1,19 +1,17 @@
 //! Snowflake SQL REST API v2 frontend (Form 2) — Design B: protocol bridge.
 //!
-//! Exposes `routes()` — a stateless `Router<Arc<AppState>>`.
-
-use std::sync::Arc;
+//! Exposes `routes()` — a stateless `Router<SnowflakeWireState>`.
 
 use axum::{
     routing::{get, post},
     Router,
 };
 
-use crate::state::AppState;
+use crate::snowflake::http::SnowflakeWireState;
 
 pub mod handlers;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<SnowflakeWireState> {
     Router::new()
         .route("/api/v2/statements", post(handlers::submit_statement))
         .route(


### PR DESCRIPTION
## Summary
- Register Snowflake wire v1 and SQL API v2 queries in a process-local in-flight map so `DELETE /queries/v1/{query_id}` and `DELETE /api/v2/statements/{handle}` abort the running task (and trigger backend cancel via `SyncCancelGuard`).
- Enforce query ownership on cancel (IDOR) and surface in-flight ids on the wire monitoring endpoint.
- Add e2e coverage that starts a long DuckDB query and cancels it while it is still running.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=target cargo clippy --workspace --all-targets --all-features --exclude queryflux-bench -- -D warnings`
- [x] `CARGO_TARGET_DIR=target cargo test -p queryflux-frontend snowflake::in_flight`
- [x] `CARGO_TARGET_DIR=target cargo test -p queryflux-e2e-tests --test snowflake_wire_tests cancel_in_flight_query`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for monitoring active Snowflake queries and retrieving running query IDs.
  - Added query cancellation for both wire protocol and SQL API requests.
  - Added authentication and ownership checks to prevent unauthorized monitoring or cancellation.

- **Bug Fixes**
  - Query execution now reports clear outcomes for successful, cancelled, failed, or unavailable requests.
  - Cancellation responses accurately reflect whether a query was found and stopped.

- **Tests**
  - Added end-to-end coverage for detecting and cancelling an in-flight query.
  - Added coverage for authorized, unauthorized, and unknown query cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->