### PR TITLE
docs: harden Helm production-values for secrets and required auth

### DIFF
--- a/charts/queryflux/README.md
+++ b/charts/queryflux/README.md
@@ -98,7 +98,8 @@ The chart also supports `env`, `envFrom`, `extraVolumes`, `extraVolumeMounts`, `
 ## Examples
 
 - `examples/external-config-values.yaml`: use a pre-created ConfigMap and Secret, and run the server-only image.
-- `examples/production-values.yaml`: shows ingress, TLS, HPA, PDB, ServiceMonitor, NetworkPolicy, resource requests, and topology spread settings.
+- `examples/production-values.yaml`: production checklist — TLS ingress, HPA, PDB, ServiceMonitor, NetworkPolicy, topology spread, `config.existingSecret`, and pre-created admin Secret (no default password in values).
+- `examples/production-config.yaml`: template for the config Secret referenced by production-values (`auth.required: true`, OIDC, Postgres URL). Create with `kubectl create secret generic queryflux-config --from-file=config.yaml=...`.
 - `examples/networkpolicy-values.yaml`: starter NetworkPolicy allowing clients, DNS, Postgres, and engines (tighten selectors before production).
 
 ## Validation

--- a/charts/queryflux/examples/production-config.yaml
+++ b/charts/queryflux/examples/production-config.yaml
@@ -1,0 +1,53 @@
+# Template for the QueryFlux config Secret used by examples/production-values.yaml.
+#
+# Fill in Postgres URL, OIDC (or switch to static/LDAP), and engine endpoints, then:
+#   kubectl create secret generic queryflux-config \
+#     --from-file=config.yaml=./production-config.yaml
+#
+# auth.required must stay true for production. With provider oidc, issuer / jwksUri /
+# audience are validated at startup (see P1-29).
+
+queryflux:
+  externalAddress: https://queryflux.example.com
+  # Must be ≥ Kubernetes terminationGracePeriodSeconds buffer (chart default 45).
+  shutdownDrainTimeoutSecs: 30
+  frontends:
+    trinoHttp:
+      enabled: true
+      port: 8080
+  persistence:
+    type: postgres
+    # Shared HA Postgres — required for replicaCount ≥ 2 / HPA.
+    url: postgres://USERNAME:PASSWORD@postgres.queryflux.svc.cluster.local:5432/queryflux
+  adminApi:
+    port: 9000
+  queryHistoryRetentionDays: 30
+
+auth:
+  provider: oidc
+  required: true
+  oidc:
+    issuer: https://idp.example.com/realms/queryflux
+    jwksUri: https://idp.example.com/realms/queryflux/protocol/openid-connect/certs
+    audience: queryflux
+    groupsClaim: groups
+    rolesClaim: roles
+
+authorization:
+  provider: none
+
+clusterGroups:
+  trino-default:
+    engine: trino
+    maxRunningQueries: 100
+    maxQueuedQueries: 200
+    capacityWaitTimeoutSecs: 300
+    clusters:
+      - name: trino-1
+        endpoint: http://trino.trino.svc.cluster.local:8080
+
+routers:
+  - type: protocolBased
+    trinoHttp: trino-default
+
+routingFallback: trino-default

--- a/charts/queryflux/examples/production-values.yaml
+++ b/charts/queryflux/examples/production-values.yaml
@@ -1,16 +1,18 @@
 # Production-oriented Helm values.
 #
+# Run the following from the repository root.
 # Before install:
 #   1. Create admin credentials Secret (do not put the password in values):
 #        kubectl create secret generic queryflux-admin \
 #          --from-literal=QUERYFLUX_ADMIN_USER=admin \
 #          --from-literal=QUERYFLUX_ADMIN_PASSWORD='<strong-password>'
-#   2. Copy examples/production-config.yaml, fill Postgres URL + OIDC (or static/
+#   2. Copy ./charts/queryflux/examples/production-config.yaml, fill Postgres URL + OIDC (or static/
 #      LDAP), then create the config Secret:
 #        kubectl create secret generic queryflux-config \
 #          --from-file=config.yaml=./production-config.yaml
 #   3. Create / reuse a TLS secret for ingress (queryflux-tls below).
-#   4. helm install queryflux ./charts/queryflux -f examples/production-values.yaml
+#   4. helm install queryflux ./charts/queryflux \
+#        -f ./charts/queryflux/examples/production-values.yaml
 #
 # Covers the production checklist: TLS, auth.required (in config Secret),
 # Postgres URL via config.existingSecret, PDB, ServiceMonitor, HPA, and

--- a/charts/queryflux/examples/production-values.yaml
+++ b/charts/queryflux/examples/production-values.yaml
@@ -1,49 +1,40 @@
-# Production-oriented example. Replace hosts, TLS secret, and backend endpoints.
+# Production-oriented Helm values.
+#
+# Before install:
+#   1. Create admin credentials Secret (do not put the password in values):
+#        kubectl create secret generic queryflux-admin \
+#          --from-literal=QUERYFLUX_ADMIN_USER=admin \
+#          --from-literal=QUERYFLUX_ADMIN_PASSWORD='<strong-password>'
+#   2. Copy examples/production-config.yaml, fill Postgres URL + OIDC (or static/
+#      LDAP), then create the config Secret:
+#        kubectl create secret generic queryflux-config \
+#          --from-file=config.yaml=./production-config.yaml
+#   3. Create / reuse a TLS secret for ingress (queryflux-tls below).
+#   4. helm install queryflux ./charts/queryflux -f examples/production-values.yaml
+#
+# Covers the production checklist: TLS, auth.required (in config Secret),
+# Postgres URL via config.existingSecret, PDB, ServiceMonitor, HPA, and
+# non-default admin Secret.
+
 replicaCount: 2
 
 image:
-  tag: latest
+  # Empty tag → chart appVersion (pin a release tag in real deploys; avoid "latest").
+  tag: ""
   pullPolicy: IfNotPresent
 
-adminCredentials:
-  username: admin
-  password: change-this-before-installing
+# Admin credentials come from a pre-created Secret — never ship default admin/admin.
+existingSecret:
+  name: queryflux-admin
+  usernameKey: QUERYFLUX_ADMIN_USER
+  passwordKey: QUERYFLUX_ADMIN_PASSWORD
 
-# NOTE: config.data is rendered into a ConfigMap, so any secret embedded here
-# (such as the Postgres password in persistence.url) is stored in plaintext.
-# QueryFlux does not interpolate environment variables into the config file, so
-# for production put the full config (including the Postgres URL) into a Secret
-# and reference it instead:
-#   config:
-#     create: false
-#     existingSecret: queryflux-config   # Secret with a config.yaml key
+# Config (including Postgres URL and OIDC client material) lives in a Secret so
+# credentials are not stored in a ConfigMap. See examples/production-config.yaml.
 config:
-  data:
-    queryflux:
-      externalAddress: https://queryflux.example.com
-      frontends:
-        trinoHttp:
-          enabled: true
-          port: 8080
-      persistence:
-        type: postgres
-        # Placeholder — replace USERNAME/PASSWORD/HOST. Prefer config.existingSecret
-        # (see note above) so credentials are not stored in plaintext.
-        url: postgres://USERNAME:PASSWORD@postgres.queryflux.svc.cluster.local:5432/queryflux
-      adminApi:
-        port: 9000
-      queryHistoryRetentionDays: 30
-    clusterGroups:
-      trino-default:
-        engine: trino
-        maxRunningQueries: 100
-        clusters:
-          - name: trino-1
-            endpoint: http://trino.trino.svc.cluster.local:8080
-    routers:
-      - type: protocolBased
-        trinoHttp: trino-default
-    routingFallback: trino-default
+  create: false
+  existingSecret: queryflux-config
+  fileName: config.yaml
 
 ingress:
   enabled: true
@@ -121,6 +112,16 @@ resources:
 
 # Keep ≥ queryflux.shutdownDrainTimeoutSecs (default 30) + buffer.
 terminationGracePeriodSeconds: 45
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: queryflux
 
 topologySpreadConstraints:
   - maxSkew: 1

--- a/charts/queryflux/values.yaml
+++ b/charts/queryflux/values.yaml
@@ -10,6 +10,8 @@
 #   6. resources          → set CPU/memory requests and limits
 #   7. ingress / TLS      → enable HTTPS termination
 #   8. config.existingSecret → use when config contains credentials
+#
+# Starter: examples/production-values.yaml + examples/production-config.yaml
 # ──────────────────────────────────────────────────────────────────────────────
 
 replicaCount: 1

--- a/scripts/check-helm-chart.sh
+++ b/scripts/check-helm-chart.sh
@@ -23,6 +23,7 @@ required_files=(
   "README.md"
   "examples/external-config-values.yaml"
   "examples/production-values.yaml"
+  "examples/production-config.yaml"
   "examples/networkpolicy-values.yaml"
   "values.yaml"
   "values.schema.json"
@@ -76,7 +77,7 @@ $output"
 run_helm "helm lint" helm lint "$CHART_DIR"
 run_helm "helm template" helm template queryflux "$CHART_DIR"
 
-for values_file in "$CHART_DIR"/examples/*.yaml; do
+for values_file in "$CHART_DIR"/examples/*-values.yaml; do
   run_helm "helm lint --values $values_file" helm lint "$CHART_DIR" --values "$values_file"
   run_helm "helm template --values $values_file" helm template queryflux "$CHART_DIR" --values "$values_file"
 done

--- a/website/docs/operations/multi-replica.md
+++ b/website/docs/operations/multi-replica.md
@@ -38,7 +38,7 @@ Do **not** set `replicaCount > 1` (or enable HPA) if any of the following hold:
 - [ ] If Snowflake HTTP is enabled: sticky sessions on that port, and set `frontends.snowflakeHttp.sessionAffinityAcknowledged: true` so the requirement is recorded in config
 - [ ] Prometheus scrape of admin `/metrics` (ServiceMonitor or equivalent)
 
-Starter values: [`charts/queryflux/examples/production-values.yaml`](https://github.com/lakeops-org/queryflux/blob/main/charts/queryflux/examples/production-values.yaml).
+Starter values: [`charts/queryflux/examples/production-values.yaml`](https://github.com/lakeops-org/queryflux/blob/main/charts/queryflux/examples/production-values.yaml) (pairs with [`production-config.yaml`](https://github.com/lakeops-org/queryflux/blob/main/charts/queryflux/examples/production-config.yaml) for the config Secret).
 
 ## Instance identity
 


### PR DESCRIPTION
## Summary
- Rework `examples/production-values.yaml` so production installs use pre-created **admin** and **config** Secrets (no plaintext Postgres URL or default admin password in values).
- Add `examples/production-config.yaml` with `auth.required: true`, OIDC placeholders, and shared Postgres persistence for multi-replica.
- Keep TLS ingress, HPA, PDB, ServiceMonitor, NetworkPolicy; pin image tag to chart `appVersion`; add preferred pod anti-affinity.
- Update chart README, values checklist comment, multi-replica runbook, and helm-check to only lint `*-values.yaml` examples.

## Test plan
- [x] `scripts/check-helm-chart.sh`
- [x] `helm template … -f examples/production-values.yaml` mounts `queryflux-admin` + `queryflux-config` and does not render a chart-owned ConfigMap/admin Secret


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded production deployment guidance to cover TLS ingress, autoscaling, disruption budgets, monitoring, network policies, topology distribution, and external Secrets.
  * Added instructions for creating and using a production configuration Secret, including authentication and PostgreSQL settings.
  * Updated multi-replica deployment guidance with links to the required production configuration.
* **Configuration**
  * Added a production configuration template with OIDC authentication, persistence, routing, query-history retention, and deployment security settings.
  * Updated production examples to use pinned image tags, pre-created Secrets, and hostname-based pod spreading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->