### PR TITLE
feat: extend passthrough enrichment to sync-bridge dispatch

### DIFF
--- a/crates/queryflux-engine-adapters/src/wire_auth.rs
+++ b/crates/queryflux-engine-adapters/src/wire_auth.rs
@@ -5,7 +5,7 @@
 //! poll/cancel can re-apply the same credential). Kept out of any single adapter so the
 //! precedence rules stay identical across call sites instead of drifting.
 
-use queryflux_auth::QueryCredentials;
+use queryflux_auth::{AuthContext, QueryCredentials};
 use queryflux_core::query::StoredWireAuth;
 use queryflux_core::session::SessionContext;
 
@@ -55,6 +55,35 @@ pub fn resolve_stored_wire_auth(
         QueryCredentials::Bearer { token } => {
             Some(StoredWireAuth::Authorization(format!("Bearer {token}")))
         }
+    }
+}
+
+/// Best-effort passthrough enrichment: if `credentials` is `Passthrough` and the session
+/// doesn't already carry a forwardable `authorization` value (the frontend's own header,
+/// or one restored from a persisted queued session), inject `Bearer {raw_token}` when the
+/// caller authenticated via OIDC. No-op for every other credential mode, and a no-op when
+/// no `raw_token` is available — the adapter is responsible for failing closed on that.
+///
+/// Must run after `BackendIdentityResolver::resolve` (needs `credentials`) and before the
+/// adapter call (`session` must still be mutable at the call site). Shared by every
+/// dispatch path — the async Trino-HTTP path and the sync-bridge path used by Postgres/
+/// MySQL/Flight-wire frontends — so passthrough works the same way regardless of which
+/// frontend the query arrived on, as long as that frontend populates `raw_token`.
+pub fn enrich_session_for_passthrough(
+    session: &mut SessionContext,
+    credentials: &QueryCredentials,
+    auth_ctx: &AuthContext,
+) {
+    if !matches!(credentials, QueryCredentials::Passthrough) {
+        return;
+    }
+    if session.extra.contains_key("authorization") {
+        return;
+    }
+    if let Some(token) = &auth_ctx.raw_token {
+        session
+            .extra
+            .insert("authorization".to_string(), format!("Bearer {token}"));
     }
 }
 
@@ -138,5 +167,64 @@ mod tests {
             resolved,
             Some(StoredWireAuth::Authorization(v)) if v == "Bearer exchanged"
         ));
