### PR TITLE
feat: add deny routing rules with Denied query history

### DIFF
--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -208,7 +208,9 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
             }
             RouterConfig::QueryRegex { rules } => {
                 for rule in rules {
-                    target_groups.push(rule.target_group.clone());
+                    if let Some(g) = &rule.target_group {
+                        target_groups.push(g.clone());
+                    }
                 }
             }
             RouterConfig::Tags { rules } => {

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -208,8 +208,10 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
             }
             RouterConfig::QueryRegex { rules } => {
                 for rule in rules {
-                    if let Some(g) = &rule.target_group {
-                        target_groups.push(g.clone());
+                    if matches!(rule.action, queryflux_core::config::RegexRouteAction::Route) {
+                        if let Some(g) = &rule.target_group {
+                            target_groups.push(g.clone());
+                        }
                     }
                 }
             }

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1258,7 +1258,24 @@ pub enum RouterConfig {
 #[serde(rename_all = "camelCase")]
 pub struct QueryRegexRule {
     pub regex: String,
-    pub target_group: String,
+    /// Cluster group to route to when [`Self::action`] is [`RegexRouteAction::Route`].
+    #[serde(default)]
+    pub target_group: Option<String>,
+    /// `route` (default) or `deny`.
+    #[serde(default)]
+    pub action: RegexRouteAction,
+    /// Client-visible message when [`Self::action`] is [`RegexRouteAction::Deny`].
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Action taken when a [`QueryRegexRule`] matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum RegexRouteAction {
+    #[default]
+    Route,
+    Deny,
 }
 
 /// A single rule in a [`RouterConfig::Tags`] router.
@@ -1481,7 +1498,8 @@ mod tests {
             RouterConfig::QueryRegex { rules } => {
                 assert_eq!(rules.len(), 1);
                 assert_eq!(rules[0].regex, "(?i)fact_");
-                assert_eq!(rules[0].target_group, "g-facts");
+                assert_eq!(rules[0].target_group.as_deref(), Some("g-facts"));
+                assert!(matches!(rules[0].action, super::RegexRouteAction::Route));
             }
             _ => panic!("expected queryRegex"),
         }

--- a/crates/queryflux-core/src/error.rs
+++ b/crates/queryflux-core/src/error.rs
@@ -26,6 +26,10 @@ pub enum QueryFluxError {
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
+    /// Rejected by a routing deny rule before dispatch. Message is safe to show to clients.
+    #[error("{0}")]
+    Denied(String),
+
     #[error("Query not found: {0}")]
     QueryNotFound(String),
 

--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -400,6 +400,8 @@ pub enum QueryStatus {
     Success,
     Failed,
     Cancelled,
+    /// Rejected by a routing deny rule before dispatch.
+    Denied,
 }
 
 #[cfg(test)]

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -2274,6 +2274,28 @@ async fn put_security_config_handler(
     }
 }
 
+/// Reject invalid query-regex patterns before persisting routing config.
+fn validate_query_regex_patterns(routers: &[serde_json::Value]) -> std::result::Result<(), String> {
+    use queryflux_routing::implementations::query_regex::QueryRegexRouter;
+
+    for router in routers {
+        if router.get("type").and_then(|t| t.as_str()) != Some("queryRegex") {
+            continue;
+        }
+        let Some(rules) = router.get("rules").and_then(|r| r.as_array()) else {
+            continue;
+        };
+        for rule in rules {
+            if let Some(regex) = rule.get("regex").and_then(|r| r.as_str()) {
+                if !regex.is_empty() {
+                    QueryRegexRouter::validate_pattern(regex)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Replace the routing configuration.
 #[utoipa::path(
     put,
@@ -2327,6 +2349,10 @@ async fn put_routing_config_handler(
             format!("routingFallback '{fallback_name}' is not a known cluster group"),
         )
             .into_response();
+    }
+
+    if let Err(msg) = validate_query_regex_patterns(&body.routers) {
+        return (StatusCode::BAD_REQUEST, msg).into_response();
     }
 
     let fallback_gid = body.routing_fallback_group_id.or_else(|| {

--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -46,6 +46,7 @@ use crate::abort::AbortOnDrop;
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx};
+use queryflux_routing::ChainRouteResult;
 
 // ── Frontend listener ─────────────────────────────────────────────────────────
 
@@ -213,7 +214,21 @@ impl FlightSqlService for QueryFluxFlightSql {
                 .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
                 .await
         };
-        let (group, _trace) = routing_result.map_err(|e| Status::internal(e.to_string()))?;
+        let (chain_result, routing_trace) =
+            routing_result.map_err(|e| Status::internal(e.to_string()))?;
+        let group = match chain_result {
+            ChainRouteResult::Routed(g) => g,
+            ChainRouteResult::Denied { message } => {
+                self.state.record_routing_deny(
+                    &sql,
+                    &session,
+                    protocol,
+                    &message,
+                    Some(routing_trace),
+                );
+                return Err(Status::permission_denied(message));
+            }
+        };
 
         // Channel: sink sends RecordBatches; FlightDataEncoderBuilder encodes them.
         let (tx, rx) =

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -43,6 +43,7 @@ use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx, MAX_FRONTEND_MESSAGE_BYTES};
+use queryflux_routing::ChainRouteResult;
 
 // ── MySQL command bytes ───────────────────────────────────────────────────────
 
@@ -380,10 +381,19 @@ async fn handle_com_query(
             .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (group, _trace) = match routing_result {
+    let (chain_result, routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             write_packet(writer, start_seq, &build_err(1105, &e.to_string())).await?;
+            return Ok(());
+        }
+    };
+    let group = match chain_result {
+        ChainRouteResult::Routed(g) => g,
+        ChainRouteResult::Denied { message } => {
+            state.record_routing_deny(sql, session, protocol, &message, Some(routing_trace));
+            // 1227 = ER_SPECIFIC_ACCESS_DENIED_ERROR
+            write_packet(writer, start_seq, &build_err(1227, &message)).await?;
             return Ok(());
         }
     };

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -35,6 +35,7 @@ use crate::abort::{wait_client_gone, AbortOnDrop};
 use crate::dispatch::{execute_to_sink, ResultSink};
 use crate::state::AppState;
 use crate::{FrontendListenerTrait, ShutdownRx, MAX_FRONTEND_MESSAGE_BYTES};
+use queryflux_routing::ChainRouteResult;
 
 // ── Postgres type OIDs (text-format only in V1) ───────────────────────────────
 
@@ -334,10 +335,20 @@ async fn handle_simple_query(
             .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (group, _trace) = match routing_result {
+    let (chain_result, routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             write_error_response(writer, "42000", &e.to_string()).await?;
+            write_msg(writer, b'Z', b"I").await?;
+            return Ok(());
+        }
+    };
+    let group = match chain_result {
+        ChainRouteResult::Routed(g) => g,
+        ChainRouteResult::Denied { message } => {
+            state.record_routing_deny(sql, session, protocol, &message, Some(routing_trace));
+            // 42501 = insufficient_privilege
+            write_error_response(writer, "42501", &message).await?;
             write_msg(writer, b'Z', b"I").await?;
             return Ok(());
         }

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -81,10 +81,10 @@ pub async fn login_request(
         extra: Default::default(),
         agent_context: None,
     };
-    let group = {
+    let routing_result = {
         let live = state.app.live.read().await;
         live.router_chain
-            .route(
+            .route_with_trace(
                 "",
                 &session_ctx,
                 &FrontendProtocol::SnowflakeHttp,
@@ -92,19 +92,22 @@ pub async fn login_request(
             )
             .await
     };
+    let (group, routing_trace) = match routing_result {
+        Ok((result, trace)) => (result, trace),
+        Err(e) => return sf_error("390000", &format!("Routing error: {e}")),
+    };
     let group = match group {
-        Ok(ChainRouteResult::Routed(g)) => g,
-        Ok(ChainRouteResult::Denied { message }) => {
+        ChainRouteResult::Routed(g) => g,
+        ChainRouteResult::Denied { message } => {
             state.app.record_routing_deny(
                 "",
                 &session_ctx,
                 FrontendProtocol::SnowflakeHttp,
                 &message,
-                None,
+                Some(routing_trace),
             );
             return sf_error("390201", &message);
         }
-        Err(e) => return sf_error("390000", &format!("Routing error: {e}")),
     };
 
     let token = state.sessions.create_session(

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -18,6 +18,7 @@ use crate::snowflake::http::handlers::common::{
     extract_snowflake_token, parse_snowflake_json_body,
 };
 use crate::snowflake::http::SnowflakeWireState;
+use queryflux_routing::ChainRouteResult;
 
 // ---------------------------------------------------------------------------
 // POST /session/v1/login-request
@@ -92,7 +93,17 @@ pub async fn login_request(
             .await
     };
     let group = match group {
-        Ok(g) => g,
+        Ok(ChainRouteResult::Routed(g)) => g,
+        Ok(ChainRouteResult::Denied { message }) => {
+            state.app.record_routing_deny(
+                "",
+                &session_ctx,
+                FrontendProtocol::SnowflakeHttp,
+                &message,
+                None,
+            );
+            return sf_error("390201", &message);
+        }
         Err(e) => return sf_error("390000", &format!("Routing error: {e}")),
     };
 

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -27,6 +27,7 @@ use crate::snowflake::http::handlers::bindings::bindings_to_params;
 use crate::snowflake::http::handlers::common::parse_snowflake_json_body;
 use crate::snowflake::http::SnowflakeWireState;
 use crate::snowflake::in_flight::{CancelOutcome, SnowflakeExecParams, SpawnExecuteResult};
+use queryflux_routing::ChainRouteResult;
 
 // ---------------------------------------------------------------------------
 // ResultSink that accumulates Arrow batches into SQL API v2 jsonv2 format
@@ -239,7 +240,17 @@ pub async fn submit_statement(
             .await
     };
     let group = match group {
-        Ok(g) => g,
+        Ok(ChainRouteResult::Routed(g)) => g,
+        Ok(ChainRouteResult::Denied { message }) => {
+            state.app.record_routing_deny(
+                &sql,
+                &session_ctx,
+                FrontendProtocol::SnowflakeSqlApi,
+                &message,
+                None,
+            );
+            return sql_api_error(StatusCode::FORBIDDEN, "390201", &message);
+        }
         Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
     };
 

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -228,10 +228,10 @@ pub async fn submit_statement(
         extra,
         agent_context: None,
     };
-    let group = {
+    let routing_result = {
         let live = state.app.live.read().await;
         live.router_chain
-            .route(
+            .route_with_trace(
                 &sql,
                 &session_ctx,
                 &FrontendProtocol::SnowflakeSqlApi,
@@ -239,19 +239,22 @@ pub async fn submit_statement(
             )
             .await
     };
+    let (group, routing_trace) = match routing_result {
+        Ok((result, trace)) => (result, trace),
+        Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
+    };
     let group = match group {
-        Ok(ChainRouteResult::Routed(g)) => g,
-        Ok(ChainRouteResult::Denied { message }) => {
+        ChainRouteResult::Routed(g) => g,
+        ChainRouteResult::Denied { message } => {
             state.app.record_routing_deny(
                 &sql,
                 &session_ctx,
                 FrontendProtocol::SnowflakeSqlApi,
                 &message,
-                None,
+                Some(routing_trace),
             );
             return sql_api_error(StatusCode::FORBIDDEN, "390201", &message);
         }
-        Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
     };
 
     let handle = Uuid::new_v4().to_string();

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -359,6 +359,55 @@ impl AppState {
         );
     }
 
+    /// Persist a `Denied` history row for a query rejected by a routing deny rule
+    /// before cluster selection / dispatch.
+    pub fn record_routing_deny(
+        &self,
+        sql: &str,
+        session: &SessionContext,
+        protocol: FrontendProtocol,
+        message: &str,
+        routing_trace: Option<RoutingTrace>,
+    ) -> ProxyQueryId {
+        let query_id = ProxyQueryId::new();
+        let dialect = protocol.default_dialect();
+        let ctx = QueryContext {
+            query_id: query_id.clone(),
+            sql: sql.to_string(),
+            session: session.clone(),
+            protocol,
+            group: ClusterGroupName(String::new()),
+            cluster: ClusterName(String::new()),
+            cluster_group_config_id: None,
+            cluster_config_id: None,
+            engine_type: EngineType::Undispatched,
+            src_dialect: dialect.clone(),
+            tgt_dialect: dialect,
+            was_translated: false,
+            translated_sql: None,
+            query_tags: session.tags.clone(),
+            query_params: vec![],
+            agent_context: session.agent_context.clone(),
+        };
+        self.record_query(
+            &ctx,
+            QueryOutcome {
+                backend_query_id: None,
+                status: QueryStatus::Denied,
+                execution_ms: 0,
+                rows: None,
+                error: Some(message.to_string()),
+                routing_trace,
+                engine_stats: None,
+                guard_actions: vec![],
+                was_guard_blocked: false,
+                queue_duration_ms: 0,
+                cache_hit: false,
+            },
+        );
+        query_id
+    }
+
     /// Persist a terminal audit row for a queued query that never reached an engine
     /// (capacity wait timeout, stale client disconnect).
     pub fn record_queued_terminal(&self, queued: &QueuedQuery, status: QueryStatus, reason: &str) {

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -387,7 +387,7 @@ impl AppState {
             translated_sql: None,
             query_tags: session.tags.clone(),
             query_params: vec![],
-            agent_context: session.agent_context.clone(),
+            agent_context: session.resolved_agent_context(),
         };
         self.record_query(
             &ctx,

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -26,6 +26,7 @@ use super::result_sink::TrinoHttpResultSink;
 use crate::dispatch::{dispatch_query, execute_to_sink, rewrite_trino_uri, DispatchOutcome};
 use crate::state::{AppState, QueryContext, QueryOutcome};
 use queryflux_persistence::QueueCoordinator;
+use queryflux_routing::ChainRouteResult;
 
 /// Stale-claim cutoff. Heartbeats must run more often than this while dispatch
 /// is in progress so a slow submit cannot look like a crashed replica.
@@ -162,6 +163,7 @@ fn client_safe_message(e: &QueryFluxError) -> &'static str {
         | Unauthorized(_)
         | QueryNotFound(_)
         | ClusterNotFound(_)
+        | Denied(_)
         | QueueFull { .. }
         | CapacityWaitTimeout { .. } => "",
         _ => "Internal error",
@@ -528,7 +530,7 @@ pub async fn post_statement(
             .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (group, _trace) = match routing_result {
+    let (chain_result, routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             warn!("Routing error: {e}");
@@ -541,6 +543,15 @@ pub async fn post_statement(
                 safe
             };
             return trino_error_response(&tmp_id.0, msg).into_response();
+        }
+    };
+    let group = match chain_result {
+        ChainRouteResult::Routed(g) => g,
+        ChainRouteResult::Denied { message } => {
+            warn!(%message, user = %auth_ctx.user, "Query denied by routing rule");
+            let query_id =
+                state.record_routing_deny(&sql, &session, protocol, &message, Some(routing_trace));
+            return trino_error_response(&query_id.0, &message).into_response();
         }
     };
 

--- a/crates/queryflux-persistence/src/routing_json.rs
+++ b/crates/queryflux-persistence/src/routing_json.rs
@@ -237,6 +237,21 @@ fn resolve_one_router_for_storage(v: &Value, id_to_name: &HashMap<i64, String>) 
                     arr.iter()
                         .map(|rule| {
                             let regex = field(rule, "regex", "regex").cloned().unwrap_or(json!(""));
+                            let action = rule
+                                .get("action")
+                                .and_then(|a| a.as_str())
+                                .unwrap_or("route");
+                            if action.eq_ignore_ascii_case("deny") {
+                                let mut out = Map::new();
+                                out.insert("regex".into(), regex);
+                                out.insert("action".into(), json!("deny"));
+                                if let Some(err) = rule.get("error") {
+                                    if !err.is_null() {
+                                        out.insert("error".into(), err.clone());
+                                    }
+                                }
+                                return Ok(Value::Object(out));
+                            }
                             let tg = field(rule, "targetGroup", "target_group")
                                 .or_else(|| rule.get("targetGroupId"));
                             let name = group_value_to_name(tg.unwrap_or(&Value::Null), id_to_name)?;

--- a/crates/queryflux-persistence/src/routing_json.rs
+++ b/crates/queryflux-persistence/src/routing_json.rs
@@ -245,10 +245,8 @@ fn resolve_one_router_for_storage(v: &Value, id_to_name: &HashMap<i64, String>) 
                                 let mut out = Map::new();
                                 out.insert("regex".into(), regex);
                                 out.insert("action".into(), json!("deny"));
-                                if let Some(err) = rule.get("error") {
-                                    if !err.is_null() {
-                                        out.insert("error".into(), err.clone());
-                                    }
+                                if let Some(err) = rule.get("error").and_then(|e| e.as_str()) {
+                                    out.insert("error".into(), json!(err));
                                 }
                                 return Ok(Value::Object(out));
                             }

--- a/crates/queryflux-persistence/src/routing_slices.rs
+++ b/crates/queryflux-persistence/src/routing_slices.rs
@@ -148,10 +148,8 @@ pub fn expand_router_for_persistence(
                         def.insert("type".into(), json!("_qfRegexLeg"));
                         def.insert("regex".into(), json!(regex));
                         def.insert("action".into(), json!("deny"));
-                        if let Some(err) = r.get("error") {
-                            if !err.is_null() {
-                                def.insert("error".into(), err.clone());
-                            }
+                        if let Some(err) = r.get("error").and_then(|e| e.as_str()) {
+                            def.insert("error".into(), json!(err));
                         }
                         out.push((Value::Object(def), None));
                         continue;
@@ -416,10 +414,8 @@ fn merge_regex_chunk(
             let mut rule = Map::new();
             rule.insert("regex".into(), json!(regex));
             rule.insert("action".into(), json!("deny"));
-            if let Some(err) = leg.definition.get("error") {
-                if !err.is_null() {
-                    rule.insert("error".into(), err.clone());
-                }
+            if let Some(err) = leg.definition.get("error").and_then(|e| e.as_str()) {
+                rule.insert("error".into(), json!(err));
             }
             rules.push(Value::Object(rule));
             continue;

--- a/crates/queryflux-persistence/src/routing_slices.rs
+++ b/crates/queryflux-persistence/src/routing_slices.rs
@@ -142,6 +142,20 @@ pub fn expand_router_for_persistence(
                         .and_then(|x| x.as_str())
                         .unwrap_or("")
                         .to_string();
+                    let action = r.get("action").and_then(|x| x.as_str()).unwrap_or("route");
+                    if action.eq_ignore_ascii_case("deny") {
+                        let mut def = Map::new();
+                        def.insert("type".into(), json!("_qfRegexLeg"));
+                        def.insert("regex".into(), json!(regex));
+                        def.insert("action".into(), json!("deny"));
+                        if let Some(err) = r.get("error") {
+                            if !err.is_null() {
+                                def.insert("error".into(), err.clone());
+                            }
+                        }
+                        out.push((Value::Object(def), None));
+                        continue;
+                    }
                     let tg = field(r, "targetGroup", "target_group")
                         .and_then(|x| x.as_str())
                         .unwrap_or("");
@@ -393,6 +407,23 @@ fn merge_regex_chunk(
             .and_then(|x| x.as_str())
             .unwrap_or("")
             .to_string();
+        let action = leg
+            .definition
+            .get("action")
+            .and_then(|x| x.as_str())
+            .unwrap_or("route");
+        if action.eq_ignore_ascii_case("deny") {
+            let mut rule = Map::new();
+            rule.insert("regex".into(), json!(regex));
+            rule.insert("action".into(), json!("deny"));
+            if let Some(err) = leg.definition.get("error") {
+                if !err.is_null() {
+                    rule.insert("error".into(), err.clone());
+                }
+            }
+            rules.push(Value::Object(rule));
+            continue;
+        }
         let gid = leg.target_group_id.ok_or_else(|| {
             QueryFluxError::Persistence("_qfRegexLeg missing target_group_id".into())
         })?;
@@ -621,5 +652,36 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["type"], json!("pythonScript"));
         assert_eq!(out[0]["script"], router["script"]);
+    }
+
+    #[test]
+    fn roundtrip_query_regex_deny_without_group() {
+        let router = json!({
+            "type": "queryRegex",
+            "rules": [{
+                "regex": "(?i)^\\\\s*DROP",
+                "action": "deny",
+                "error": "DDL blocked"
+            }]
+        });
+        let slices = expand_router_for_persistence(&router, &HashMap::new()).unwrap();
+        assert_eq!(slices.len(), 1);
+        assert!(slices[0].1.is_none());
+        assert_eq!(slices[0].0["type"], json!("_qfRegexLeg"));
+        assert_eq!(slices[0].0["action"], json!("deny"));
+
+        let row = RoutingRulePersistRow {
+            sort_order: 0,
+            router_logical_index: 0,
+            slice_index: 0,
+            target_group_id: None,
+            definition: slices[0].0.clone(),
+        };
+        let out = collapse_rows_to_routers(&[row], &HashMap::new()).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], json!("queryRegex"));
+        assert_eq!(out[0]["rules"][0]["action"], json!("deny"));
+        assert_eq!(out[0]["rules"][0]["error"], json!("DDL blocked"));
+        assert!(out[0]["rules"][0].get("targetGroup").is_none());
     }
 }

--- a/crates/queryflux-routing/src/chain.rs
+++ b/crates/queryflux-routing/src/chain.rs
@@ -6,15 +6,18 @@ use queryflux_core::{
 };
 use serde::Serialize;
 
-use crate::RouterTrait;
+use crate::{ChainRouteResult, RouterTrait, RoutingDecision};
 
 /// One router's evaluation result recorded in the trace.
 #[derive(Debug, Clone, Serialize)]
 pub struct RouterDecision {
     pub router_type: &'static str,
     pub matched: bool,
-    /// The group selected by this router, if it matched.
+    /// The group selected by this router, if it routed.
     pub result: Option<String>,
+    /// Present when this router denied the query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deny_message: Option<String>,
 }
 
 /// Full record of how a query was routed: every router that was evaluated,
@@ -24,10 +27,13 @@ pub struct RoutingTrace {
     pub decisions: Vec<RouterDecision>,
     pub final_group: String,
     pub used_fallback: bool,
+    /// Present when routing ended in a deny (final_group may be empty).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub denied: Option<String>,
 }
 
-/// Evaluates a list of routers in order; first non-None result wins.
-/// Falls back to the configured default group if all routers return None.
+/// Evaluates a list of routers in order; first Route or Deny wins.
+/// Falls back to the configured default group if all routers return NoMatch.
 pub struct RouterChain {
     routers: Vec<Box<dyn RouterTrait>>,
     fallback: ClusterGroupName,
@@ -38,33 +44,37 @@ impl RouterChain {
         Self { routers, fallback }
     }
 
-    /// Route and return only the target group (no trace overhead).
+    /// Route and return only the chain result (no trace overhead).
     pub async fn route(
         &self,
         sql: &str,
         session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&AuthContext>,
-    ) -> Result<ClusterGroupName> {
+    ) -> Result<ChainRouteResult> {
         for router in &self.routers {
-            if let Some(group) = router
+            match router
                 .route(sql, session, frontend_protocol, auth_ctx)
                 .await?
             {
-                return Ok(group);
+                RoutingDecision::Route(group) => return Ok(ChainRouteResult::Routed(group)),
+                RoutingDecision::Deny { message } => {
+                    return Ok(ChainRouteResult::Denied { message });
+                }
+                RoutingDecision::NoMatch => {}
             }
         }
-        Ok(self.fallback.clone())
+        Ok(ChainRouteResult::Routed(self.fallback.clone()))
     }
 
-    /// Route and return both the target group and a full routing trace for metrics/UI.
+    /// Route and return both the chain result and a full routing trace for metrics/UI.
     pub async fn route_with_trace(
         &self,
         sql: &str,
         session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&AuthContext>,
-    ) -> Result<(ClusterGroupName, RoutingTrace)> {
+    ) -> Result<(ChainRouteResult, RoutingTrace)> {
         let mut decisions = Vec::with_capacity(self.routers.len());
 
         for router in &self.routers {
@@ -72,24 +82,42 @@ impl RouterChain {
                 .route(sql, session, frontend_protocol, auth_ctx)
                 .await?
             {
-                Some(group) => {
+                RoutingDecision::Route(group) => {
                     decisions.push(RouterDecision {
                         router_type: router.type_name(),
                         matched: true,
                         result: Some(group.0.clone()),
+                        deny_message: None,
                     });
                     let trace = RoutingTrace {
                         decisions,
                         final_group: group.0.clone(),
                         used_fallback: false,
+                        denied: None,
                     };
-                    return Ok((group, trace));
+                    return Ok((ChainRouteResult::Routed(group), trace));
                 }
-                None => {
+                RoutingDecision::Deny { message } => {
+                    decisions.push(RouterDecision {
+                        router_type: router.type_name(),
+                        matched: true,
+                        result: None,
+                        deny_message: Some(message.clone()),
+                    });
+                    let trace = RoutingTrace {
+                        decisions,
+                        final_group: String::new(),
+                        used_fallback: false,
+                        denied: Some(message.clone()),
+                    };
+                    return Ok((ChainRouteResult::Denied { message }, trace));
+                }
+                RoutingDecision::NoMatch => {
                     decisions.push(RouterDecision {
                         router_type: router.type_name(),
                         matched: false,
                         result: None,
+                        deny_message: None,
                     });
                 }
             }
@@ -99,7 +127,8 @@ impl RouterChain {
             decisions,
             final_group: self.fallback.0.clone(),
             used_fallback: true,
+            denied: None,
         };
-        Ok((self.fallback.clone(), trace))
+        Ok((ChainRouteResult::Routed(self.fallback.clone()), trace))
     }
 }

--- a/crates/queryflux-routing/src/implementations/client_tags.rs
+++ b/crates/queryflux-routing/src/implementations/client_tags.rs
@@ -7,7 +7,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes based on Trino client tags (`X-Trino-Client-Tags` header).
 /// If the client sends any tag that matches a rule, that group is selected.
@@ -34,15 +34,15 @@ impl RouterTrait for ClientTagsRouter {
         session: &SessionContext,
         _frontend_protocol: &FrontendProtocol,
         _auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         // X-Trino-Client-Tags is a comma-separated list of tags stored in extra.
         if let Some(tags_header) = session.extra.get("x-trino-client-tags") {
             for tag in tags_header.split(',').map(|t| t.trim()) {
                 if let Some(group) = self.tag_to_group.get(tag) {
-                    return Ok(Some(group.clone()));
+                    return Ok(RoutingDecision::Route(group.clone()));
                 }
             }
         }
-        Ok(None)
+        Ok(RoutingDecision::NoMatch)
     }
 }

--- a/crates/queryflux-routing/src/implementations/compound.rs
+++ b/crates/queryflux-routing/src/implementations/compound.rs
@@ -8,7 +8,7 @@ use queryflux_core::{
 };
 use regex::Regex;
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 enum CompiledCondition {
     Protocol(FrontendProtocol),
@@ -144,11 +144,11 @@ impl RouterTrait for CompoundRouter {
         session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         if self.matches(sql, session, frontend_protocol, auth_ctx) {
-            Ok(Some(self.target.clone()))
+            Ok(RoutingDecision::Route(self.target.clone()))
         } else {
-            Ok(None)
+            Ok(RoutingDecision::NoMatch)
         }
     }
 }

--- a/crates/queryflux-routing/src/implementations/header.rs
+++ b/crates/queryflux-routing/src/implementations/header.rs
@@ -7,7 +7,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes based on a specific HTTP header value.
 /// Only applies to Trino HTTP frontend (other protocols don't have arbitrary headers).
@@ -38,10 +38,10 @@ impl RouterTrait for HeaderRouter {
         session: &SessionContext,
         _frontend_protocol: &FrontendProtocol,
         _auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         if let Some(value) = session.extra.get(&self.header_name) {
-            return Ok(self.mapping.get(value).cloned());
+            return Ok(self.mapping.get(value).cloned().into());
         }
-        Ok(None)
+        Ok(RoutingDecision::NoMatch)
     }
 }

--- a/crates/queryflux-routing/src/implementations/protocol_based.rs
+++ b/crates/queryflux-routing/src/implementations/protocol_based.rs
@@ -5,7 +5,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes based on which frontend protocol the client used.
 /// Useful for directing MySQL-wire clients (StarRocks) to a different group
@@ -32,7 +32,7 @@ impl RouterTrait for ProtocolBasedRouter {
         _session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         _auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         let group = match frontend_protocol {
             FrontendProtocol::TrinoHttp => self.trino_http.clone(),
             FrontendProtocol::PostgresWire => self.postgres_wire.clone(),
@@ -42,6 +42,6 @@ impl RouterTrait for ProtocolBasedRouter {
             FrontendProtocol::SnowflakeHttp => self.snowflake_http.clone(),
             FrontendProtocol::SnowflakeSqlApi => self.snowflake_sql_api.clone(),
         };
-        Ok(group)
+        Ok(group.into())
     }
 }

--- a/crates/queryflux-routing/src/implementations/python_script.rs
+++ b/crates/queryflux-routing/src/implementations/python_script.rs
@@ -8,7 +8,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes queries using a user-supplied Python function.
 ///
@@ -50,7 +50,7 @@ impl RouterTrait for PythonScriptRouter {
         session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         let sql = sql.to_string();
         let script = self.script.clone();
         let session = session.clone();
@@ -137,7 +137,7 @@ fn call_python_router(
     session: &SessionContext,
     protocol: FrontendProtocol,
     auth: Option<&AuthContext>,
-) -> Result<Option<ClusterGroupName>> {
+) -> Result<RoutingDecision> {
     Python::attach(|py| {
         let globals = PyDict::new(py);
         let cscript = std::ffi::CString::new(script)
@@ -163,13 +163,13 @@ fn call_python_router(
             })?;
 
         if result.is_none() {
-            return Ok(None);
+            return Ok(RoutingDecision::NoMatch);
         }
 
         let group: String = result.extract().map_err(|e| {
             QueryFluxError::Routing(format!("route() must return str or None: {e}"))
         })?;
 
-        Ok(Some(ClusterGroupName(group)))
+        Ok(RoutingDecision::Route(ClusterGroupName(group)))
     })
 }

--- a/crates/queryflux-routing/src/implementations/query_regex.rs
+++ b/crates/queryflux-routing/src/implementations/query_regex.rs
@@ -1,27 +1,35 @@
 use async_trait::async_trait;
 use queryflux_core::{
+    config::{QueryRegexRule, RegexRouteAction},
     error::Result,
     query::{ClusterGroupName, FrontendProtocol},
     session::SessionContext,
 };
 use regex::Regex;
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
+
+enum CompiledAction {
+    Route(ClusterGroupName),
+    Deny(String),
+}
 
 /// Routes based on regex patterns matched against the SQL text.
-/// Rules are evaluated in order — first match wins.
+/// Rules are evaluated in order — first match wins (route or deny).
 pub struct QueryRegexRouter {
-    rules: Vec<(Regex, ClusterGroupName)>,
+    rules: Vec<(Regex, CompiledAction)>,
 }
 
 impl QueryRegexRouter {
     /// Build from a list of (pattern, group) pairs. Skips rules with invalid regex
     /// and logs a warning so a bad pattern doesn't crash startup.
+    ///
+    /// Prefer [`Self::from_rules`] when deny actions are needed.
     pub fn new(rules: Vec<(String, String)>) -> Self {
         let compiled = rules
             .into_iter()
             .filter_map(|(pattern, group)| match Regex::new(&pattern) {
-                Ok(re) => Some((re, ClusterGroupName(group))),
+                Ok(re) => Some((re, CompiledAction::Route(ClusterGroupName(group)))),
                 Err(e) => {
                     tracing::warn!(
                         "QueryRegexRouter: skipping invalid regex {:?}: {}",
@@ -30,6 +38,48 @@ impl QueryRegexRouter {
                     );
                     None
                 }
+            })
+            .collect();
+        Self { rules: compiled }
+    }
+
+    /// Build from full [`QueryRegexRule`] config (supports `action: deny`).
+    pub fn from_rules(rules: Vec<QueryRegexRule>) -> Self {
+        let compiled = rules
+            .into_iter()
+            .filter_map(|rule| {
+                let re = match Regex::new(&rule.regex) {
+                    Ok(re) => re,
+                    Err(e) => {
+                        tracing::warn!(
+                            "QueryRegexRouter: skipping invalid regex {:?}: {}",
+                            rule.regex,
+                            e
+                        );
+                        return None;
+                    }
+                };
+                let action = match rule.action {
+                    RegexRouteAction::Deny => {
+                        let message = rule
+                            .error
+                            .filter(|s| !s.trim().is_empty())
+                            .unwrap_or_else(|| "Query denied by routing rule".to_string());
+                        CompiledAction::Deny(message)
+                    }
+                    RegexRouteAction::Route => {
+                        let Some(group) = rule.target_group.filter(|s| !s.is_empty()) else {
+                            tracing::warn!(
+                                "QueryRegexRouter: skipping route rule with empty targetGroup \
+                                 (regex={:?})",
+                                rule.regex
+                            );
+                            return None;
+                        };
+                        CompiledAction::Route(ClusterGroupName(group))
+                    }
+                };
+                Some((re, action))
             })
             .collect();
         Self { rules: compiled }
@@ -48,12 +98,71 @@ impl RouterTrait for QueryRegexRouter {
         _session: &SessionContext,
         _frontend_protocol: &FrontendProtocol,
         _auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
-        for (re, group) in &self.rules {
+    ) -> Result<RoutingDecision> {
+        for (re, action) in &self.rules {
             if re.is_match(sql) {
-                return Ok(Some(group.clone()));
+                return Ok(match action {
+                    CompiledAction::Route(group) => RoutingDecision::Route(group.clone()),
+                    CompiledAction::Deny(message) => RoutingDecision::Deny {
+                        message: message.clone(),
+                    },
+                });
             }
         }
-        Ok(None)
+        Ok(RoutingDecision::NoMatch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::config::QueryRegexRule;
+
+    #[tokio::test]
+    async fn deny_action_rejects_matching_sql() {
+        let router = QueryRegexRouter::from_rules(vec![QueryRegexRule {
+            regex: r"(?i)^\s*(INSERT|UPDATE|DELETE|DROP)".into(),
+            target_group: None,
+            action: RegexRouteAction::Deny,
+            error: Some("Writes are not permitted".into()),
+        }]);
+        let decision = router
+            .route(
+                "INSERT INTO t VALUES (1)",
+                &Default::default(),
+                &FrontendProtocol::TrinoHttp,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            decision,
+            RoutingDecision::Deny {
+                message: "Writes are not permitted".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn route_action_still_selects_group() {
+        let router = QueryRegexRouter::from_rules(vec![QueryRegexRule {
+            regex: r"(?i)from\s+prod\.".into(),
+            target_group: Some("heavy".into()),
+            action: RegexRouteAction::Route,
+            error: None,
+        }]);
+        let decision = router
+            .route(
+                "SELECT * FROM prod.orders",
+                &Default::default(),
+                &FrontendProtocol::TrinoHttp,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            decision,
+            RoutingDecision::Route(ClusterGroupName("heavy".into()))
+        );
     }
 }

--- a/crates/queryflux-routing/src/implementations/query_regex.rs
+++ b/crates/queryflux-routing/src/implementations/query_regex.rs
@@ -84,6 +84,13 @@ impl QueryRegexRouter {
             .collect();
         Self { rules: compiled }
     }
+
+    /// Validate a regex pattern using the same engine as runtime routing.
+    pub fn validate_pattern(pattern: &str) -> std::result::Result<(), String> {
+        Regex::new(pattern)
+            .map(|_| ())
+            .map_err(|e| format!("invalid regex: {e}"))
+    }
 }
 
 #[async_trait]

--- a/crates/queryflux-routing/src/implementations/tags.rs
+++ b/crates/queryflux-routing/src/implementations/tags.rs
@@ -7,7 +7,7 @@ use queryflux_core::{
     tags::QueryTags,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes queries based on tag key+value matching.
 ///
@@ -41,19 +41,21 @@ impl RouterTrait for TagsRouter {
         session: &SessionContext,
         _frontend_protocol: &FrontendProtocol,
         _auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         let session_tags = session.tags();
         if session_tags.is_empty() {
-            return Ok(None);
+            return Ok(RoutingDecision::NoMatch);
         }
 
         for rule in &self.rules {
             if rule_matches(&rule.tags, session_tags) {
-                return Ok(Some(ClusterGroupName(rule.target_group.clone())));
+                return Ok(RoutingDecision::Route(ClusterGroupName(
+                    rule.target_group.clone(),
+                )));
             }
         }
 
-        Ok(None)
+        Ok(RoutingDecision::NoMatch)
     }
 }
 
@@ -82,7 +84,7 @@ mod tests {
     };
 
     use super::TagsRouter;
-    use crate::RouterTrait;
+    use crate::{RouterTrait, RoutingDecision};
 
     fn group(name: &str) -> queryflux_core::query::ClusterGroupName {
         queryflux_core::query::ClusterGroupName(name.to_string())
@@ -121,7 +123,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("engineering")));
+        assert_eq!(result, Some(group("engineering")).into());
     }
 
     #[tokio::test]
@@ -135,7 +137,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, RoutingDecision::NoMatch);
     }
 
     #[tokio::test]
@@ -149,7 +151,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("batch-cluster")));
+        assert_eq!(result, Some(group("batch-cluster")).into());
     }
 
     #[tokio::test]
@@ -163,7 +165,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("batch-cluster")));
+        assert_eq!(result, Some(group("batch-cluster")).into());
     }
 
     #[tokio::test]
@@ -181,7 +183,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, RoutingDecision::NoMatch);
     }
 
     #[tokio::test]
@@ -201,7 +203,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("first")));
+        assert_eq!(result, Some(group("first")).into());
     }
 
     #[tokio::test]
@@ -215,7 +217,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("analytics")));
+        assert_eq!(result, Some(group("analytics")).into());
     }
 
     #[tokio::test]
@@ -229,7 +231,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, RoutingDecision::NoMatch);
     }
 
     #[tokio::test]
@@ -243,6 +245,6 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
             .await
             .unwrap();
-        assert_eq!(result, Some(group("engineering")));
+        assert_eq!(result, Some(group("engineering")).into());
     }
 }

--- a/crates/queryflux-routing/src/implementations/user_group.rs
+++ b/crates/queryflux-routing/src/implementations/user_group.rs
@@ -7,7 +7,7 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-use crate::RouterTrait;
+use crate::{RouterTrait, RoutingDecision};
 
 /// Routes by authenticated username → cluster group.
 ///
@@ -36,14 +36,14 @@ impl RouterTrait for UserGroupRouter {
         session: &SessionContext,
         _frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&queryflux_auth::AuthContext>,
-    ) -> Result<Option<ClusterGroupName>> {
+    ) -> Result<RoutingDecision> {
         let user = auth_ctx
             .map(|ctx| ctx.user.as_str())
             .or_else(|| session.user());
         if let Some(user) = user {
-            return Ok(self.mapping.get(user).cloned());
+            return Ok(self.mapping.get(user).cloned().into());
         }
-        Ok(None)
+        Ok(RoutingDecision::NoMatch)
     }
 }
 
@@ -83,7 +83,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(group, Some(ClusterGroupName("prod".into())));
+        assert_eq!(group, Some(ClusterGroupName("prod".into())).into());
     }
 
     #[tokio::test]
@@ -97,7 +97,7 @@ mod tests {
             .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
             .await
             .unwrap();
-        assert_eq!(group, Some(ClusterGroupName("dev".into())));
+        assert_eq!(group, Some(ClusterGroupName("dev".into())).into());
     }
 
     #[tokio::test]
@@ -118,6 +118,6 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(group, None);
+        assert_eq!(group, RoutingDecision::NoMatch);
     }
 }

--- a/crates/queryflux-routing/src/lib.rs
+++ b/crates/queryflux-routing/src/lib.rs
@@ -9,16 +9,43 @@ use queryflux_core::{
     session::SessionContext,
 };
 
-/// A router inspects an incoming query and optionally returns the target cluster group.
+/// Outcome of a single router's evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RoutingDecision {
+    /// Router did not match — try the next router in the chain.
+    NoMatch,
+    /// Route the query to this cluster group.
+    Route(ClusterGroupName),
+    /// Reject the query before dispatch with a client-visible message.
+    Deny { message: String },
+}
+
+impl From<Option<ClusterGroupName>> for RoutingDecision {
+    fn from(value: Option<ClusterGroupName>) -> Self {
+        match value {
+            Some(group) => Self::Route(group),
+            None => Self::NoMatch,
+        }
+    }
+}
+
+/// Final outcome of evaluating the full router chain (after fallback).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainRouteResult {
+    Routed(ClusterGroupName),
+    Denied { message: String },
+}
+
+/// A router inspects an incoming query and returns a routing decision.
 ///
-/// Routers are evaluated in order (a chain). The first router that returns `Some` wins.
-/// If all routers return `None`, the routing fallback group from config is used.
+/// Routers are evaluated in order (a chain). The first `Route` or `Deny` wins.
+/// If all routers return `NoMatch`, the routing fallback group from config is used.
 #[async_trait]
 pub trait RouterTrait: Send + Sync {
     /// Short name used in routing traces (e.g. `"Header"`, `"QueryRegex"`).
     fn type_name(&self) -> &'static str;
 
-    /// Route an incoming query to a cluster group.
+    /// Route an incoming query.
     ///
     /// `auth_ctx` is `None` during Phase 1 (NoneAuthProvider, no threading yet) and
     /// `Some` once authentication is wired into all frontends (Phase 2+).
@@ -30,5 +57,5 @@ pub trait RouterTrait: Send + Sync {
         session: &SessionContext,
         frontend_protocol: &FrontendProtocol,
         auth_ctx: Option<&AuthContext>,
-    ) -> Result<Option<ClusterGroupName>>;
+    ) -> Result<RoutingDecision>;
 }

--- a/crates/queryflux-routing/tests/router_tests.rs
+++ b/crates/queryflux-routing/tests/router_tests.rs
@@ -20,7 +20,7 @@ use queryflux_routing::{
         compound::CompoundRouter, header::HeaderRouter, protocol_based::ProtocolBasedRouter,
         python_script::PythonScriptRouter, query_regex::QueryRegexRouter, tags::TagsRouter,
     },
-    RouterTrait,
+    ChainRouteResult, RouterTrait, RoutingDecision,
 };
 
 // ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ async fn header_router_matches() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("analytics-group")));
+    assert_eq!(result, RoutingDecision::Route(group("analytics-group")));
 }
 
 #[tokio::test]
@@ -102,7 +102,7 @@ async fn header_router_value_not_in_mapping() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -116,7 +116,7 @@ async fn header_router_absent() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -135,7 +135,7 @@ async fn header_router_non_trino_session() {
         )
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +158,7 @@ async fn protocol_router_trino_http() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("trino-group")));
+    assert_eq!(result, RoutingDecision::Route(group("trino-group")));
 }
 
 #[tokio::test]
