### PR TITLE
fix: fail-closed guard kinds (script + webhook)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,6 +3901,7 @@ dependencies = [
  "async-trait",
  "queryflux-core",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -4050,6 +4051,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/queryflux-config/Cargo.toml
+++ b/crates/queryflux-config/Cargo.toml
@@ -10,3 +10,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 serde_yaml = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "fs"] }

--- a/crates/queryflux-config/src/yaml.rs
+++ b/crates/queryflux-config/src/yaml.rs
@@ -38,14 +38,67 @@ impl ConfigProvider for YamlFileConfigProvider {
         })?;
 
         if let Some(guardrails) = &config.guardrails {
-            if let Err(e) = guardrails.validate() {
-                tracing::warn!(
-                    "Invalid guardrails in {}: {e} — will be ignored if Postgres config overrides YAML",
+            guardrails.validate().map_err(|e| {
+                QueryFluxError::Config(format!(
+                    "Invalid guardrails in {}: {e}",
                     self.path.display()
-                );
-            }
+                ))
+            })?;
         }
 
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn load_rejects_invalid_guardrails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.yaml");
+        tokio::fs::write(
+            &path,
+            r#"
+queryflux: {}
+guardrails:
+  global:
+    - kind: python_script
+"#,
+        )
+        .await
+        .expect("write config");
+
+        let provider = YamlFileConfigProvider::new(&path);
+        let err = provider
+            .load()
+            .await
+            .expect_err("invalid guardrails must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("script"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn load_accepts_valid_guardrails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.yaml");
+        tokio::fs::write(
+            &path,
+            r#"
+queryflux: {}
+guardrails:
+  global:
+    - kind: python_script
+      script: |
+        def check(ctx):
+            return {"action": "allow"}
+"#,
+        )
+        .await
+        .expect("write config");
+
+        let provider = YamlFileConfigProvider::new(&path);
+        provider.load().await.expect("valid guardrails should load");
     }
 }

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -79,7 +79,11 @@ impl ProxyConfig {
     /// Fail-closed checks run before auth providers are constructed at startup.
     pub fn validate_startup_security(&self) -> std::result::Result<(), String> {
         self.auth.validate_for_required()?;
-        self.authorization.validate()
+        self.authorization.validate()?;
+        if let Some(guardrails) = &self.guardrails {
+            guardrails.validate()?;
+        }
+        Ok(())
     }
 }
 
@@ -266,10 +270,19 @@ impl GuardSpecConfig {
                 Ok(())
             }
             GuardKindConfig::HttpWebhook => {
-                if self.url.as_deref().unwrap_or_default().trim().is_empty() {
+                let raw = self.url.as_deref().unwrap_or_default().trim();
+                if raw.is_empty() {
                     return Err("http_webhook guard is missing required field \"url\"".to_string());
                 }
-                Ok(())
+                match url::Url::parse(raw) {
+                    Ok(parsed) => match parsed.scheme() {
+                        "http" | "https" => Ok(()),
+                        other => Err(format!(
+                            "http_webhook url must use http or https scheme, got \"{other}\""
+                        )),
+                    },
+                    Err(e) => Err(format!("http_webhook url is not a valid URL: {e}")),
+                }
             }
         }
     }
@@ -1610,6 +1623,38 @@ guardrails:
         assert!(matches!(spec.kind, GuardKindConfig::HttpWebhook));
         assert_eq!(spec.url.as_deref(), Some("https://policy.internal/guard"));
         assert_eq!(spec.timeout_ms, Some(500));
+    }
+
+    #[test]
+    fn guardrails_validation_rejects_non_http_url_scheme() {
+        let webhook = GuardSpecConfig {
+            kind: GuardKindConfig::HttpWebhook,
+            name: None,
+            script_id: None,
+            script: None,
+            url: Some("file:///etc/passwd".to_string()),
+            timeout_ms: None,
+            retry_count: None,
+            fail_behavior: None,
+            headers: None,
+            max_rows: None,
+            applies_to: None,
+        };
+        let err = webhook.validate().unwrap_err();
+        assert!(err.contains("http or https"), "{err}");
+    }
+
+    #[test]
+    fn startup_rejects_invalid_guardrails() {
+        let yaml = r#"
+queryflux: {}
+guardrails:
+  global:
+    - kind: http_webhook
+"#;
+        let cfg: ProxyConfig = serde_yaml::from_str(yaml).unwrap();
+        let err = cfg.validate_startup_security().unwrap_err();
+        assert!(err.contains("url"), "{err}");
     }
 
     #[test]

