### PR TITLE
chore: add MySQL, Postgres, and Flight SQL wire e2e smoke tests (P2-40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,11 +644,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -1012,6 +1012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1208,7 +1217,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1273,6 +1282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1327,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1441,6 +1462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1522,7 +1561,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1590,10 +1629,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1630,7 +1681,7 @@ checksum = "f13bc6d6487032fc2825a62ef8b4924b2378a2eb3166e132e5f3141ae9dd633f"
 dependencies = [
  "arrow",
  "cast",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libduckdb-sys",
@@ -1691,6 +1742,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -1967,7 +2024,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2126,7 +2183,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2135,7 +2192,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2213,6 +2279,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2928,7 +3003,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2966,7 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3069,7 +3154,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "subprocess",
  "thiserror 1.0.69",
@@ -3100,7 +3185,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -3196,6 +3281,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,7 +3337,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml",
  "reqsign",
@@ -3404,8 +3507,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3439,7 +3542,17 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -3447,6 +3560,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -3505,7 +3627,7 @@ dependencies = [
  "der",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -3562,6 +3684,36 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3928,10 +4080,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-flight",
  "async-trait",
  "axum",
  "base64 0.22.1",
  "futures",
+ "mysql_async",
+ "prost 0.14.3",
  "queryflux-auth",
  "queryflux-cache",
  "queryflux-cluster-manager",
@@ -3946,6 +4101,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-postgres",
+ "tonic 0.14.5",
  "tracing-subscriber",
  "trino-rust-client",
 ]
@@ -4022,7 +4179,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tokio-stream",
  "tonic 0.14.5",
@@ -4379,7 +4536,7 @@ dependencies = [
  "form_urlencoded",
  "getrandom 0.2.17",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "http 1.4.0",
  "jsonwebtoken 9.3.1",
@@ -4393,7 +4550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -4525,15 +4682,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -4779,7 +4936,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4923,7 +5080,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4934,7 +5091,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4968,7 +5136,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5096,7 +5264,7 @@ dependencies = [
  "rustls 0.23.37",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5135,7 +5303,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5158,7 +5326,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5168,10 +5336,10 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -5179,14 +5347,14 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5208,24 +5376,24 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5541,6 +5709,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-util",
+ "whoami 2.1.1",
 ]
 
 [[package]]
@@ -6079,6 +6273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6101,6 +6304,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6262,7 +6474,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/queryflux-e2e-tests/Cargo.toml
+++ b/crates/queryflux-e2e-tests/Cargo.toml
@@ -44,6 +44,13 @@ tracing-subscriber = { workspace = true }
 # Async trait
 async-trait = { workspace = true }
 
+# Wire protocol e2e clients
+mysql_async = { workspace = true }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+arrow-flight = { version = "58.1.0", features = ["flight-sql"] }
+tonic = { version = "0.14.5", features = ["transport"] }
+prost = "0.14.3"
+
 # ADBC Trino integration test (StreamExt)
 futures = { workspace = true }
 

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -37,9 +37,13 @@ use queryflux_engine_adapters::{
     AdapterKind,
 };
 use queryflux_frontend::{
+    flight_sql::FlightSqlFrontend,
+    mysql_wire::MysqlWireFrontend,
+    postgres_wire::PostgresWireFrontend,
     snowflake::SnowflakeFrontend,
     state::LiveConfig,
     trino_http::{state::AppState, TrinoHttpFrontend},
+    FrontendListenerTrait, ShutdownRx,
 };
 use queryflux_metrics::{ClusterSnapshot, MetricsStore, QueryRecord};
 use queryflux_persistence::in_memory::InMemoryPersistence;
@@ -785,4 +789,150 @@ impl MetricsStore for NullMetrics {
     async fn record_cluster_snapshot(&self, _s: ClusterSnapshot) -> QfResult<()> {
         Ok(())
     }
+}
+
+// ---------------------------------------------------------------------------
+// ProtocolWireHarness — MySQL wire, Postgres wire, and Flight SQL on DuckDB.
+// ---------------------------------------------------------------------------
+
+pub struct ProtocolWireHarness {
+    pub mysql_port: u16,
+    pub postgres_port: u16,
+    pub flight_port: u16,
+    _shutdown_tx: tokio::sync::watch::Sender<bool>,
+}
+
+impl ProtocolWireHarness {
+    pub async fn new() -> Result<Self> {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter("error")
+            .try_init();
+
+        let group = ClusterGroupName(GROUP_DUCKDB.to_string());
+        let cluster = ClusterName("duckdb-wire-proto-1".to_string());
+        let cs = Arc::new(ClusterState::new(
+            cluster.clone(),
+            group.clone(),
+            None,
+            None,
+            EngineType::DuckDb,
+            None,
+            4,
+            true,
+        ));
+        let adapter = Arc::new(
+            DuckDbAdapter::new(
+                cluster.clone(),
+                group.clone(),
+                DuckDbConfig {
+                    database_path: None,
+                    motherduck_token: None,
+                    pool_size: 2,
+                    max_result_buffer_bytes: DEFAULT_MAX_RESULT_BUFFER_BYTES,
+                },
+            )
+            .map_err(|e| anyhow!("DuckDB adapter: {e}"))?,
+        );
+
+        let mut group_states: HashMap<ClusterGroupName, _> = HashMap::new();
+        group_states.insert(group.clone(), (vec![cs], strategy_from_config(None)));
+        let mut adapters: HashMap<String, AdapterKind> = HashMap::new();
+        adapters.insert(cluster.0.clone(), AdapterKind::Sync(adapter));
+
+        let duckdb_group = group.clone();
+        let router = Box::new(ProtocolBasedRouter {
+            trino_http: None,
+            postgres_wire: Some(duckdb_group.clone()),
+            mysql_wire: Some(duckdb_group.clone()),
+            clickhouse_http: None,
+            flight_sql: Some(duckdb_group.clone()),
+            snowflake_http: None,
+            snowflake_sql_api: None,
+        });
+
+        let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
+        let translation = Arc::new(TranslationService::disabled());
+        let router_chain = RouterChain::new(vec![router], group.clone());
+
+        let live_config = LiveConfig {
+            router_chain,
+            guard_chain: None,
+            group_guard_chains: HashMap::new(),
+            cluster_manager,
+            adapters,
+            health_check_targets: vec![],
+            cluster_configs: HashMap::new(),
+            group_members: HashMap::from([(GROUP_DUCKDB.to_string(), vec![cluster.0.clone()])]),
+            group_order: vec![GROUP_DUCKDB.to_string()],
+            group_translation_scripts: HashMap::new(),
+            group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
+            group_cache_settings: HashMap::new(),
+            auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
+            authorization: Arc::new(AllowAllAuthorization::default())
+                as Arc<dyn AuthorizationChecker>,
+        };
+
+        let state = Arc::new(AppState {
+            external_address: "http://127.0.0.1:0".to_string(),
+            live: Arc::new(tokio::sync::RwLock::new(live_config)),
+            persistence: Arc::new(InMemoryPersistence::new()),
+            translation,
+            metrics: Arc::new(NullMetrics),
+            identity_resolver: Arc::new(BackendIdentityResolver::new()),
+            capacity_store: None,
+            queue_coordinator: None,
+            instance_id: "wire-proto-harness".to_string(),
+            http_client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("build http client"),
+            result_cache: Arc::new(queryflux_cache::noop::NoopResultCache),
+        });
+
+        let mysql_port = bind_ephemeral_port().await?;
+        let postgres_port = bind_ephemeral_port().await?;
+        let flight_port = bind_ephemeral_port().await?;
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+        spawn_wire_frontend(
+            MysqlWireFrontend::new(state.clone(), mysql_port, None),
+            shutdown_rx.clone(),
+        );
+        spawn_wire_frontend(
+            PostgresWireFrontend::new(state.clone(), postgres_port, None),
+            shutdown_rx.clone(),
+        );
+        spawn_wire_frontend(
+            FlightSqlFrontend::new(state, flight_port, None),
+            shutdown_rx,
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        Ok(Self {
+            mysql_port,
+            postgres_port,
+            flight_port,
+            _shutdown_tx: shutdown_tx,
+        })
+    }
+}
+
+async fn bind_ephemeral_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn spawn_wire_frontend<F>(frontend: F, shutdown: ShutdownRx)
+where
+    F: FrontendListenerTrait + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        let _ = frontend.listen(shutdown).await;
+    });
 }

--- a/crates/queryflux-e2e-tests/src/lib.rs
+++ b/crates/queryflux-e2e-tests/src/lib.rs
@@ -3,3 +3,4 @@ pub mod iceberg_seed;
 pub mod snowflake_client;
 pub mod snowflake_wire_client;
 pub mod trino_client;
+pub mod wire_protocol_clients;

--- a/crates/queryflux-e2e-tests/src/wire_protocol_clients.rs
+++ b/crates/queryflux-e2e-tests/src/wire_protocol_clients.rs
@@ -1,0 +1,83 @@
+//! Thin clients for MySQL wire, Postgres wire, and Flight SQL e2e smoke tests.
+
+use anyhow::{Context, Result};
+use arrow_flight::sql::client::FlightSqlServiceClient;
+use futures::StreamExt;
+use mysql_async::prelude::Queryable;
+use mysql_async::{Conn, OptsBuilder};
+use tokio_postgres::SimpleQueryMessage;
+use tonic::transport::Channel;
+
+/// Run `SELECT 1` over the MySQL wire protocol.
+pub async fn mysql_select_one(host: &str, port: u16, user: &str) -> Result<i64> {
+    let opts = OptsBuilder::default()
+        .ip_or_hostname(host)
+        .tcp_port(port)
+        .user(Some(user.to_string()))
+        .pass(None::<String>)
+        .db_name(Some("default".to_string()));
+
+    let mut conn = Conn::new(opts).await.context("mysql wire connect")?;
+    let row: Option<i64> = conn
+        .query_first("SELECT 1 AS n")
+        .await
+        .context("mysql wire query")?;
+    row.context("mysql wire: expected one row")
+}
+
+/// Run `SELECT 1` over the Postgres wire protocol.
+pub async fn postgres_select_one(host: &str, port: u16, user: &str) -> Result<i32> {
+    let url = format!("postgresql://{user}@{host}:{port}/postgres");
+    let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls)
+        .await
+        .context("postgres wire connect")?;
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    let messages = client
+        .simple_query("SELECT 1 AS n")
+        .await
+        .context("postgres wire query")?;
+    for msg in messages {
+        if let SimpleQueryMessage::Row(row) = msg {
+            let val = row
+                .get(0)
+                .context("postgres wire: missing column")?
+                .parse::<i32>()
+                .context("postgres wire: parse int")?;
+            return Ok(val);
+        }
+    }
+    anyhow::bail!("postgres wire: expected one row")
+}
+
+/// Run `SELECT 1` over Arrow Flight SQL (GetFlightInfo + DoGet).
+pub async fn flight_sql_select_one(host: &str, port: u16) -> Result<i64> {
+    let endpoint = format!("http://{host}:{port}");
+    let channel = Channel::from_shared(endpoint)
+        .context("flight sql endpoint")?
+        .connect()
+        .await
+        .context("flight sql connect")?;
+
+    let mut client = FlightSqlServiceClient::new(channel);
+    let flight_info = client
+        .execute("SELECT 1 AS n".to_string(), None)
+        .await
+        .context("flight sql execute")?;
+
+    let ticket = flight_info
+        .endpoint
+        .first()
+        .and_then(|ep| ep.ticket.clone())
+        .context("flight sql: missing ticket")?;
+
+    let mut stream = client.do_get(ticket).await.context("flight sql do_get")?;
+
+    let mut total = 0i64;
+    while let Some(batch) = stream.next().await {
+        let batch = batch.context("flight sql batch")?;
+        total += batch.num_rows() as i64;
+    }
+    Ok(total)
+}