+    }
+
+    fn auth_ctx(raw_token: Option<&str>) -> AuthContext {
+        AuthContext {
+            user: "alice".to_string(),
+            groups: vec![],
+            roles: vec![],
+            raw_token: raw_token.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn enrich_injects_bearer_when_passthrough_and_no_header_and_raw_token_present() {
+        let mut session = session_with_auth(None);
+        enrich_session_for_passthrough(
+            &mut session,
+            &QueryCredentials::Passthrough,
+            &auth_ctx(Some("oidc-jwt")),
+        );
+        assert_eq!(
+            session.extra.get("authorization").map(String::as_str),
+            Some("Bearer oidc-jwt")
+        );
+    }
+
+    #[test]
+    fn enrich_does_not_overwrite_an_existing_authorization_header() {
+        let mut session = session_with_auth(Some("Bearer client-sent-token"));
+        enrich_session_for_passthrough(
+            &mut session,
+            &QueryCredentials::Passthrough,
+            &auth_ctx(Some("oidc-jwt")),
+        );
+        assert_eq!(
+            session.extra.get("authorization").map(String::as_str),
+            Some("Bearer client-sent-token")
+        );
+    }
+
+    #[test]
+    fn enrich_is_a_noop_without_a_raw_token() {
+        let mut session = session_with_auth(None);
+        enrich_session_for_passthrough(
+            &mut session,
+            &QueryCredentials::Passthrough,
+            &auth_ctx(None),
+        );
+        assert!(!session.extra.contains_key("authorization"));
+    }
+
+    #[test]
+    fn enrich_is_a_noop_for_non_passthrough_modes() {
+        let mut session = session_with_auth(None);
+        enrich_session_for_passthrough(
+            &mut session,
+            &QueryCredentials::ServiceAccount,
+            &auth_ctx(Some("oidc-jwt")),
+        );
+        assert!(!session.extra.contains_key("authorization"));
     }
 }

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -21,8 +21,8 @@ use queryflux_core::{
     session::SessionContext,
 };
 use queryflux_engine_adapters::{
-    wire_auth::resolve_stored_wire_auth, AdapterKind, AsyncAdapter, BackendQueryIdSlot,
-    ConnectionFormat, SyncAdapter,
+    wire_auth::{enrich_session_for_passthrough, resolve_stored_wire_auth},
+    AdapterKind, AsyncAdapter, BackendQueryIdSlot, ConnectionFormat, SyncAdapter,
 };
 use queryflux_guardrails::{GuardChain, GuardContext, GuardLayer};
 use queryflux_metrics::MetricsStore;
@@ -279,15 +279,7 @@ pub async fn dispatch_query(
     // captured one; otherwise inject a Bearer built from the OIDC raw_token so the
     // backend still receives a per-user credential. The adapter fails closed if
     // neither is available — this is best-effort enrichment, not the fail-closed check.
-    if matches!(credentials, QueryCredentials::Passthrough)
-        && !session.extra.contains_key("authorization")
-    {
-        if let Some(token) = &auth_ctx.raw_token {
-            session
-                .extra
-                .insert("authorization".to_string(), format!("Bearer {token}"));
-        }
-    }
+    enrich_session_for_passthrough(&mut session, &credentials, auth_ctx);
 
     // Resolved once here (mirroring what the Trino adapter derives internally for the
     // POST itself) so the exact same wire auth can be persisted on `ExecutingQuery` and
@@ -1419,21 +1411,12 @@ async fn setup_sync_query(
         }
     };
 
-    // Same enrichment as the async dispatch path: forward the client's own Authorization
-    // if the frontend already captured one; otherwise inject a Bearer built from the OIDC
-    // raw_token so the backend still receives a per-user credential. Without this, an
-    // OIDC-authenticated sync request (Postgres/MySQL/Flight wire) with no original
-    // Authorization header would resolve to Passthrough, find nothing forwardable, and
-    // fail closed — even though a raw_token was available to build one from.
-    if matches!(credentials, QueryCredentials::Passthrough)
-        && !session.extra.contains_key("authorization")
-    {
-        if let Some(token) = &auth_ctx.raw_token {
-            session
-                .extra
-                .insert("authorization".to_string(), format!("Bearer {token}"));
-        }
-    }
+    // Same enrichment as the async dispatch path: Flight SQL already forwards a client
+    // `Authorization` gRPC metadata header into `session.extra` verbatim, so this is only
+    // a no-op fallback for `passthrough` clusters when that header is missing but the
+    // caller authenticated via OIDC. `execute_as_arrow` (Trino reached via this sync
+    // bridge) resolves its own wire auth internally from this same session.
+    enrich_session_for_passthrough(&mut session, &credentials, auth_ctx);
 
     // Resolved the same way as the async dispatch path (after enrichment, so passthrough
     // benefits from it too), so a disconnect mid-query cancels with the identity the query

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -291,6 +291,12 @@ async fn handle_com_query(
     // Auth-complete early gate: all statement/metadata fast paths must still
     // be subject to authentication when `auth.required=true`.
     let protocol = FrontendProtocol::MySqlWire;
+    // No `bearer_token` captured here — the MySQL wire handshake password is not threaded
+    // through to `Credentials`, so `AuthContext.raw_token` is always `None` for this
+    // frontend. `queryAuth: passthrough` / `tokenExchange` on a backend cluster can never
+    // resolve a per-user credential when reached this way — only `serviceAccount` (and
+    // `impersonate`, backend-side) work. Use the Trino HTTP or Flight SQL frontend when
+    // per-user backend identity is required.
     let creds = Credentials {
         username: session.user().map(|s| s.to_string()),
         ..Default::default()

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -304,6 +304,13 @@ async fn handle_simple_query(
 
     let protocol = FrontendProtocol::PostgresWire;
 
+    // No `bearer_token` captured here — the Postgres wire startup message carries only a
+    // username (password auth, if any, happens in a separate AuthenticationMD5Password/
+    // cleartext exchange this handler doesn't thread through to `Credentials`). That means
+    // `AuthContext.raw_token` is always `None` for this frontend, so `queryAuth: passthrough`
+    // / `tokenExchange` on a backend cluster can never resolve a per-user credential when
+    // reached this way — only `serviceAccount` (and `impersonate`, backend-side) work.
+    // Use the Trino HTTP or Flight SQL frontend when per-user backend identity is required.
     let creds = Credentials {
         username: session.user().map(|s| s.to_string()),
         ..Default::default()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Trino passthrough authentication for forwarding client credentials.
  * Added impersonation and token-exchange authentication flows.
  * Preserved authentication details for reliable asynchronous polling and cancellation.

* **Bug Fixes**
  * Authentication failures now stop requests instead of falling back to service accounts.
  * Added validation for incompatible engine and authentication configurations.
  * Improved token-exchange isolation and credential handling.

* **Documentation**
  * Added a complete Keycloak OIDC example with setup instructions and reference configurations.
  * Clarified authentication limitations for MySQL and PostgreSQL wire connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->