@@ -181,7 +181,7 @@ async fn protocol_router_postgres_wire() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("pg-group")));
+    assert_eq!(result, RoutingDecision::Route(group("pg-group")));
 }
 
 #[tokio::test]
@@ -204,7 +204,7 @@ async fn protocol_router_unconfigured() {
         )
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -227,7 +227,7 @@ async fn protocol_router_mysql_wire() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("mysql-group")));
+    assert_eq!(result, RoutingDecision::Route(group("mysql-group")));
 }
 
 #[tokio::test]
@@ -250,7 +250,7 @@ async fn protocol_router_clickhouse_http() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("ch-group")));
+    assert_eq!(result, RoutingDecision::Route(group("ch-group")));
 }
 
 #[tokio::test]
@@ -274,7 +274,7 @@ async fn protocol_router_flight_sql() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("sf-analytics")));
+    assert_eq!(result, RoutingDecision::Route(group("sf-analytics")));
 }
 
 #[tokio::test]
@@ -297,7 +297,7 @@ async fn protocol_router_snowflake_http() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("sf-wire")));
+    assert_eq!(result, RoutingDecision::Route(group("sf-wire")));
 }
 
 #[tokio::test]
@@ -320,7 +320,7 @@ async fn protocol_router_snowflake_sql_api() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("sf-rest")));
+    assert_eq!(result, RoutingDecision::Route(group("sf-rest")));
 }
 
 // ---------------------------------------------------------------------------
