### PR TITLE
feat: authorization-aware first-fit when routing uses fallback

### DIFF
--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -214,9 +214,9 @@ impl FlightSqlService for QueryFluxFlightSql {
                 .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
                 .await
         };
-        let (chain_result, routing_trace) =
+        let (chain_result, mut routing_trace) =
             routing_result.map_err(|e| Status::internal(e.to_string()))?;
-        let group = match chain_result {
+        let mut group = match chain_result {
             ChainRouteResult::Routed(g) => g,
             ChainRouteResult::Denied { message } => {
                 self.state.record_routing_deny(
@@ -229,6 +229,14 @@ impl FlightSqlService for QueryFluxFlightSql {
                 return Err(Status::permission_denied(message));
             }
         };
+        group = self
+            .state
+            .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+            .await
+            .map_err(|e| match e {
+                QueryFluxError::Unauthorized(msg) => Status::permission_denied(msg),
+                other => Status::internal(other.to_string()),
+            })?;
 
         // Channel: sink sends RecordBatches; FlightDataEncoderBuilder encodes them.
         let (tx, rx) =

--- a/crates/queryflux-frontend/src/lib.rs
+++ b/crates/queryflux-frontend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dispatch;
 pub mod flight_sql;
 pub mod mysql_wire;
 pub mod postgres_wire;
+pub mod routing_resolve;
 pub mod snowflake;
 pub mod state;
 pub mod tee_sink;

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -381,19 +381,33 @@ async fn handle_com_query(
             .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (chain_result, routing_trace) = match routing_result {
+    let (chain_result, mut routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             write_packet(writer, start_seq, &build_err(1105, &e.to_string())).await?;
             return Ok(());
         }
     };
-    let group = match chain_result {
+    let mut group = match chain_result {
         ChainRouteResult::Routed(g) => g,
         ChainRouteResult::Denied { message } => {
             state.record_routing_deny(sql, session, protocol, &message, Some(routing_trace));
             // 1227 = ER_SPECIFIC_ACCESS_DENIED_ERROR
             write_packet(writer, start_seq, &build_err(1227, &message)).await?;
+            return Ok(());
+        }
+    };
+    group = match state
+        .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(QueryFluxError::Unauthorized(msg)) => {
+            write_packet(writer, start_seq, &build_err(1227, &msg)).await?;
+            return Ok(());
+        }
+        Err(e) => {
+            write_packet(writer, start_seq, &build_err(1105, &e.to_string())).await?;
             return Ok(());
         }
     };

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -335,7 +335,7 @@ async fn handle_simple_query(
             .route_with_trace(sql, session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (chain_result, routing_trace) = match routing_result {
+    let (chain_result, mut routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             write_error_response(writer, "42000", &e.to_string()).await?;
@@ -343,12 +343,28 @@ async fn handle_simple_query(
             return Ok(());
         }
     };
-    let group = match chain_result {
+    let mut group = match chain_result {
         ChainRouteResult::Routed(g) => g,
         ChainRouteResult::Denied { message } => {
             state.record_routing_deny(sql, session, protocol, &message, Some(routing_trace));
             // 42501 = insufficient_privilege
             write_error_response(writer, "42501", &message).await?;
+            write_msg(writer, b'Z', b"I").await?;
+            return Ok(());
+        }
+    };
+    group = match state
+        .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(QueryFluxError::Unauthorized(msg)) => {
+            write_error_response(writer, "42501", &msg).await?;
+            write_msg(writer, b'Z', b"I").await?;
+            return Ok(());
+        }
+        Err(e) => {
+            write_error_response(writer, "42000", &e.to_string()).await?;
             write_msg(writer, b'Z', b"I").await?;
             return Ok(());
         }

--- a/crates/queryflux-frontend/src/routing_resolve.rs
+++ b/crates/queryflux-frontend/src/routing_resolve.rs
@@ -137,6 +137,7 @@ mod tests {
             decisions: vec![],
             final_group: "default".into(),
             used_fallback: false,
+            denied: None,
         };
         let routed = ClusterGroupName("default".into());
         let out = resolve_routed_group(
@@ -173,6 +174,7 @@ mod tests {
             decisions: vec![],
             final_group: "default".into(),
             used_fallback: true,
+            denied: None,
         };
         let out = resolve_routed_group(
             &live.group_order,
@@ -209,6 +211,7 @@ mod tests {
             decisions: vec![],
             final_group: "default".into(),
             used_fallback: true,
+            denied: None,
         };
         let err = resolve_routed_group(
             &live.group_order,
@@ -231,6 +234,7 @@ mod tests {
             decisions: vec![],
             final_group: "default".into(),
             used_fallback: true,
+            denied: None,
         };
         let out = resolve_routed_group(
             &live.group_order,

--- a/crates/queryflux-frontend/src/routing_resolve.rs
+++ b/crates/queryflux-frontend/src/routing_resolve.rs
@@ -1,0 +1,235 @@
+//! Post-routing resolution: authorization-aware first-fit when the chain used fallback.
+
+use queryflux_auth::AuthContext;
+use queryflux_core::{error::QueryFluxError, query::ClusterGroupName};
+use queryflux_routing::chain::RoutingTrace;
+
+use crate::state::LiveConfig;
+
+/// When the router chain used its static fallback, pick the first cluster group in
+/// `group_order` the caller may access. Explicit router matches are returned as-is
+/// (dispatch enforces `allowUsers` / `allowGroups` separately).
+pub async fn resolve_routed_group(
+    live: &LiveConfig,
+    routed: ClusterGroupName,
+    trace: &mut RoutingTrace,
+    auth_ctx: &AuthContext,
+) -> Result<ClusterGroupName, QueryFluxError> {
+    if !trace.used_fallback {
+        return Ok(routed);
+    }
+
+    for name in &live.group_order {
+        if live.authorization.check(auth_ctx, name).await {
+            if name != &trace.final_group {
+                trace.final_group = name.clone();
+            }
+            return Ok(ClusterGroupName(name.clone()));
+        }
+    }
+
+    Err(QueryFluxError::Unauthorized(format!(
+        "user '{}' is not authorized for any cluster group",
+        auth_ctx.user
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use queryflux_auth::{
+        AllowAllAuthorization, AuthContext, AuthorizationChecker, SimpleAuthorizationPolicy,
+    };
+    use queryflux_cluster_manager::{
+        cluster_state::ClusterState, simple::SimpleClusterGroupManager,
+        strategy::RoundRobinStrategy,
+    };
+    use queryflux_core::{
+        config::ClusterGroupAuthorizationConfig,
+        query::{ClusterGroupName, ClusterName, EngineType},
+    };
+    use queryflux_routing::chain::{RouterChain, RoutingTrace};
+
+    use super::*;
+    use crate::state::LiveConfig;
+
+    fn auth(user: &str, groups: &[&str]) -> AuthContext {
+        AuthContext {
+            user: user.into(),
+            groups: groups.iter().map(|g| g.to_string()).collect(),
+            roles: vec![],
+            raw_token: None,
+        }
+    }
+
+    fn live_with_policies(
+        policies: HashMap<String, ClusterGroupAuthorizationConfig>,
+    ) -> LiveConfig {
+        let analytics = ClusterGroupName("analytics".into());
+        let default = ClusterGroupName("default".into());
+        let cluster = ClusterName("c1".into());
+        let state = Arc::new(ClusterState::new(
+            cluster.clone(),
+            analytics.clone(),
+            None,
+            None,
+            EngineType::Trino,
+            Some("http://trino.test:8080".into()),
+            10,
+            true,
+        ));
+        let mut groups = HashMap::new();
+        groups.insert(
+            analytics.clone(),
+            (
+                vec![state],
+                Arc::new(RoundRobinStrategy::new())
+                    as Arc<dyn queryflux_cluster_manager::strategy::ClusterSelectionStrategy>,
+            ),
+        );
+        LiveConfig {
+            router_chain: RouterChain::new(vec![], default.clone()),
+            guard_chain: None,
+            group_guard_chains: HashMap::new(),
+            cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),
+            adapters: HashMap::new(),
+            health_check_targets: vec![],
+            cluster_configs: HashMap::new(),
+            group_members: HashMap::from([
+                ("analytics".into(), vec!["c1".into()]),
+                ("default".into(), vec!["c1".into()]),
+            ]),
+            group_order: vec!["analytics".into(), "default".into()],
+            group_translation_scripts: HashMap::new(),
+            group_default_tags: HashMap::new(),
+            group_max_queued_queries: HashMap::new(),
+            group_capacity_wait_timeout_secs: HashMap::new(),
+            group_cache_settings: HashMap::new(),
+            auth_provider: Arc::new(queryflux_auth::NoneAuthProvider::new(false)),
+            authorization: Arc::new(SimpleAuthorizationPolicy::new(policies))
+                as Arc<dyn AuthorizationChecker>,
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_route_skips_first_fit() {
+        let live = live_with_policies(HashMap::from([
+            (
+                "analytics".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-a".into()],
+                    allow_users: vec![],
+                },
+            ),
+            (
+                "default".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-b".into()],
+                    allow_users: vec![],
+                },
+            ),
+        ]));
+        let mut trace = RoutingTrace {
+            decisions: vec![],
+            final_group: "default".into(),
+            used_fallback: false,
+        };
+        let routed = ClusterGroupName("default".into());
+        let out = resolve_routed_group(&live, routed.clone(), &mut trace, &auth("alice", &[]))
+            .await
+            .unwrap();
+        assert_eq!(out, routed);
+    }
+
+    #[tokio::test]
+    async fn fallback_picks_first_authorized_group() {
+        let live = live_with_policies(HashMap::from([
+            (
+                "analytics".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-a".into()],
+                    allow_users: vec![],
+                },
+            ),
+            (
+                "default".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-b".into()],
+                    allow_users: vec![],
+                },
+            ),
+        ]));
+        let mut trace = RoutingTrace {
+            decisions: vec![],
+            final_group: "default".into(),
+            used_fallback: true,
+        };
+        let out = resolve_routed_group(
+            &live,
+            ClusterGroupName("default".into()),
+            &mut trace,
+            &auth("alice", &["team-a"]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.0, "analytics");
+        assert_eq!(trace.final_group, "analytics");
+    }
+
+    #[tokio::test]
+    async fn fallback_none_authorized_returns_unauthorized() {
+        let live = live_with_policies(HashMap::from([
+            (
+                "analytics".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-a".into()],
+                    allow_users: vec![],
+                },
+            ),
+            (
+                "default".into(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-b".into()],
+                    allow_users: vec![],
+                },
+            ),
+        ]));
+        let mut trace = RoutingTrace {
+            decisions: vec![],
+            final_group: "default".into(),
+            used_fallback: true,
+        };
+        let err = resolve_routed_group(
+            &live,
+            ClusterGroupName("default".into()),
+            &mut trace,
+            &auth("bob", &[]),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, QueryFluxError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn allow_all_policy_uses_first_group_on_fallback() {
+        let live = live_with_policies(HashMap::new());
+        let mut live = live;
+        live.authorization = Arc::new(AllowAllAuthorization::default());
+        let mut trace = RoutingTrace {
+            decisions: vec![],
+            final_group: "default".into(),
+            used_fallback: true,
+        };
+        let out = resolve_routed_group(
+            &live,
+            ClusterGroupName("default".into()),
+            &mut trace,
+            &auth("anyone", &[]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.0, "analytics");
+    }
+}

--- a/crates/queryflux-frontend/src/routing_resolve.rs
+++ b/crates/queryflux-frontend/src/routing_resolve.rs
@@ -1,16 +1,18 @@
 //! Post-routing resolution: authorization-aware first-fit when the chain used fallback.
 
-use queryflux_auth::AuthContext;
+use queryflux_auth::{AuthContext, AuthorizationChecker};
 use queryflux_core::{error::QueryFluxError, query::ClusterGroupName};
 use queryflux_routing::chain::RoutingTrace;
-
-use crate::state::LiveConfig;
 
 /// When the router chain used its static fallback, pick the first cluster group in
 /// `group_order` the caller may access. Explicit router matches are returned as-is
 /// (dispatch enforces `allowUsers` / `allowGroups` separately).
+///
+/// Callers should snapshot `group_order` and `authorization` and drop any live-config
+/// lock before awaiting this — `check` may perform remote I/O (e.g. OpenFGA).
 pub async fn resolve_routed_group(
-    live: &LiveConfig,
+    group_order: &[String],
+    authorization: &dyn AuthorizationChecker,
     routed: ClusterGroupName,
     trace: &mut RoutingTrace,
     auth_ctx: &AuthContext,
@@ -19,8 +21,8 @@ pub async fn resolve_routed_group(
         return Ok(routed);
     }
 
-    for name in &live.group_order {
-        if live.authorization.check(auth_ctx, name).await {
+    for name in group_order {
+        if authorization.check(auth_ctx, name).await {
             if name != &trace.final_group {
                 trace.final_group = name.clone();
             }
@@ -137,9 +139,15 @@ mod tests {
             used_fallback: false,
         };
         let routed = ClusterGroupName("default".into());
-        let out = resolve_routed_group(&live, routed.clone(), &mut trace, &auth("alice", &[]))
-            .await
-            .unwrap();
+        let out = resolve_routed_group(
+            &live.group_order,
+            live.authorization.as_ref(),
+            routed.clone(),
+            &mut trace,
+            &auth("alice", &[]),
+        )
+        .await
+        .unwrap();
         assert_eq!(out, routed);
     }
 
@@ -167,7 +175,8 @@ mod tests {
             used_fallback: true,
         };
         let out = resolve_routed_group(
-            &live,
+            &live.group_order,
+            live.authorization.as_ref(),
             ClusterGroupName("default".into()),
             &mut trace,
             &auth("alice", &["team-a"]),
@@ -202,7 +211,8 @@ mod tests {
             used_fallback: true,
         };
         let err = resolve_routed_group(
-            &live,
+            &live.group_order,
+            live.authorization.as_ref(),
             ClusterGroupName("default".into()),
             &mut trace,
             &auth("bob", &[]),
@@ -223,7 +233,8 @@ mod tests {
             used_fallback: true,
         };
         let out = resolve_routed_group(
-            &live,
+            &live.group_order,
+            live.authorization.as_ref(),
             ClusterGroupName("default".into()),
             &mut trace,
             &auth("anyone", &[]),

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -9,7 +9,9 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use queryflux_auth::Credentials;
-use queryflux_core::{query::FrontendProtocol, session::SessionContext, tags::QueryTags};
+use queryflux_core::{
+    error::QueryFluxError, query::FrontendProtocol, session::SessionContext, tags::QueryTags,
+};
 use serde_json::json;
 use tracing::warn;
 use uuid::Uuid;
@@ -92,11 +94,11 @@ pub async fn login_request(
             )
             .await
     };
-    let (group, routing_trace) = match routing_result {
-        Ok((result, trace)) => (result, trace),
+    let (chain_result, mut routing_trace) = match routing_result {
+        Ok(r) => r,
         Err(e) => return sf_error("390000", &format!("Routing error: {e}")),
     };
-    let group = match group {
+    let mut group = match chain_result {
         ChainRouteResult::Routed(g) => g,
         ChainRouteResult::Denied { message } => {
             state.app.record_routing_deny(
@@ -108,6 +110,15 @@ pub async fn login_request(
             );
             return sf_error("390201", &message);
         }
+    };
+    group = match state
+        .app
+        .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(QueryFluxError::Unauthorized(msg)) => return sf_error("390201", &msg),
+        Err(e) => return sf_error("390000", &format!("Routing error: {e}")),
     };
 
     let token = state.sessions.create_session(

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -12,7 +12,7 @@ use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use queryflux_auth::Credentials;
 use queryflux_core::{
-    error::Result,
+    error::{QueryFluxError, Result},
     query::{FrontendProtocol, QueryStats},
     session::SessionContext,
     tags::QueryTags,
@@ -239,11 +239,11 @@ pub async fn submit_statement(
             )
             .await
     };
-    let (group, routing_trace) = match routing_result {
-        Ok((result, trace)) => (result, trace),
+    let (chain_result, mut routing_trace) = match routing_result {
+        Ok(r) => r,
         Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
     };
-    let group = match group {
+    let mut group = match chain_result {
         ChainRouteResult::Routed(g) => g,
         ChainRouteResult::Denied { message } => {
             state.app.record_routing_deny(
@@ -255,6 +255,17 @@ pub async fn submit_statement(
             );
             return sql_api_error(StatusCode::FORBIDDEN, "390201", &message);
         }
+    };
+    group = match state
+        .app
+        .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(QueryFluxError::Unauthorized(msg)) => {
+            return sql_api_error(StatusCode::FORBIDDEN, "390201", &msg);
+        }
+        Err(e) => return sql_api_error(StatusCode::BAD_GATEWAY, "390000", &e.to_string()),
     };
 
     let handle = Uuid::new_v4().to_string();

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -408,6 +408,17 @@ impl AppState {
         query_id
     }
 
+    /// Apply authorization-aware first-fit when the router chain used fallback.
+    pub async fn resolve_routed_group(
+        &self,
+        routed: ClusterGroupName,
+        trace: &mut queryflux_routing::chain::RoutingTrace,
+        auth_ctx: &queryflux_auth::AuthContext,
+    ) -> queryflux_core::error::Result<ClusterGroupName> {
+        let live = self.live.read().await;
+        crate::routing_resolve::resolve_routed_group(&live, routed, trace, auth_ctx).await
+    }
+
     /// Persist a terminal audit row for a queued query that never reached an engine
     /// (capacity wait timeout, stale client disconnect).
     pub fn record_queued_terminal(&self, queued: &QueuedQuery, status: QueryStatus, reason: &str) {

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -415,8 +415,21 @@ impl AppState {
         trace: &mut queryflux_routing::chain::RoutingTrace,
         auth_ctx: &queryflux_auth::AuthContext,
     ) -> queryflux_core::error::Result<ClusterGroupName> {
-        let live = self.live.read().await;
-        crate::routing_resolve::resolve_routed_group(&live, routed, trace, auth_ctx).await
+        let (group_order, authorization) = {
+            let live = self.live.read().await;
+            if !trace.used_fallback {
+                return Ok(routed);
+            }
+            (live.group_order.clone(), live.authorization.clone())
+        };
+        crate::routing_resolve::resolve_routed_group(
+            &group_order,
+            authorization.as_ref(),
+            routed,
+            trace,
+            auth_ctx,
+        )
+        .await
     }
 
     /// Persist a terminal audit row for a queued query that never reached an engine

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -530,7 +530,7 @@ pub async fn post_statement(
             .route_with_trace(&sql, &session, &protocol, Some(&auth_ctx))
             .await
     };
-    let (chain_result, routing_trace) = match routing_result {
+    let (chain_result, mut routing_trace) = match routing_result {
         Ok(r) => r,
         Err(e) => {
             warn!("Routing error: {e}");
@@ -545,13 +545,29 @@ pub async fn post_statement(
             return trino_error_response(&tmp_id.0, msg).into_response();
         }
     };
-    let group = match chain_result {
+    let mut group = match chain_result {
         ChainRouteResult::Routed(g) => g,
         ChainRouteResult::Denied { message } => {
             warn!(%message, user = %auth_ctx.user, "Query denied by routing rule");
             let query_id =
                 state.record_routing_deny(&sql, &session, protocol, &message, Some(routing_trace));
             return trino_error_response(&query_id.0, &message).into_response();
+        }
+    };
+    group = match state
+        .resolve_routed_group(group, &mut routing_trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(QueryFluxError::Unauthorized(msg)) => {
+            warn!(user = %auth_ctx.user, "{msg}");
+            let tmp_id = ProxyQueryId::new();
+            return trino_error_response(&tmp_id.0, &msg).into_response();
+        }
+        Err(e) => {
+            warn!("Routing resolution error: {e}");
+            let tmp_id = ProxyQueryId::new();
+            return trino_error_response(&tmp_id.0, &e.to_string()).into_response();
         }
     };
 


### PR DESCRIPTION
## Summary
- When the router chain uses fallback (`used_fallback`), scan `group_order` and pick the first cluster group the caller may access via `SimpleAuthorizationPolicy` / OpenFGA.
- Wire into Trino HTTP, MySQL/Postgres wire, Flight SQL, and Snowflake HTTP/SQL API (switch Snowflake to `route_with_trace` so fallback is detectable).
- Explicit router matches are unchanged; dispatch still enforces per-group allow lists.

## Test plan
- [ ] Unit: `cargo test -p queryflux-frontend routing_resolve`
- [ ] Two groups with disjoint `allowGroups`; no routing rules → user A lands on their group, user B on theirs
- [ ] User with no matching allow list → 403 / protocol error on submit
- [ ] Queued query dequeue still works for owner (dispatch re-checks auth)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authorization-aware routing across Flight SQL, MySQL, PostgreSQL, Snowflake, and Trino interfaces.
  - Requests now select an accessible fallback destination when the initially routed destination requires resolution.
  - Routing context is preserved throughout request processing.

- **Bug Fixes**
  - Unauthorized destination access now returns clear, protocol-specific permission errors instead of generic failures.
  - Other routing failures continue to return appropriate internal or gateway error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->