--- a/crates/queryflux-guardrails/Cargo.toml
+++ b/crates/queryflux-guardrails/Cargo.toml
@@ -16,3 +16,4 @@ tracing = { workspace = true }
 pyo3 = { workspace = true }
 reqwest = { workspace = true }
 regex = "1.12.3"
+url = { workspace = true }

--- a/crates/queryflux-guardrails/src/config.rs
+++ b/crates/queryflux-guardrails/src/config.rs
@@ -83,10 +83,19 @@ impl GuardSpec {
                 Ok(())
             }
             GuardKind::HttpWebhook { url, .. } => {
-                if url.trim().is_empty() {
+                let raw = url.trim();
+                if raw.is_empty() {
                     return Err("http_webhook guard is missing required field \"url\"".to_string());
                 }
-                Ok(())
+                match url::Url::parse(raw) {
+                    Ok(parsed) => match parsed.scheme() {
+                        "http" | "https" => Ok(()),
+                        other => Err(format!(
+                            "http_webhook url must use http or https scheme, got \"{other}\""
+                        )),
+                    },
+                    Err(e) => Err(format!("http_webhook url is not a valid URL: {e}")),
+                }
             }
         }
     }

--- a/crates/queryflux-guardrails/src/external.rs
+++ b/crates/queryflux-guardrails/src/external.rs
@@ -384,7 +384,7 @@ mod tests {
     async fn http_webhook_retries_then_denies_on_failure() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
+        let listener_task = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.unwrap();
             let mut buf = [0_u8; 2048];
             let _ = socket.read(&mut buf).await.unwrap();
@@ -406,6 +406,12 @@ mod tests {
         let tc = TestCtx::new("SELECT 1");
         let result = guard.check(&tc.ctx()).await;
         assert!(matches!(result, GuardResult::Deny { .. }));
+
+        // retry_count: 1 => two attempts; wait for the listener to finish both accepts.
+        tokio::time::timeout(Duration::from_secs(2), listener_task)
+            .await
+            .expect("listener should accept both retry attempts before deadline")
+            .expect("listener task should complete without panic");
     }
 
     #[tokio::test]

--- a/crates/queryflux-guardrails/src/external.rs
+++ b/crates/queryflux-guardrails/src/external.rs
@@ -362,4 +362,64 @@ mod tests {
             } if reason == "blocked by policy" && code == "POLICY_DENY"
         ));
     }
+
+    #[tokio::test]
+    async fn misconfigured_guard_denies() {
+        let guard = MisconfiguredGuard {
+            guard_name: "python_script",
+            reason: "missing script".to_string(),
+        };
+        let tc = TestCtx::new("SELECT 1");
+        let result = guard.check(&tc.ctx()).await;
+        assert!(matches!(
+            result,
+            GuardResult::Deny {
+                reason,
+                code: Some(code)
+            } if reason == "missing script" && code == "GUARD_CONFIG_ERROR"
+        ));
+    }
+
+    #[tokio::test]
+    async fn http_webhook_retries_then_denies_on_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0_u8; 2048];
+            let _ = socket.read(&mut buf).await.unwrap();
+            let response = "HTTP/1.1 503 Service Unavailable\r\ncontent-length: 0\r\nconnection: close\r\n\r\n";
+            socket.write_all(response.as_bytes()).await.unwrap();
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let _ = socket.read(&mut buf).await.unwrap();
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let guard = HttpWebhookGuard {
+            url: format!("http://{addr}/guard"),
+            timeout_ms: Some(500),
+            retry_count: 1,
+            fail_behavior: FailBehavior::Deny,
+            headers: HashMap::new(),
+            client: reqwest::Client::new(),
+        };
+        let tc = TestCtx::new("SELECT 1");
+        let result = guard.check(&tc.ctx()).await;
+        assert!(matches!(result, GuardResult::Deny { .. }));
+    }
+
+    #[tokio::test]
+    async fn http_webhook_fail_open_allows_on_unreachable() {
+        let guard = HttpWebhookGuard {
+            url: "http://127.0.0.1:1/unreachable".to_string(),
+            timeout_ms: Some(100),
+            retry_count: 0,
+            fail_behavior: FailBehavior::Allow,
+            headers: HashMap::new(),
+            client: reqwest::Client::new(),
+        };
+        let tc = TestCtx::new("SELECT 1");
+        let result = guard.check(&tc.ctx()).await;
+        assert!(!result.is_deny());
+    }
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -2756,21 +2756,44 @@ fn make_http_webhook_guard(
     fail_behavior: FailBehavior,
     headers: HashMap<String, String>,
 ) -> Box<dyn Guard> {
-    if url.trim().is_empty() {
+    let raw = url.trim();
+    if raw.is_empty() {
         tracing::warn!("http_webhook guard has empty URL; using MisconfiguredGuard");
-        Box::new(MisconfiguredGuard {
+        return Box::new(MisconfiguredGuard {
             guard_name: "http_webhook",
             reason: "http_webhook guard is missing required field \"url\"".to_string(),
-        })
-    } else {
-        Box::new(HttpWebhookGuard {
-            url,
-            timeout_ms,
-            retry_count,
-            fail_behavior,
-            headers,
-            client: reqwest::Client::new(),
-        })
+        });
+    }
+    match reqwest::Url::parse(raw) {
+        Ok(parsed) => match parsed.scheme() {
+            "http" | "https" => Box::new(HttpWebhookGuard {
+                url: raw.to_string(),
+                timeout_ms,
+                retry_count,
+                fail_behavior,
+                headers,
+                client: reqwest::Client::new(),
+            }),
+            other => {
+                tracing::warn!(
+                    scheme = other,
+                    "http_webhook guard URL must use http or https; using MisconfiguredGuard"
+                );
+                Box::new(MisconfiguredGuard {
+                    guard_name: "http_webhook",
+                    reason: format!(
+                        "http_webhook url must use http or https scheme, got \"{other}\""
+                    ),
+                })
+            }
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "http_webhook guard URL is invalid; using MisconfiguredGuard");
+            Box::new(MisconfiguredGuard {
+                guard_name: "http_webhook",
+                reason: format!("http_webhook url is not a valid URL: {e}"),
+            })
+        }
     }
 }
 