@@ -361,7 +361,7 @@ async fn tags_trino_key_only_match() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("premium-group")));
+    assert_eq!(result, RoutingDecision::Route(group("premium-group")));
 }
 
 #[tokio::test]
@@ -380,7 +380,7 @@ async fn tags_kv_match_postgres() {
         .route("SELECT 1", &session, &FrontendProtocol::PostgresWire, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("analytics-group")));
+    assert_eq!(result, RoutingDecision::Route(group("analytics-group")));
 }
 
 #[tokio::test]
@@ -395,7 +395,7 @@ async fn tags_kv_wrong_value_no_match() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -406,7 +406,7 @@ async fn tags_no_tags_no_match() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -424,7 +424,7 @@ async fn tags_and_logic_partial_no_match() {
         .route("SELECT 1", &session, &FrontendProtocol::MySqlWire, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 // ---------------------------------------------------------------------------
@@ -447,7 +447,7 @@ async fn query_regex_match() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("orders-group")));
+    assert_eq!(result, RoutingDecision::Route(group("orders-group")));
 }
 
 #[tokio::test]
@@ -466,7 +466,7 @@ async fn query_regex_no_match() {
         )
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -489,7 +489,7 @@ async fn query_regex_first_match_wins() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("orders-group")));
+    assert_eq!(result, RoutingDecision::Route(group("orders-group")));
 }
 
 #[tokio::test]