--- a/crates/queryflux-e2e-tests/tests/wire_protocol_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/wire_protocol_tests.rs
@@ -1,0 +1,45 @@
+//! Smoke e2e tests for MySQL wire, Postgres wire, and Flight SQL frontends.
+//!
+//! Uses an in-process `ProtocolWireHarness` backed by DuckDB (no docker).
+//!
+//! Run with: `cargo test -p queryflux-e2e-tests --test wire_protocol_tests`
+
+use queryflux_e2e_tests::{
+    harness::ProtocolWireHarness,
+    wire_protocol_clients::{flight_sql_select_one, mysql_select_one, postgres_select_one},
+};
+
+const HOST: &str = "127.0.0.1";
+
+#[tokio::test]
+async fn mysql_wire_select_one() {
+    let h = ProtocolWireHarness::new()
+        .await
+        .expect("ProtocolWireHarness::new");
+    let n = mysql_select_one(HOST, h.mysql_port, "testuser")
+        .await
+        .expect("mysql SELECT 1");
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+async fn postgres_wire_select_one() {
+    let h = ProtocolWireHarness::new()
+        .await
+        .expect("ProtocolWireHarness::new");
+    let n = postgres_select_one(HOST, h.postgres_port, "testuser")
+        .await
+        .expect("postgres SELECT 1");
+    assert_eq!(n, 1);
+}
+
+#[tokio::test]
+async fn flight_sql_wire_select_one() {
+    let h = ProtocolWireHarness::new()
+        .await
+        .expect("ProtocolWireHarness::new");
+    let rows = flight_sql_select_one(HOST, h.flight_port)
+        .await
+        .expect("flight sql SELECT 1");
+    assert_eq!(rows, 1);
+}

--- a/crates/queryflux-engine-adapters/src/lib.rs
+++ b/crates/queryflux-engine-adapters/src/lib.rs
@@ -108,7 +108,6 @@ impl ConnectionFormat {
                     ConnectionFormat::PostgresWire,
                     FrontendProtocol::PostgresWire
                 )
-                | (ConnectionFormat::Arrow, FrontendProtocol::FlightSql)
                 | (ConnectionFormat::TrinoHttp, FrontendProtocol::TrinoHttp)
                 | (
                     ConnectionFormat::ClickHouseHttp,
@@ -136,8 +135,8 @@ mod connection_format_tests {
     }
 
     #[test]
-    fn arrow_matches_flight_sql() {
-        assert!(ConnectionFormat::Arrow.matches_frontend(&FrontendProtocol::FlightSql));
+    fn arrow_does_not_match_flight_sql() {
+        assert!(!ConnectionFormat::Arrow.matches_frontend(&FrontendProtocol::FlightSql));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `ProtocolWireHarness` plus smoke e2e tests that run `SELECT 1` over MySQL wire, Postgres wire, and Flight SQL against in-process DuckDB (no docker).
- Route Flight SQL through Arrow streaming instead of `execute_native` so Arrow backends (DuckDB) work; the native path is only for matching wire formats.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=target cargo clippy --workspace --all-targets --all-features --exclude queryflux-bench -- -D warnings`
- [x] `CARGO_TARGET_DIR=target cargo test -p queryflux-e2e-tests --test wire_protocol_tests`
- [x] `CARGO_TARGET_DIR=target cargo test -p queryflux-engine-adapters connection_format`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support coverage for MySQL, PostgreSQL, and Flight SQL connections.
  * Added end-to-end validation for executing basic queries through each wire protocol.

* **Bug Fixes**
  * Corrected connection format matching so Arrow connections are not incorrectly identified as Flight SQL.

* **Tests**
  * Added smoke tests confirming successful query execution and response handling across all supported protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->