@@ -3124,6 +3147,92 @@ mod tests {
             let ctx = plan_ctx(&engine, &group, &tags);
             let (_, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
             assert!(!blocked);
+        }
+
+        #[tokio::test]
+        async fn non_http_webhook_url_denies_even_when_fail_open() {
+            use queryflux_core::config::GuardFailBehaviorConfig;
+
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = vec![GuardSpecConfig {
+                kind: GuardKindConfig::HttpWebhook,
+                name: None,
+                script_id: None,
+                script: None,
+                url: Some("file:///tmp/policy".to_string()),
+                timeout_ms: Some(100),
+                retry_count: None,
+                fail_behavior: Some(GuardFailBehaviorConfig::Allow),
+                headers: None,
+                max_rows: None,
+                applies_to: None,
+            }];
+            let chain = build_chain_from_yaml_specs(&specs, &HashMap::new())
+                .expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (actions, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(blocked, "non-http(s) webhook URL must deny at construction");
+            assert_eq!(actions[0].guard, "http_webhook");
+            assert!(actions[0]
+                .reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("http or https"));
+        }
+
+        #[tokio::test]
+        async fn http_webhook_url_is_accepted_and_can_fail_open() {
+            use queryflux_core::config::GuardFailBehaviorConfig;
+
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = vec![GuardSpecConfig {
+                kind: GuardKindConfig::HttpWebhook,
+                name: None,
+                script_id: None,
+                script: None,
+                url: Some("http://127.0.0.1:1/unreachable".to_string()),
+                timeout_ms: Some(100),
+                retry_count: Some(0),
+                fail_behavior: Some(GuardFailBehaviorConfig::Allow),
+                headers: None,
+                max_rows: None,
+                applies_to: None,
+            }];
+            let chain = build_chain_from_yaml_specs(&specs, &HashMap::new())
+                .expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (_, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(
+                !blocked,
+                "valid http(s) webhook with fail_open must allow when unreachable"
+            );
+        }
+
+        #[tokio::test]
+        async fn db_non_http_webhook_url_denies_at_runtime() {
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = serde_json::json!([{
+                "kind": "http_webhook",
+                "url": "ftp://evil.example/guard",
+                "fail_behavior": "allow"
+            }]);
+            let chain =
+                build_chain_from_db_specs(&specs, &HashMap::new()).expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (actions, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(blocked);
+            assert_eq!(actions[0].guard, "http_webhook");
+            assert!(actions[0]
+                .reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("http or https"));
         }
     }
 

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -2700,6 +2700,28 @@ async fn load_guard_script_bodies_from_admin(admin: &dyn AdminStore) -> HashMap<
         })
 }
 