@@ -509,7 +509,7 @@ async fn query_regex_invalid_regex_skipped() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("orders-group")));
+    assert_eq!(result, RoutingDecision::Route(group("orders-group")));
 }
 
 #[tokio::test]
@@ -527,7 +527,7 @@ async fn query_regex_matches_under_postgres_protocol() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("cust-group")));
+    assert_eq!(result, RoutingDecision::Route(group("cust-group")));
 }
 
 // ---------------------------------------------------------------------------
@@ -553,7 +553,7 @@ async fn compound_all_both_match() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("premium-group")));
+    assert_eq!(result, RoutingDecision::Route(group("premium-group")));
 }
 
 #[tokio::test]
@@ -576,7 +576,7 @@ async fn compound_all_one_fails() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -599,7 +599,7 @@ async fn compound_any_first_matches() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("any-group")));
+    assert_eq!(result, RoutingDecision::Route(group("any-group")));
 }
 
 #[tokio::test]
@@ -622,7 +622,7 @@ async fn compound_any_none_match() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -639,7 +639,7 @@ async fn compound_client_tag_condition() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("team-a-group")));
+    assert_eq!(result, RoutingDecision::Route(group("team-a-group")));
 }
 
 #[tokio::test]
@@ -661,7 +661,7 @@ async fn compound_query_regex_condition() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("lineitem-group")));
+    assert_eq!(result, RoutingDecision::Route(group("lineitem-group")));
 }
 
 #[tokio::test]
@@ -679,7 +679,7 @@ async fn compound_header_condition_trino_http() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, Some(group("batch-group")));
+    assert_eq!(result, RoutingDecision::Route(group("batch-group")));
 }
 
 #[tokio::test]
@@ -702,7 +702,7 @@ async fn compound_header_condition_clickhouse_http() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("olap-group")));
+    assert_eq!(result, RoutingDecision::Route(group("olap-group")));
 }
 
 #[tokio::test]
@@ -723,7 +723,7 @@ async fn compound_user_matches_mysql_session_user() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("mysql-users")));
+    assert_eq!(result, RoutingDecision::Route(group("mysql-users")));
 }
 
 #[tokio::test]
@@ -751,7 +751,7 @@ async fn compound_user_prefers_auth_context_over_session_header() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("auth-wins")));
+    assert_eq!(result, RoutingDecision::Route(group("auth-wins")));
 }
 
 #[tokio::test]
@@ -772,7 +772,7 @@ async fn compound_protocol_mysql_wire() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("mysql-only")));
+    assert_eq!(result, RoutingDecision::Route(group("mysql-only")));
 }
 
 #[tokio::test]
@@ -793,7 +793,7 @@ async fn compound_protocol_clickhouse_http() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("ch-only")));
+    assert_eq!(result, RoutingDecision::Route(group("ch-only")));
 }
 
 #[tokio::test]