+fn resolve_built_in_guard(
+    name: Option<&str>,
+    max_rows: Option<u64>,
+    applies_to: Option<Vec<String>>,
+) -> Box<dyn Guard> {
+    match name {
+        Some("read_only") => Box::new(ReadOnlyGuard),
+        Some("row_limit") => Box::new(RowLimitGuard { max_rows }),
+        Some("require_predicate") => Box::new(RequirePredicateGuard {
+            applies_to: applies_to.unwrap_or_default(),
+        }),
+        Some(other) => Box::new(MisconfiguredGuard {
+            guard_name: "built_in",
+            reason: format!("unsupported built_in guard name \"{other}\""),
+        }),
+        None => Box::new(MisconfiguredGuard {
+            guard_name: "built_in",
+            reason: "built_in guard is missing required field \"name\"".to_string(),
+        }),
+    }
+}
+
 fn resolve_python_guard_script(
     inline_script: Option<String>,
     script_id: Option<i64>,
@@ -2763,20 +2785,11 @@ fn build_chain_from_yaml_specs(
     for spec in specs {
         match &spec.kind {
             GuardKindConfig::BuiltIn => {
-                let Some(name) = spec.name.as_deref() else {
-                    tracing::error!("built_in guard is missing required field \"name\"; skipping");
-                    continue;
-                };
-                match name {
-                    "read_only" => guards.push(Box::new(ReadOnlyGuard)),
-                    "row_limit" => guards.push(Box::new(RowLimitGuard {
-                        max_rows: spec.max_rows,
-                    })),
-                    "require_predicate" => guards.push(Box::new(RequirePredicateGuard {
-                        applies_to: spec.applies_to.clone().unwrap_or_default(),
-                    })),
-                    other => tracing::warn!(name = other, "Unknown built-in guard name; skipping"),
-                }
+                guards.push(resolve_built_in_guard(
+                    spec.name.as_deref(),
+                    spec.max_rows,
+                    spec.applies_to.clone(),
+                ));
             }
             GuardKindConfig::PythonScript => {
                 let guard = resolve_python_guard_script(
@@ -2883,21 +2896,19 @@ fn build_chain_from_db_specs(
     let mut guards: Vec<Box<dyn Guard>> = Vec::new();
     for item in arr {
         let Some(spec) = parse_spec(item) else {
+            guards.push(Box::new(MisconfiguredGuard {
+                guard_name: "guard",
+                reason: "guard spec is not a valid object with a \"kind\" field".to_string(),
+            }));
             continue;
         };
         match spec.kind.as_str() {
             "built_in" => {
-                let name = spec.name.as_deref().unwrap_or("");
-                match name {
-                    "read_only" => guards.push(Box::new(ReadOnlyGuard)),
-                    "row_limit" => guards.push(Box::new(RowLimitGuard {
-                        max_rows: spec.max_rows,
-                    })),
-                    "require_predicate" => guards.push(Box::new(RequirePredicateGuard {
-                        applies_to: spec.applies_to.unwrap_or_default(),
-                    })),
-                    other => tracing::warn!(name = other, "Unknown built-in guard name; skipping"),
-                }
+                guards.push(resolve_built_in_guard(
+                    spec.name.as_deref(),
+                    spec.max_rows,
+                    spec.applies_to,
+                ));
             }
             "http_webhook" => {
                 guards.push(make_http_webhook_guard(
@@ -2920,7 +2931,10 @@ fn build_chain_from_db_specs(
                 );
                 guards.push(guard);
             }
-            other => tracing::warn!(kind = other, "Unknown guard kind; skipping"),
+            other => guards.push(Box::new(MisconfiguredGuard {
+                guard_name: "guard",
+                reason: format!("unsupported guard kind \"{other}\""),
+            })),
         }
     }
     if guards.is_empty() {
@@ -2980,6 +2994,139 @@ fn in_memory_metrics(
 
 #[cfg(test)]
 mod tests {
+    mod guard_chains {
+        use std::collections::HashMap;
+
+        use queryflux_core::config::{GuardKindConfig, GuardSpecConfig, GuardrailsConfig};
+        use queryflux_core::query::{ClusterGroupName, EngineType};
+        use queryflux_core::tags::QueryTags;
+        use queryflux_guardrails::context::{GuardContext, GuardLayer};
+
+        use super::super::{build_chain_from_db_specs, build_chain_from_yaml_specs};
+
+        fn plan_ctx<'a>(
+            engine: &'a EngineType,
+            group: &'a ClusterGroupName,
+            tags: &'a QueryTags,
+        ) -> GuardContext<'a> {
+            GuardContext {
+                sql: "SELECT 1",
+                translated_sql: "SELECT 1",
+                engine_type: engine,
+                cluster_group: group,
+                user: Some("alice"),
+                agent_context: None,
+                query_tags: tags,
+            }
+        }
+
+        #[tokio::test]
+        async fn yaml_unknown_built_in_denies_at_runtime() {
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = vec![GuardSpecConfig {
+                kind: GuardKindConfig::BuiltIn,
+                name: Some("does_not_exist".to_string()),
+                script_id: None,
+                script: None,
+                url: None,
+                timeout_ms: None,
+                retry_count: None,
+                fail_behavior: None,
+                headers: None,
+                max_rows: None,
+                applies_to: None,
+            }];
+            let chain = build_chain_from_yaml_specs(&specs, &HashMap::new())
+                .expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (actions, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(blocked);
+            assert_eq!(actions.len(), 1);
+            assert_eq!(actions[0].guard, "built_in");
+            assert_eq!(actions[0].action, "deny");
+        }
+
+        #[tokio::test]
+        async fn yaml_python_script_without_body_denies_at_runtime() {
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = vec![GuardSpecConfig {
+                kind: GuardKindConfig::PythonScript,
+                name: None,
+                script_id: None,
+                script: None,
+                url: None,
+                timeout_ms: None,
+                retry_count: None,
+                fail_behavior: None,
+                headers: None,
+                max_rows: None,
+                applies_to: None,
+            }];
+            let err = GuardrailsConfig {
+                global: specs.clone(),
+                groups: HashMap::new(),
+            }
+            .validate()
+            .expect_err("startup validation must reject");
+            assert!(err.contains("script"), "{err}");
+
+            // Misconfigured guards still deny if validation is bypassed (e.g. DB reload).
+            let chain = build_chain_from_yaml_specs(&specs, &HashMap::new())
+                .expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (_, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(blocked);
+        }
+
+        #[tokio::test]
+        async fn db_unknown_kind_denies_at_runtime() {
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = serde_json::json!([{ "kind": "future_kind" }]);
+            let chain =
+                build_chain_from_db_specs(&specs, &HashMap::new()).expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (actions, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(blocked);
+            assert_eq!(actions[0].guard, "guard");
+            assert!(actions[0]
+                .reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("future_kind"));
+        }
+
+        #[tokio::test]
+        async fn inline_python_script_guard_allows() {
+            let engine = EngineType::DuckDb;
+            let group = ClusterGroupName("default".to_string());
+            let tags = QueryTags::new();
+            let specs = vec![GuardSpecConfig {
+                kind: GuardKindConfig::PythonScript,
+                name: None,
+                script_id: None,
+                script: Some("def check(ctx):\n    return {'action': 'allow'}".to_string()),
+                url: None,
+                timeout_ms: Some(500),
+                retry_count: None,
+                fail_behavior: None,
+                headers: None,
+                max_rows: None,
+                applies_to: None,
+            }];
+            let chain = build_chain_from_yaml_specs(&specs, &HashMap::new())
+                .expect("chain should be built");
+            let ctx = plan_ctx(&engine, &group, &tags);
+            let (_, blocked) = chain.run(&ctx, GuardLayer::Plan).await;
+            assert!(!blocked);
+        }
+    }
+
     mod in_memory_metrics {
         use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
- Fail YAML load and startup validation when guardrails config is invalid (missing script/url, bad webhook URL scheme) instead of logging a warning and continuing.
- Replace silent skips in guard chain builders with `MisconfiguredGuard` so unknown built-in names, unknown DB guard kinds, and malformed specs deny queries at runtime rather than no-op.
- Add tests for config validation, YAML load, webhook retry/fail-open behavior, and guard chain runtime deny/allow paths.

Part of the productionize epic item: **Guard kinds are real or rejected**.

## Test plan
- [x] `cargo test -p queryflux-core guard`
- [x] `cargo test -p queryflux-config`
- [x] `cargo test -p queryflux-guardrails external::tests`
- [x] `cargo test -p queryflux guard_chains`
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=target cargo clippy --workspace --all-targets --all-features --exclude queryflux-bench -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid YAML guardrail configurations now prevent startup instead of being ignored.
  * Guardrails with missing, unknown, or unsupported definitions now deny requests safely.
  * HTTP webhook validation rejects blank, malformed, and non-HTTP(S) URLs.
  * Startup validation catches guardrails missing required webhook fields.
  * Inline Python guards and valid configurations continue to load correctly.
  * Webhook behavior is more reliable, including retries for temporary failures and fail-open handling when endpoints are unreachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->