@@ -814,7 +814,7 @@ async fn compound_protocol_flight_sql() {
         )
         .await
         .unwrap();
-    assert_eq!(result, Some(group("flight-only")));
+    assert_eq!(result, RoutingDecision::Route(group("flight-only")));
 }
 
 #[tokio::test]
@@ -825,7 +825,7 @@ async fn compound_empty_conditions_never_matches() {
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 #[tokio::test]
@@ -846,7 +846,7 @@ async fn compound_only_invalid_regex_conditions_never_matches() {
         )
         .await
         .unwrap();
-    assert_eq!(result, None);
+    assert_eq!(result, RoutingDecision::NoMatch);
 }
 
 // ---------------------------------------------------------------------------
@@ -867,7 +867,7 @@ def route(query, ctx):
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(out, Some(group("g-trino")));
+    assert_eq!(out, RoutingDecision::Route(group("g-trino")));
 }
 
 #[tokio::test]
@@ -896,7 +896,7 @@ def route(query, ctx):
         )
         .await
         .unwrap();
-    assert_eq!(out, Some(group("admin-group")));
+    assert_eq!(out, RoutingDecision::Route(group("admin-group")));
 }
 
 #[tokio::test]
@@ -911,7 +911,7 @@ def route(query, ctx):
         .route("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(out, None);
+    assert_eq!(out, RoutingDecision::NoMatch);
 }
 
 // ---------------------------------------------------------------------------
@@ -938,7 +938,7 @@ async fn chain_first_router_matches() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("analytics-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("analytics-group")));
     assert!(!trace.used_fallback);
 }
 
@@ -956,7 +956,7 @@ async fn chain_fallback_when_no_match() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("fallback-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("fallback-group")));
     assert!(trace.used_fallback);
 }
 
@@ -1009,7 +1009,7 @@ async fn chain_second_router_matches() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("second-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("second-group")));
     assert!(!trace.used_fallback);
     assert_eq!(trace.decisions.len(), 2);
     assert!(!trace.decisions[0].matched); // first router missed
@@ -1036,7 +1036,7 @@ async fn chain_short_circuits_after_first_match() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("priority-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("priority-group")));
     assert!(!trace.used_fallback);
     assert_eq!(
         trace.decisions.len(),
@@ -1066,7 +1066,7 @@ async fn chain_regex_then_header_first_wins_on_both_match() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("regex-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("regex-group")));
     assert_eq!(trace.decisions.len(), 1);
     assert!(trace.decisions[0].matched);
 }
@@ -1091,7 +1091,7 @@ async fn chain_regex_miss_then_header_match() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("api-group"));
+    assert_eq!(result, ChainRouteResult::Routed(group("api-group")));
     assert_eq!(trace.decisions.len(), 2);
     assert!(!trace.decisions[0].matched);
     assert!(trace.decisions[1].matched);
@@ -1122,8 +1122,44 @@ async fn chain_protocol_based_then_header_fallback() {
         .route_with_trace("SELECT 1", &session, &FrontendProtocol::TrinoHttp, None)
         .await
         .unwrap();
-    assert_eq!(result, group("tenant-acme"));
+    assert_eq!(result, ChainRouteResult::Routed(group("tenant-acme")));
     assert_eq!(trace.decisions.len(), 2);
     assert!(!trace.decisions[0].matched);
     assert!(trace.decisions[1].matched);
+}
+
+#[tokio::test]
+async fn chain_deny_short_circuits_before_later_routers() {
+    use queryflux_core::config::{QueryRegexRule, RegexRouteAction};
+
+    let chain = RouterChain::new(
+        vec![
+            Box::new(QueryRegexRouter::from_rules(vec![QueryRegexRule {
+                regex: r"(?i)^\s*DROP".into(),
+                target_group: None,
+                action: RegexRouteAction::Deny,
+                error: Some("DDL denied".into()),
+            }])),
+            Box::new(HeaderRouter::new(
+                "x-group".to_string(),
+                HashMap::from([("analytics".to_string(), group("analytics-group"))]),
+            )),
+        ],
+        group("fallback-group"),
+    );
+    let session = trino_session(&[("x-group", "analytics")]);
+    let (result, trace) = chain
+        .route_with_trace("DROP TABLE t", &session, &FrontendProtocol::TrinoHttp, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        ChainRouteResult::Denied {
+            message: "DDL denied".into()
+        }
+    );
+    assert_eq!(trace.denied.as_deref(), Some("DDL denied"));
+    assert!(trace.final_group.is_empty());
+    assert_eq!(trace.decisions.len(), 1);
+    assert!(trace.decisions[0].matched);
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -1987,14 +1987,15 @@ fn validate_live_config_refs(
                 refs.extend(user_to_group.values().map(String::as_str));
             }
             RouterConfig::QueryRegex { rules } => {
-                refs.extend(
-                    rules
-                        .iter()
-                        .filter(|r| {
-                            matches!(r.action, queryflux_core::config::RegexRouteAction::Route)
-                        })
-                        .filter_map(|r| r.target_group.as_deref()),
-                );
+                for rule in rules {
+                    if matches!(rule.action, queryflux_core::config::RegexRouteAction::Route) {
+                        if let Some(group) = rule.target_group.as_deref() {
+                            refs.push(group);
+                        } else {
+                            issues.push("queryRegex route rule requires targetGroup".to_string());
+                        }
+                    }
+                }
             }
             RouterConfig::Tags { rules } => {
                 refs.extend(rules.iter().map(|r| r.target_group.as_str()));

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -603,11 +603,7 @@ async fn main() -> Result<()> {
                 routers.push(Box::new(UserGroupRouter::new(mapping)));
             }
             RouterConfig::QueryRegex { rules } => {
-                let pairs = rules
-                    .iter()
-                    .map(|r| (r.regex.clone(), r.target_group.clone()))
-                    .collect();
-                routers.push(Box::new(QueryRegexRouter::new(pairs)));
+                routers.push(Box::new(QueryRegexRouter::from_rules(rules.clone())));
             }
             RouterConfig::Tags { rules } => {
                 routers.push(Box::new(TagsRouter::new(rules.clone())));
@@ -1991,7 +1987,14 @@ fn validate_live_config_refs(
                 refs.extend(user_to_group.values().map(String::as_str));
             }
             RouterConfig::QueryRegex { rules } => {
-                refs.extend(rules.iter().map(|r| r.target_group.as_str()));
+                refs.extend(
+                    rules
+                        .iter()
+                        .filter(|r| {
+                            matches!(r.action, queryflux_core::config::RegexRouteAction::Route)
+                        })
+                        .filter_map(|r| r.target_group.as_deref()),
+                );
             }
             RouterConfig::Tags { rules } => {
                 refs.extend(rules.iter().map(|r| r.target_group.as_str()));
@@ -2297,12 +2300,10 @@ async fn build_live_config(
                 ));
             }
             RouterConfig::QueryRegex { rules } => {
-                let pairs = rules
-                    .iter()
-                    .map(|r| (r.regex.clone(), r.target_group.clone()))
-                    .collect();
                 routers.push(Box::new(
-                    queryflux_routing::implementations::query_regex::QueryRegexRouter::new(pairs),
+                    queryflux_routing::implementations::query_regex::QueryRegexRouter::from_rules(
+                        rules.clone(),
+                    ),
                 ));
             }
             RouterConfig::Tags { rules } => {

--- a/queryflux-studio/app/queries/page.tsx
+++ b/queryflux-studio/app/queries/page.tsx
@@ -84,6 +84,7 @@ export default async function QueriesPage({ searchParams }: Props) {
             <option value="Success">Success</option>
             <option value="Failed">Failed</option>
             <option value="Cancelled">Cancelled</option>
+            <option value="Denied">Denied</option>
           </select>
           <select
             name="engine"

--- a/queryflux-studio/app/routing/routing-editor.tsx
+++ b/queryflux-studio/app/routing/routing-editor.tsx
@@ -91,6 +91,10 @@ interface FlatRule {
   tagValue: string;
   // regex
   regex: string;
+  /** SQL regex action: route (default) or deny. */
+  regexAction: "route" | "deny";
+  /** Client-visible message when regexAction is deny. */
+  denyError: string;
   // protocol
   protocol: string;
   // shared — cluster_group_configs.id
@@ -133,6 +137,8 @@ function blankRule(ruleType: FlatRuleType): FlatRule {
     tagKey: "",
     tagValue: "",
     regex: "",
+    regexAction: "route",
+    denyError: "",
     protocol: "trinoHttp",
     targetGroupId: null,
   };
@@ -235,7 +241,14 @@ function flatRuleToChainItem(rule: FlatRule): ChainItem {
     case "tag":
       return { id, kind: "tag", tagKey: rule.tagKey, tagValue: rule.tagValue, targetGroupId: rule.targetGroupId };
     case "regex":
-      return { id, kind: "regex", regex: rule.regex, targetGroupId: rule.targetGroupId };
+      return {
+        id,
+        kind: "regex",
+        regex: rule.regex,
+        action: rule.regexAction,
+        error: rule.denyError,
+        targetGroupId: rule.regexAction === "deny" ? null : rule.targetGroupId,
+      };
     case "protocol":
       return {
         id,
@@ -774,19 +787,24 @@ function NewRuleForm({
   const [form, setForm] = useState<FlatRule>(blankRule("header"));
 
   const isValid =
-    form.targetGroupId != null &&
     (() => {
       switch (form.ruleType) {
         case "header":
-          return form.headerName.trim() !== "" && form.headerValue.trim() !== "";
+          return (
+            form.targetGroupId != null &&
+            form.headerName.trim() !== "" &&
+            form.headerValue.trim() !== ""
+          );
         case "user":
-          return form.username.trim() !== "";
+          return form.targetGroupId != null && form.username.trim() !== "";
         case "tag":
-          return form.tagKey.trim() !== "";
+          return form.targetGroupId != null && form.tagKey.trim() !== "";
         case "regex":
-          return form.regex.trim() !== "";
+          if (form.regex.trim() === "") return false;
+          if (form.regexAction === "deny") return true;
+          return form.targetGroupId != null;
         case "protocol":
-          return form.protocol !== "";
+          return form.targetGroupId != null && form.protocol !== "";
       }
     })();
 
@@ -879,11 +897,47 @@ function NewRuleForm({
         )}
 
         {form.ruleType === "regex" && (
-          <div className="flex-1 min-w-[220px]">
-            <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
-              Regex pattern
-            </label>
-            {input("^SELECT.*fact_", form.regex, (v) => setForm((f) => ({ ...f, regex: v })), "w-full")}
+          <div className="flex-1 min-w-[220px] space-y-3">
+            <div>
+              <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
+                Regex pattern
+              </label>
+              {input("^SELECT.*fact_", form.regex, (v) => setForm((f) => ({ ...f, regex: v })), "w-full")}
+            </div>
+            <div className="flex flex-wrap gap-3 items-end">
+              <div>
+                <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
+                  Action
+                </label>
+                <select
+                  className="px-2.5 py-1.5 text-xs rounded-lg border border-slate-200 bg-white text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                  value={form.regexAction}
+                  onChange={(e) =>
+                    setForm((f) => ({
+                      ...f,
+                      regexAction: e.target.value as "route" | "deny",
+                      targetGroupId: e.target.value === "deny" ? null : f.targetGroupId,
+                    }))
+                  }
+                >
+                  <option value="route">Route</option>
+                  <option value="deny">Deny</option>
+                </select>
+              </div>
+              {form.regexAction === "deny" && (
+                <div className="flex-1 min-w-[180px]">
+                  <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
+                    Error message
+                  </label>
+                  {input(
+                    "Query denied by routing rule",
+                    form.denyError,
+                    (v) => setForm((f) => ({ ...f, denyError: v })),
+                    "w-full",
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         )}
 
@@ -911,16 +965,22 @@ function NewRuleForm({
           <ArrowRight size={14} />
         </div>
 
-        {/* Target group */}
+        {/* Target group / deny */}
         <div>
           <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1">
-            Route to group
+            {form.ruleType === "regex" && form.regexAction === "deny" ? "Outcome" : "Route to group"}
           </label>
-          <GroupSelectById
-            valueId={form.targetGroupId}
-            onChangeId={(id) => setForm((f) => ({ ...f, targetGroupId: id }))}
-            groups={groups}
-          />
+          {form.ruleType === "regex" && form.regexAction === "deny" ? (
+            <span className="inline-flex items-center px-2.5 py-1.5 text-xs font-semibold rounded-lg bg-amber-50 text-amber-800 ring-1 ring-amber-200">
+              Deny query
+            </span>
+          ) : (
+            <GroupSelectById
+              valueId={form.targetGroupId}
+              onChangeId={(id) => setForm((f) => ({ ...f, targetGroupId: id }))}
+              groups={groups}
+            />
+          )}
         </div>
       </div>
 
@@ -962,6 +1022,7 @@ function SortableChainRow({
   onEditCompound,
   onEditPython,
   onSetTargetGroup,
+  onSetDenyError,
 }: {
   item: ChainItem;
   index: number;
@@ -973,6 +1034,7 @@ function SortableChainRow({
   onEditCompound: () => void;
   onEditPython: () => void;
   onSetTargetGroup: (id: number | null) => void;
+  onSetDenyError: (error: string) => void;
 }) {
   const {
     attributes,
@@ -1063,6 +1125,18 @@ function SortableChainRow({
           <span className="text-slate-400 text-[11px]">
             {item.kind === "pythonScript" ? "— (group from script)" : "— (see raw config)"}
           </span>
+        ) : item.kind === "regex" && item.action === "deny" ? (
+          <div className="space-y-1">
+            <span className="inline-flex items-center px-2 py-0.5 text-[11px] font-semibold rounded-md bg-amber-50 text-amber-800 ring-1 ring-amber-200">
+              Deny
+            </span>
+            <input
+              className="w-full max-w-[220px] px-2 py-1 text-[11px] rounded-md border border-slate-200 bg-white text-slate-700 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              placeholder="Query denied by routing rule"
+              value={item.error}
+              onChange={(e) => onSetDenyError(e.target.value)}
+            />
+          </div>
         ) : (
           <GroupSelectById
             valueId={item.targetGroupId}
@@ -1234,6 +1308,12 @@ export function RoutingEditor({ initialRouting, groups }: RoutingEditorProps) {
     );
   }
 
+  function setChainItemDenyError(id: string, error: string) {
+    setChainItems((items) =>
+      items.map((x) => (x.id === id && x.kind === "regex" ? { ...x, error } : x)),
+    );
+  }
+
   const saveRoutingConfig = async () => {
     setRoutingSaving(true);
     setRoutingMsg(null);
@@ -1259,7 +1339,7 @@ export function RoutingEditor({ initialRouting, groups }: RoutingEditorProps) {
         <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Routing</h1>
         <p className="text-sm text-slate-500 mt-1">
           Request routing rules and fallback group. Rules are evaluated <strong>top to bottom</strong>; the{" "}
-          <strong>first</strong> rule that selects a group wins. Reorder by dragging the grip in the first
+          <strong>first</strong> rule that selects a group or denies the query wins. Reorder by dragging the grip in the first
           column (or use ↑ ↓).{" "}
           <Link href="/security" className="text-indigo-600 hover:text-indigo-700 font-medium">
             Security &amp; auth
@@ -1356,6 +1436,7 @@ export function RoutingEditor({ initialRouting, groups }: RoutingEditorProps) {
                               openPythonDialogEdit(item.id, item.script);
                             }}
                             onSetTargetGroup={(id) => setChainItemTargetGroup(item.id, id)}
+                            onSetDenyError={(error) => setChainItemDenyError(item.id, error)}
                           />
                         ))}
                       </SortableContext>

--- a/queryflux-studio/app/routing/routing-editor.tsx
+++ b/queryflux-studio/app/routing/routing-editor.tsx
@@ -801,6 +801,11 @@ function NewRuleForm({
           return form.targetGroupId != null && form.tagKey.trim() !== "";
         case "regex":
           if (form.regex.trim() === "") return false;
+          try {
+            new RegExp(form.regex);
+          } catch {
+            return false;
+          }
           if (form.regexAction === "deny") return true;
           return form.targetGroupId != null;
         case "protocol":
@@ -813,11 +818,13 @@ function NewRuleForm({
     value: string,
     onChange: (v: string) => void,
     extraClass = "",
+    ariaLabel?: string,
   ) => (
     <input
       className={`px-2.5 py-1.5 text-xs rounded-lg border border-slate-200 bg-white text-slate-900 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300 ${extraClass}`}
       placeholder={placeholder}
       value={value}
+      aria-label={ariaLabel}
       onChange={(e) => onChange(e.target.value)}
     />
   );
@@ -934,6 +941,7 @@ function NewRuleForm({
                     form.denyError,
                     (v) => setForm((f) => ({ ...f, denyError: v })),
                     "w-full",
+                    "Denial message",
                   )}
                 </div>
               )}
@@ -1131,6 +1139,7 @@ function SortableChainRow({
               Deny
             </span>
             <input
+              aria-label="Denial message"
               className="w-full max-w-[220px] px-2 py-1 text-[11px] rounded-md border border-slate-200 bg-white text-slate-700 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-300"
               placeholder="Query denied by routing rule"
               value={item.error}
@@ -1318,6 +1327,15 @@ export function RoutingEditor({ initialRouting, groups }: RoutingEditorProps) {
     setRoutingSaving(true);
     setRoutingMsg(null);
     try {
+      for (const item of chainItems) {
+        if (item.kind === "regex" && item.regex.trim() !== "") {
+          try {
+            new RegExp(item.regex);
+          } catch {
+            throw new Error(`Invalid regex pattern: ${item.regex}`);
+          }
+        }
+      }
       await putRoutingConfig({
         routingFallbackGroupId: routingFallbackId,
         routingFallback: "",

--- a/queryflux-studio/components/ui-helpers.tsx
+++ b/queryflux-studio/components/ui-helpers.tsx
@@ -7,11 +7,13 @@ export function StatusBadge({ status }: { status: string }) {
     Success: "bg-emerald-50 text-emerald-700 ring-emerald-200",
     Failed: "bg-red-50 text-red-600 ring-red-200",
     Cancelled: "bg-slate-100 text-slate-500 ring-slate-200",
+    Denied: "bg-amber-50 text-amber-800 ring-amber-200",
   };
   const dots: Record<string, string> = {
     Success: "bg-emerald-400",
     Failed: "bg-red-400",
     Cancelled: "bg-slate-400",
+    Denied: "bg-amber-500",
   };
   const cls = styles[status] ?? "bg-slate-100 text-slate-500 ring-slate-200";
   const dot = dots[status] ?? "bg-slate-400";

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -413,6 +413,8 @@ export interface RouterConfigEntry {
         target_group?: string;
         targetGroup?: string;
         targetGroupId?: number;
+        action?: "route" | "deny";
+        error?: string;
       }
     | TagRoutingRule
   >;

--- a/queryflux-studio/lib/routing-chain.ts
+++ b/queryflux-studio/lib/routing-chain.ts
@@ -22,7 +22,16 @@ export type ChainItem =
       tagValue: string;
       targetGroupId: number | null;
     }
-  | { id: string; kind: "regex"; regex: string; targetGroupId: number | null }
+  | {
+      id: string;
+      kind: "regex";
+      regex: string;
+      /** `route` (default) or `deny`. */
+      action: "route" | "deny";
+      /** Client-visible message when action is deny. */
+      error: string;
+      targetGroupId: number | null;
+    }
   | {
       id: string;
       kind: "compound";
@@ -152,14 +161,19 @@ export function routersToChainItems(
       case "queryRegex": {
         for (const rule of router.rules ?? []) {
           if (!rule || typeof rule !== "object" || !("regex" in rule)) continue;
+          const action = rule.action === "deny" ? "deny" : "route";
           const tgName = rule.targetGroup ?? rule.target_group;
           const gid =
-            (typeof rule.targetGroupId === "number" ? rule.targetGroupId : undefined) ??
-            cellToGroupId(tgName, byName);
+            action === "deny"
+              ? null
+              : (typeof rule.targetGroupId === "number" ? rule.targetGroupId : undefined) ??
+                cellToGroupId(tgName, byName);
           out.push({
             id: uid(),
             kind: "regex",
             regex: rule.regex,
+            action,
+            error: typeof rule.error === "string" ? rule.error : "",
             targetGroupId: gid,
           });
         }
@@ -260,6 +274,19 @@ export function chainItemsToRouters(items: ChainItem[]): RouterConfigEntry[] {
         break;
       }
       case "regex": {
+        if (item.action === "deny") {
+          result.push({
+            type: "queryRegex",
+            rules: [
+              {
+                regex: item.regex,
+                action: "deny",
+                ...(item.error.trim() !== "" ? { error: item.error.trim() } : {}),
+              },
+            ],
+          });
+          break;
+        }
         if (item.targetGroupId == null) continue;
         result.push({
           type: "queryRegex",


### PR DESCRIPTION
## Summary
- Add `action: deny` for `queryRegex` routing rules (`RoutingDecision` / `ChainRouteResult`), with optional client-visible `error` message.
- Frontends return protocol-correct errors (Trino JSON, MySQL 1227, Postgres `42501`, Flight `permission_denied`, Snowflake FORBIDDEN) and persist history as `QueryStatus::Denied`.
- Persist deny legs without a target group; Studio routing editor can create/edit deny regex rules; queries page filters Denied status.

## Test plan
- [ ] Unit: `cargo test -p queryflux-routing -p queryflux-persistence`
- [ ] Configure a `queryRegex` deny rule (YAML or Studio), submit matching SQL via Trino HTTP — expect FAILED + deny message and a Denied history row
- [ ] Confirm route rules still work when `action` omitted / `route`
- [ ] Save a deny rule from Studio, reload page — rule survives round-trip


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQL regex routing rules with **route** or **deny** actions.
  * Denial rules can include a client-visible message without selecting a target group.
  * Added a **Denied** query status, filtering, routing traces, and query history details.
* **Bug Fixes**
  * Denied requests stop before dispatch and return protocol-specific permission errors.
  * Optional target groups and invalid regex patterns are handled correctly.
* **Documentation**
  * Clarified that the first matching route or denial rule takes effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->