### PR TITLE
feat: ADBC tokenExchange for Snowflake via per-identity sub-pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "aws-sdk-athena",
  "aws-types",
  "bytes",
+ "dashmap",
  "duckdb",
  "futures",
  "mysql_async",

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1134,6 +1134,14 @@ pub struct ClusterConfig {
     /// 1 GiB when omitted. Other engines ignore this.
     #[serde(default)]
     pub max_result_buffer_bytes: Option<u64>,
+    /// ADBC driver name (e.g. `"snowflake"`, `"flightsql"`) — only meaningful when
+    /// `engine` is [`EngineConfig::Adbc`]. ADBC clusters are admin-API-only (never YAML),
+    /// so this is populated from the persisted JSONB `driver` key, not deserialized from
+    /// this struct's own YAML/JSON representation. Used by [`query_auth_supported`] since
+    /// `EngineConfig::Adbc` alone doesn't say which underlying driver — and therefore
+    /// which OAuth-capable drivers — a cluster uses.
+    #[serde(default)]
+    pub driver: Option<String>,
     #[serde(default)]
     pub tls: Option<TlsConfig>,
     /// Type 1 credentials — service account used for health checks and (by default) query execution.
@@ -1232,35 +1240,57 @@ pub enum QueryAuthConfig {
     TokenExchange(TokenExchangeConfig),
 }
 
+/// ADBC drivers whose adapter code knows how to put an OAuth token into connection
+/// options via a per-identity sub-pool (see `AdbcAdapter`). Every other ADBC driver is
+/// `serviceAccount`-only — `EngineConfig::Adbc` alone can't tell drivers apart, so this
+/// list is what actually gates `tokenExchange` for ADBC clusters.
+const ADBC_TOKEN_EXCHANGE_DRIVERS: &[&str] = &["snowflake"];
+
 /// Centralizes the engine × `queryAuth` support matrix so YAML load, Studio PUT, and
 /// startup validation can't drift apart. Returns `Err` with an operator-facing message
-/// when `mode` is not implemented for `engine` yet.
+/// when `mode` is not implemented for `engine` (and, for ADBC, `driver`) yet.
 ///
-/// `serviceAccount` is always allowed. Every other mode is Trino-only in this release —
-/// ADBC/ClickHouse/StarRocks adapters do not yet consume `QueryCredentials`, so accepting
-/// the config silently would produce a cluster that claims per-user identity but never
-/// applies it.
+/// `serviceAccount` is always allowed. Trino supports every mode. ADBC supports
+/// `tokenExchange` only for drivers in [`ADBC_TOKEN_EXCHANGE_DRIVERS`] — `driver` is
+/// ignored for every other engine. Everything else (ClickHouse, StarRocks, and all other
+/// ADBC drivers) is `serviceAccount`-only in this release; accepting the config silently
+/// would produce a cluster that claims per-user identity but never applies it.
 pub fn query_auth_supported(
     engine: Option<&EngineConfig>,
+    driver: Option<&str>,
     mode: &QueryAuthConfig,
 ) -> Result<(), String> {
     if matches!(mode, QueryAuthConfig::ServiceAccount) {
         return Ok(());
     }
+    let mode_name = match mode {
+        QueryAuthConfig::Passthrough => "passthrough",
+        QueryAuthConfig::Impersonate => "impersonate",
+        QueryAuthConfig::TokenExchange(_) => "tokenExchange",
+        QueryAuthConfig::ServiceAccount => unreachable!("handled above"),
+    };
     match engine {
         Some(EngineConfig::Trino) => Ok(()),
+        Some(EngineConfig::Adbc)
+            if matches!(mode, QueryAuthConfig::TokenExchange(_))
+                && driver.is_some_and(|d| ADBC_TOKEN_EXCHANGE_DRIVERS.contains(&d)) =>
+        {
+            Ok(())
+        }
+        Some(EngineConfig::Adbc) => {
+            let driver_name = driver.unwrap_or("<unknown>");
+            Err(format!(
+                "queryAuth.type = {mode_name} is not supported for ADBC driver '{driver_name}' \
+                 in this release (only tokenExchange for {ADBC_TOKEN_EXCHANGE_DRIVERS:?})"
+            ))
+        }
         other => {
             let engine_name = other
                 .map(|e| format!("{e:?}"))
                 .unwrap_or_else(|| "<unknown>".to_string());
-            let mode_name = match mode {
-                QueryAuthConfig::Passthrough => "passthrough",
-                QueryAuthConfig::Impersonate => "impersonate",
-                QueryAuthConfig::TokenExchange(_) => "tokenExchange",
-                QueryAuthConfig::ServiceAccount => unreachable!("handled above"),
-            };
             Err(format!(
-                "queryAuth.type = {mode_name} is only supported for Trino in this release, got {engine_name}"
+                "queryAuth.type = {mode_name} is only supported for Trino (and tokenExchange \
+                 for ADBC/snowflake) in this release, got {engine_name}"
             ))
         }
     }
@@ -1565,14 +1595,25 @@ mod tests {
         ProxyConfig, QueryAuthConfig, RouterConfig, TokenExchangeConfig,
     };
 
+    fn token_exchange_mode() -> QueryAuthConfig {
+        QueryAuthConfig::TokenExchange(TokenExchangeConfig {
+            token_endpoint: "https://idp.example/token".to_string(),
+            client_id: "queryflux".to_string(),
+            client_secret: "secret".to_string(),
+            target_audience: None,
+            scope: None,
+        })
+    }
+
     #[test]
     fn service_account_is_allowed_for_every_engine_including_unknown() {
         assert!(query_auth_supported(
             Some(&EngineConfig::ClickHouse),
+            None,
             &QueryAuthConfig::ServiceAccount
         )
         .is_ok());
-        assert!(query_auth_supported(None, &QueryAuthConfig::ServiceAccount).is_ok());
+        assert!(query_auth_supported(None, None, &QueryAuthConfig::ServiceAccount).is_ok());
     }
 
     #[test]
@@ -1580,27 +1621,58 @@ mod tests {
         for mode in [
             QueryAuthConfig::Passthrough,
             QueryAuthConfig::Impersonate,
-            QueryAuthConfig::TokenExchange(TokenExchangeConfig {
-                token_endpoint: "https://idp.example/token".to_string(),
-                client_id: "queryflux".to_string(),
-                client_secret: "secret".to_string(),
-                target_audience: None,
-                scope: None,
-            }),
+            token_exchange_mode(),
         ] {
             assert!(
-                query_auth_supported(Some(&EngineConfig::Trino), &mode).is_ok(),
+                query_auth_supported(Some(&EngineConfig::Trino), None, &mode).is_ok(),
                 "Trino should support {mode:?}"
             );
             assert!(
-                query_auth_supported(Some(&EngineConfig::ClickHouse), &mode).is_err(),
+                query_auth_supported(Some(&EngineConfig::ClickHouse), None, &mode).is_err(),
                 "ClickHouse should not support {mode:?} in this release"
             );
             assert!(
-                query_auth_supported(None, &mode).is_err(),
+                query_auth_supported(None, None, &mode).is_err(),
                 "an unknown engine should not support {mode:?}"
             );
         }
+    }
+
+    #[test]
+    fn adbc_token_exchange_allowed_only_for_snowflake_driver() {
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("snowflake"),
+            &token_exchange_mode()
+        )
+        .is_ok());
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("postgresql"),
+            &token_exchange_mode()
+        )
+        .is_err());
+        assert!(
+            query_auth_supported(Some(&EngineConfig::Adbc), None, &token_exchange_mode()).is_err()
+        );
+    }
+
+    #[test]
+    fn adbc_passthrough_and_impersonate_rejected_even_for_snowflake_driver() {
+        // Only tokenExchange is wired for ADBC in this release — passthrough/impersonate
+        // are rejected regardless of driver.
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("snowflake"),
+            &QueryAuthConfig::Passthrough
+        )
+        .is_err());
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("snowflake"),
+            &QueryAuthConfig::Impersonate
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/queryflux-core/src/config_json.rs
+++ b/crates/queryflux-core/src/config_json.rs
@@ -146,6 +146,7 @@ pub fn cluster_config_from_persisted_json(
         max_wait_secs: None,
         tls: None,
         max_result_buffer_bytes: None,
+        driver: json_str(config, "driver"),
         auth,
         query_auth,
     }

--- a/crates/queryflux-engine-adapters/Cargo.toml
+++ b/crates/queryflux-engine-adapters/Cargo.toml
@@ -29,3 +29,4 @@ adbc_core = "0.23"
 adbc_driver_manager = "0.23"
 r2d2 = "0.8"
 r2d2_adbc = { git = "https://github.com/amitgilad3/r2d2-adbc.git" }
+dashmap = { workspace = true }

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -6,6 +6,7 @@ use adbc_driver_manager::{ManagedDatabase, ManagedDriver};
 use arrow::array::Array;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
+use dashmap::DashMap;
 use queryflux_core::{
     catalog::TableSchema,
     config::ClusterConfig,
@@ -268,6 +269,52 @@ impl crate::EngineConfigParseable for AdbcConfig {
 
 type AdbcPool = r2d2::Pool<AdbcConnectionManager<ManagedDatabase>>;
 
+/// Small per-user pool, built on demand for `tokenExchange` clusters. Kept separate from
+/// the static `pool` (Type 1 / `serviceAccount`) because its `ManagedDatabase` bakes in a
+/// per-user OAuth token at connection-option time — there is no way to swap credentials on
+/// a checked-out connection from a shared pool, so a distinct user needs a distinct
+/// `ManagedDatabase`. Small size + idle eviction keep this from growing unbounded across a
+/// long-running process; see `identity_pool_for_token`.
+struct IdentityPoolEntry {
+    pool: AdbcPool,
+    last_used: std::time::Instant,
+}
+
+/// Max connections per per-identity sub-pool. Deliberately small — this exists to amortize
+/// the OAuth-token-scoped connection setup cost across the handful of queries a user runs
+/// in quick succession, not to serve as a general-purpose pool.
+const IDENTITY_POOL_MAX_SIZE: u32 = 2;
+
+/// Evict a per-identity sub-pool after this long without use. Roughly matches how often the
+/// resolver's own token cache refreshes (tokens are typically short-lived), so a pool rarely
+/// outlives the token it was built for by much.
+const IDENTITY_POOL_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+
+/// Per-driver OAuth connection-option keys for `tokenExchange`. Only `snowflake` is wired in
+/// this release — must stay in sync with `ADBC_TOKEN_EXCHANGE_DRIVERS` in
+/// `queryflux_core::config`, which is what actually gates which clusters can reach this code
+/// path (startup validation rejects `tokenExchange` for any other ADBC driver).
+fn oauth_token_options(
+    driver: &str,
+    token: &str,
+) -> Result<Vec<(OptionDatabase, adbc_core::options::OptionValue)>> {
+    match driver {
+        "snowflake" => Ok(vec![
+            (
+                OptionDatabase::Other("adbc.snowflake.sql.auth_type".to_string()),
+                "auth_oauth".into(),
+            ),
+            (
+                OptionDatabase::Other("adbc.snowflake.sql.client_option.auth_token".to_string()),
+                token.to_string().into(),
+            ),
+        ]),
+        other => Err(QueryFluxError::Engine(format!(
+            "ADBC driver '{other}' has no tokenExchange connection-option wiring in this release"
+        ))),
+    }
+}
+
 /// ADBC adapter — wraps any ADBC-compatible shared library driver.
 ///
 /// The driver is loaded once at construction via `load_from_name` (manifest-based, searches
@@ -277,6 +324,16 @@ pub struct AdbcAdapter {
     pub cluster_name: ClusterName,
     pub group_name: ClusterGroupName,
     pool: AdbcPool,
+    /// Kept (not dropped after `new()`) so per-identity `ManagedDatabase`s can be built on
+    /// demand — cheap to clone (`Arc` inside), see `adbc_driver_manager::ManagedDriver`.
+    driver: ManagedDriver,
+    /// Raw driver key (e.g. `"snowflake"`) — distinct from `engine_type`, which can be
+    /// overridden for `flightsql` via `flightSqlClusterDialect` and would then no longer
+    /// identify which OAuth option keys to use.
+    driver_name: String,
+    base_uri: String,
+    base_db_kwargs: Vec<(String, String)>,
+    identity_pools: Arc<DashMap<String, IdentityPoolEntry>>,
     engine_type: EngineType,
     translation_dialect: queryflux_core::query::SqlDialect,
 }
@@ -289,6 +346,9 @@ impl AdbcAdapter {
     ) -> Result<Self> {
         let engine_type = config.engine_type();
         let translation_dialect = config.flight_sql_translation_dialect();
+        let driver_name = config.driver.clone();
+        let base_uri = config.uri.clone();
+        let base_db_kwargs = config.db_kwargs.clone();
 
         let mut driver = ManagedDriver::load_from_name(
             &config.driver,
@@ -323,8 +383,9 @@ impl AdbcAdapter {
                 cluster_name.0
             ))
         })?;
-        // driver dropped here — ManagedDatabase holds Arc ref to driver internals,
-        // so the shared library remains loaded.
+        // `driver` is kept (not dropped) on the adapter so per-identity `ManagedDatabase`s
+        // can be built later for `tokenExchange` — see `identity_pool_for_token`. Cloning it
+        // is cheap (Arc-backed), and the shared library stays loaded via that Arc either way.
 
         let manager = AdbcConnectionManager::new(database);
         let pool = r2d2::Pool::builder()
@@ -341,9 +402,70 @@ impl AdbcAdapter {
             cluster_name,
             group_name,
             pool,
+            driver,
+            driver_name,
+            base_uri,
+            base_db_kwargs,
+            identity_pools: Arc::new(DashMap::new()),
             engine_type,
             translation_dialect,
         })
+    }
+
+    /// Return the small per-identity pool for `token`, building (and caching) it on first
+    /// use. Runs synchronously — call from a blocking context (`execute_as_arrow` already
+    /// dispatches into `spawn_blocking` for every query, so this rides along on that same
+    /// thread rather than needing its own).
+    ///
+    /// Sweeps idle entries on every call (same pattern as
+    /// `BackendIdentityResolver::exchange_token`'s cache) rather than running a background
+    /// task — the map holds at most one entry per active user, so this stays cheap.
+    fn identity_pool_for_token(&self, token: &str) -> Result<AdbcPool> {
+        let now = std::time::Instant::now();
+        if let Some(mut entry) = self.identity_pools.get_mut(token) {
+            entry.last_used = now;
+            return Ok(entry.pool.clone());
+        }
+
+        let opts = oauth_token_options(&self.driver_name, token)?;
+        let mut opts_with_uri = vec![(OptionDatabase::Uri, self.base_uri.clone().into())];
+        for (k, v) in &self.base_db_kwargs {
+            opts_with_uri.push((OptionDatabase::Other(k.clone()), v.clone().into()));
+        }
+        opts_with_uri.extend(opts);
+
+        let mut driver = self.driver.clone();
+        let database = driver.new_database_with_opts(opts_with_uri).map_err(|e| {
+            QueryFluxError::Engine(format!(
+                "cluster '{}': failed to create per-identity ADBC database: {e}",
+                self.cluster_name.0
+            ))
+        })?;
+        let manager = AdbcConnectionManager::new(database);
+        let pool = r2d2::Pool::builder()
+            .max_size(IDENTITY_POOL_MAX_SIZE)
+            .build(manager)
+            .map_err(|e| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': failed to create per-identity ADBC connection pool: {e}",
+                    self.cluster_name.0
+                ))
+            })?;
+
+        self.identity_pools.insert(
+            token.to_string(),
+            IdentityPoolEntry {
+                pool: pool.clone(),
+                last_used: now,
+            },
+        );
+        // Evict idle entries — bounds the map across a long-running process without a
+        // separate background task. O(n) in the number of distinct recent identities,
+        // which for a per-user OAuth pool is small.
+        self.identity_pools
+            .retain(|_, e| now.duration_since(e.last_used) < IDENTITY_POOL_IDLE_TTL);
+
+        Ok(pool)
     }
 
     pub fn descriptor() -> EngineDescriptor {
@@ -488,7 +610,7 @@ impl SyncAdapter for AdbcAdapter {
         &self,
         sql: &str,
         _session: &SessionContext,
-        _credentials: &queryflux_auth::QueryCredentials,
+        credentials: &queryflux_auth::QueryCredentials,
         _tags: &QueryTags,
         params: &queryflux_core::params::QueryParams,
         _id_slot: &BackendQueryIdSlot,
@@ -503,7 +625,20 @@ impl SyncAdapter for AdbcAdapter {
             attempt_id = %uuid::Uuid::new_v4(),
             "Executing ADBC query"
         );
-        let pool = self.pool.clone();
+        // `Bearer` is the only non-serviceAccount `QueryCredentials` that can reach an ADBC
+        // adapter — startup validation (`query_auth_supported`) rejects `passthrough`/
+        // `impersonate` for every ADBC driver, so `tokenExchange` (resolved to `Bearer`) is
+        // the only other case to handle here. `identity_pool_for_token` is a cheap DashMap
+        // lookup on cache hits; the miss path calls the driver FFI to build a new database,
+        // which can block, but that only happens once per user per token-cache window, so
+        // it's run inline on the async executor rather than adding a second spawn_blocking
+        // just for this rare path.
+        let pool = match credentials {
+            queryflux_auth::QueryCredentials::Bearer { token } => {
+                self.identity_pool_for_token(token)?
+            }
+            _ => self.pool.clone(),
+        };
         let sql = sql.to_string();
         let param_batch = if params.is_empty() {
             None
@@ -803,9 +938,35 @@ impl EngineAdapterFactory for AdbcFactory {
 
 #[cfg(test)]
 mod tests {
-    use super::AdbcConfig;
+    use super::{oauth_token_options, AdbcConfig};
     use crate::EngineConfigParseable;
     use queryflux_core::query::{EngineType, SqlDialect};
+
+    #[test]
+    fn oauth_token_options_snowflake_sets_auth_type_and_token() {
+        let opts = oauth_token_options("snowflake", "the-token").expect("snowflake is wired");
+        let keys: Vec<String> = opts.iter().map(|(k, _)| format!("{k:?}")).collect();
+        assert!(
+            keys.iter()
+                .any(|k| k.contains("adbc.snowflake.sql.auth_type")),
+            "missing auth_type option, got: {keys:?}"
+        );
+        assert!(
+            keys.iter()
+                .any(|k| k.contains("adbc.snowflake.sql.client_option.auth_token")),
+            "missing auth_token option, got: {keys:?}"
+        );
+    }
+
+    #[test]
+    fn oauth_token_options_rejects_unwired_drivers() {
+        for driver in ["postgresql", "mysql", "flightsql", "databricks", "unknown"] {
+            assert!(
+                oauth_token_options(driver, "token").is_err(),
+                "driver '{driver}' should not be wired for tokenExchange yet"
+            );
+        }
+    }
 
     #[test]
     fn trino_driver_maps_to_trino_engine_type() {

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -290,6 +290,10 @@ const IDENTITY_POOL_MAX_SIZE: u32 = 2;
 /// outlives the token it was built for by much.
 const IDENTITY_POOL_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 
+/// Bound on building a per-identity `ManagedDatabase` (the driver FFI call that can involve
+/// real OAuth token validation) — see `AdbcAdapter::identity_pool_for_token`.
+const IDENTITY_POOL_BUILD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Per-driver OAuth connection-option keys for `tokenExchange`. Only `snowflake` is wired in
 /// this release — must stay in sync with `ADBC_TOKEN_EXCHANGE_DRIVERS` in
 /// `queryflux_core::config`, which is what actually gates which clusters can reach this code
@@ -413,44 +417,78 @@ impl AdbcAdapter {
     }
 
     /// Return the small per-identity pool for `token`, building (and caching) it on first
-    /// use. Runs synchronously — call from a blocking context (`execute_as_arrow` already
-    /// dispatches into `spawn_blocking` for every query, so this rides along on that same
-    /// thread rather than needing its own).
+    /// use.
+    ///
+    /// The cache-hit path is a cheap `DashMap` lookup, safe to call directly from async
+    /// context. The cache-miss path calls the driver FFI (`new_database_with_opts`) — a
+    /// genuinely blocking call (Snowflake's driver validates the OAuth token, which can
+    /// mean real network I/O), so it runs inside `spawn_blocking` rather than directly on
+    /// the async executor — an earlier version of this comment claimed it "rides along" on
+    /// `execute_as_arrow`'s own `spawn_blocking`, which was wrong: this is called *before*
+    /// that, so without its own `spawn_blocking` it would have blocked whatever tokio
+    /// worker thread happened to be running the query. Also bounded by
+    /// [`IDENTITY_POOL_BUILD_TIMEOUT`] — left unbounded, a slow or unreachable Snowflake
+    /// OAuth endpoint would hang the query indefinitely instead of failing it.
     ///
     /// Sweeps idle entries on every call (same pattern as
     /// `BackendIdentityResolver::exchange_token`'s cache) rather than running a background
     /// task — the map holds at most one entry per active user, so this stays cheap.
-    fn identity_pool_for_token(&self, token: &str) -> Result<AdbcPool> {
+    async fn identity_pool_for_token(&self, token: &str) -> Result<AdbcPool> {
         let now = std::time::Instant::now();
         if let Some(mut entry) = self.identity_pools.get_mut(token) {
             entry.last_used = now;
             return Ok(entry.pool.clone());
         }
 
-        let opts = oauth_token_options(&self.driver_name, token)?;
-        let mut opts_with_uri = vec![(OptionDatabase::Uri, self.base_uri.clone().into())];
-        for (k, v) in &self.base_db_kwargs {
-            opts_with_uri.push((OptionDatabase::Other(k.clone()), v.clone().into()));
-        }
-        opts_with_uri.extend(opts);
-
+        let driver_name = self.driver_name.clone();
         let mut driver = self.driver.clone();
-        let database = driver.new_database_with_opts(opts_with_uri).map_err(|e| {
-            QueryFluxError::Engine(format!(
-                "cluster '{}': failed to create per-identity ADBC database: {e}",
-                self.cluster_name.0
-            ))
-        })?;
-        let manager = AdbcConnectionManager::new(database);
-        let pool = r2d2::Pool::builder()
-            .max_size(IDENTITY_POOL_MAX_SIZE)
-            .build(manager)
-            .map_err(|e| {
+        let base_uri = self.base_uri.clone();
+        let base_db_kwargs = self.base_db_kwargs.clone();
+        let cluster_name = self.cluster_name.0.clone();
+        let token_owned = token.to_string();
+
+        let build = tokio::task::spawn_blocking(move || -> Result<AdbcPool> {
+            let opts = oauth_token_options(&driver_name, &token_owned)?;
+            let mut opts_with_uri = vec![(OptionDatabase::Uri, base_uri.into())];
+            for (k, v) in &base_db_kwargs {
+                opts_with_uri.push((OptionDatabase::Other(k.clone()), v.clone().into()));
+            }
+            opts_with_uri.extend(opts);
+
+            let database = driver.new_database_with_opts(opts_with_uri).map_err(|e| {
                 QueryFluxError::Engine(format!(
-                    "cluster '{}': failed to create per-identity ADBC connection pool: {e}",
-                    self.cluster_name.0
+                    "cluster '{cluster_name}': failed to create per-identity ADBC database: {e}"
                 ))
             })?;
+            let manager = AdbcConnectionManager::new(database);
+            r2d2::Pool::builder()
+                .max_size(IDENTITY_POOL_MAX_SIZE)
+                .build(manager)
+                .map_err(|e| {
+                    QueryFluxError::Engine(format!(
+                        "cluster '{cluster_name}': failed to create per-identity ADBC \
+                         connection pool: {e}"
+                    ))
+                })
+        });
+
+        let pool = tokio::time::timeout(IDENTITY_POOL_BUILD_TIMEOUT, build)
+            .await
+            .map_err(|_| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': building a per-identity ADBC connection timed out after \
+                     {}s (the OAuth token validation may be slow or the identity backend \
+                     unreachable)",
+                    self.cluster_name.0,
+                    IDENTITY_POOL_BUILD_TIMEOUT.as_secs()
+                ))
+            })?
+            .map_err(|e| {
+                QueryFluxError::Engine(format!(
+                    "cluster '{}': per-identity ADBC connection task panicked: {e}",
+                    self.cluster_name.0
+                ))
+            })??;
 
         self.identity_pools.insert(
             token.to_string(),
@@ -462,8 +500,9 @@ impl AdbcAdapter {
         // Evict idle entries — bounds the map across a long-running process without a
         // separate background task. O(n) in the number of distinct recent identities,
         // which for a per-user OAuth pool is small.
+        let swept_at = std::time::Instant::now();
         self.identity_pools
-            .retain(|_, e| now.duration_since(e.last_used) < IDENTITY_POOL_IDLE_TTL);
+            .retain(|_, e| swept_at.duration_since(e.last_used) < IDENTITY_POOL_IDLE_TTL);
 
         Ok(pool)
     }
@@ -629,13 +668,11 @@ impl SyncAdapter for AdbcAdapter {
         // adapter — startup validation (`query_auth_supported`) rejects `passthrough`/
         // `impersonate` for every ADBC driver, so `tokenExchange` (resolved to `Bearer`) is
         // the only other case to handle here. `identity_pool_for_token` is a cheap DashMap
-        // lookup on cache hits; the miss path calls the driver FFI to build a new database,
-        // which can block, but that only happens once per user per token-cache window, so
-        // it's run inline on the async executor rather than adding a second spawn_blocking
-        // just for this rare path.
+        // lookup on cache hits; the miss path runs the blocking driver FFI call inside its
+        // own `spawn_blocking` with a timeout, not inline here.
         let pool = match credentials {
             queryflux_auth::QueryCredentials::Bearer { token } => {
-                self.identity_pool_for_token(token)?
+                self.identity_pool_for_token(token).await?
             }
             _ => self.pool.clone(),
         };

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -294,6 +294,15 @@ const IDENTITY_POOL_IDLE_TTL: std::time::Duration = std::time::Duration::from_se
 /// real OAuth token validation) — see `AdbcAdapter::identity_pool_for_token`.
 const IDENTITY_POOL_BUILD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Cap on concurrent per-identity pool builds (across all tokens) in flight at once.
+/// `tokio::time::timeout` gives up on *waiting* for a `spawn_blocking` task, but does not
+/// cancel it — the underlying OS thread keeps running the driver FFI call until it returns
+/// (or hangs) regardless. Without a cap, a burst of distinct identities hitting a slow or
+/// unreachable OAuth endpoint at the same time could each leave a zombie build running,
+/// piling up on the shared tokio blocking thread pool. Combined with single-flighting
+/// same-token builds (below), this bounds worst-case blocking-thread usage from this path.
+const IDENTITY_POOL_MAX_CONCURRENT_BUILDS: usize = 8;
+
 /// Per-driver OAuth connection-option keys for `tokenExchange`. Only `snowflake` is wired in
 /// this release — must stay in sync with `ADBC_TOKEN_EXCHANGE_DRIVERS` in
 /// `queryflux_core::config`, which is what actually gates which clusters can reach this code
@@ -338,6 +347,14 @@ pub struct AdbcAdapter {
     base_uri: String,
     base_db_kwargs: Vec<(String, String)>,
     identity_pools: Arc<DashMap<String, IdentityPoolEntry>>,
+    /// Per-token single-flight locks — serializes concurrent cache-miss builds for the same
+    /// token so a burst of queries from one identity builds exactly one pool instead of
+    /// racing to build (and discard all but the last of) several. See
+    /// `identity_pool_for_token`.
+    identity_pool_build_locks: Arc<DashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Caps total concurrent per-identity pool builds across all tokens. See
+    /// `IDENTITY_POOL_MAX_CONCURRENT_BUILDS`.
+    identity_pool_build_semaphore: Arc<tokio::sync::Semaphore>,
     engine_type: EngineType,
     translation_dialect: queryflux_core::query::SqlDialect,
 }
@@ -411,6 +428,10 @@ impl AdbcAdapter {
             base_uri,
             base_db_kwargs,
             identity_pools: Arc::new(DashMap::new()),
+            identity_pool_build_locks: Arc::new(DashMap::new()),
+            identity_pool_build_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                IDENTITY_POOL_MAX_CONCURRENT_BUILDS,
+            )),
             engine_type,
             translation_dialect,
         })
@@ -430,15 +451,51 @@ impl AdbcAdapter {
     /// [`IDENTITY_POOL_BUILD_TIMEOUT`] — left unbounded, a slow or unreachable Snowflake
     /// OAuth endpoint would hang the query indefinitely instead of failing it.
     ///
-    /// Sweeps idle entries on every call (same pattern as
-    /// `BackendIdentityResolver::exchange_token`'s cache) rather than running a background
-    /// task — the map holds at most one entry per active user, so this stays cheap.
+    /// Concurrent cache misses for the *same* token are single-flighted through
+    /// `identity_pool_build_locks`: only the first caller actually builds; the rest wait on
+    /// the per-token lock and then hit the now-populated cache. Without this, a burst of
+    /// queries from one identity would each build (and all but one immediately discard) a
+    /// real Snowflake connection — wasted OAuth validation calls, not just wasted CPU.
+    /// `identity_pool_build_semaphore` additionally caps concurrent builds *across* distinct
+    /// tokens, since a timed-out build's `spawn_blocking` task keeps running rather than
+    /// being cancelled (see `IDENTITY_POOL_MAX_CONCURRENT_BUILDS`).
+    ///
+    /// Sweeps idle entries at the *start* of every call, before the cache-hit check —
+    /// sweeping only on the (rarer, in steady state) miss path would let an expired pool
+    /// stay reachable indefinitely as long as it kept getting cache hits.
     async fn identity_pool_for_token(&self, token: &str) -> Result<AdbcPool> {
         let now = std::time::Instant::now();
+        self.identity_pools
+            .retain(|_, e| now.duration_since(e.last_used) < IDENTITY_POOL_IDLE_TTL);
+
         if let Some(mut entry) = self.identity_pools.get_mut(token) {
             entry.last_used = now;
             return Ok(entry.pool.clone());
         }
+
+        let lock = self
+            .identity_pool_build_locks
+            .entry(token.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _build_guard = lock.lock().await;
+
+        // Re-check: another waiter may have just finished building this token's pool while
+        // we were waiting for the lock.
+        if let Some(mut entry) = self.identity_pools.get_mut(token) {
+            entry.last_used = std::time::Instant::now();
+            self.identity_pool_build_locks.remove(token);
+            return Ok(entry.pool.clone());
+        }
+
+        let permit = self
+            .identity_pool_build_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| {
+                QueryFluxError::Engine(format!("identity pool build semaphore closed: {e}"))
+            })?;
 
         let driver_name = self.driver_name.clone();
         let mut driver = self.driver.clone();
@@ -448,6 +505,7 @@ impl AdbcAdapter {
         let token_owned = token.to_string();
 
         let build = tokio::task::spawn_blocking(move || -> Result<AdbcPool> {
+            let _permit = permit;
             let opts = oauth_token_options(&driver_name, &token_owned)?;
             let mut opts_with_uri = vec![(OptionDatabase::Uri, base_uri.into())];
             for (k, v) in &base_db_kwargs {
@@ -472,7 +530,7 @@ impl AdbcAdapter {
                 })
         });
 
-        let pool = tokio::time::timeout(IDENTITY_POOL_BUILD_TIMEOUT, build)
+        let result = tokio::time::timeout(IDENTITY_POOL_BUILD_TIMEOUT, build)
             .await
             .map_err(|_| {
                 QueryFluxError::Engine(format!(
@@ -482,29 +540,36 @@ impl AdbcAdapter {
                     self.cluster_name.0,
                     IDENTITY_POOL_BUILD_TIMEOUT.as_secs()
                 ))
-            })?
-            .map_err(|e| {
-                QueryFluxError::Engine(format!(
-                    "cluster '{}': per-identity ADBC connection task panicked: {e}",
-                    self.cluster_name.0
-                ))
-            })??;
+            })
+            .and_then(|joined| {
+                joined.map_err(|e| {
+                    QueryFluxError::Engine(format!(
+                        "cluster '{}': per-identity ADBC connection task panicked: {e}",
+                        self.cluster_name.0
+                    ))
+                })
+            })
+            .and_then(|built| built);
 
-        self.identity_pools.insert(
-            token.to_string(),
-            IdentityPoolEntry {
-                pool: pool.clone(),
-                last_used: now,
-            },
-        );
-        // Evict idle entries — bounds the map across a long-running process without a
-        // separate background task. O(n) in the number of distinct recent identities,
-        // which for a per-user OAuth pool is small.
-        let swept_at = std::time::Instant::now();
-        self.identity_pools
-            .retain(|_, e| swept_at.duration_since(e.last_used) < IDENTITY_POOL_IDLE_TTL);
+        // Populate the cache (on success) *before* releasing the single-flight lock, so a
+        // brand-new caller that arrives right after the lock is released is guaranteed to
+        // see the cache hit rather than racing to start a redundant build. Release the lock
+        // regardless of outcome — a build failure must not wedge every subsequent attempt
+        // for this token behind a lock nobody will ever release again (the `Arc<Mutex>`
+        // itself is dropped along with the map entry once every clone — including whichever
+        // waiters are still parked on `.lock().await` — has released it).
+        if let Ok(pool) = &result {
+            self.identity_pools.insert(
+                token.to_string(),
+                IdentityPoolEntry {
+                    pool: pool.clone(),
+                    last_used: std::time::Instant::now(),
+                },
+            );
+        }
+        self.identity_pool_build_locks.remove(token);
 
-        Ok(pool)
+        result
     }
 
     pub fn descriptor() -> EngineDescriptor {

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -834,6 +834,7 @@ mod tests {
             tls: None,
             max_wait_secs: None,
             max_result_buffer_bytes: None,
+            driver: None,
             auth: None,
             query_auth: None,
         };

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -1685,7 +1685,11 @@ fn validate_query_auth_for_upsert(body: &UpsertClusterConfig) -> std::result::Re
         queryflux_core::engine_registry::parse_query_auth_from_config_json(&body.config)
             .map_err(|e| e.to_string())?;
     if let Some(mode) = &query_auth {
-        queryflux_core::config::query_auth_supported(Some(&engine), mode)?;
+        // ADBC's `driver` key lives in the raw config JSON, not on `EngineConfig` itself —
+        // `query_auth_supported` needs it to tell an OAuth-capable driver (e.g. snowflake)
+        // apart from one that isn't.
+        let driver = body.config.get("driver").and_then(|v| v.as_str());
+        queryflux_core::config::query_auth_supported(Some(&engine), driver, mode)?;
     }
     Ok(())
 }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -702,13 +702,16 @@ async fn main() -> Result<()> {
 
     // --- Startup validation: engine × queryAuth support matrix ---
     // Centralized in `query_auth_supported` so YAML load, Studio PUT, and this check can't
-    // drift apart. `passthrough`/`impersonate`/`tokenExchange` are Trino-only in this
-    // release — every other adapter still ignores `QueryCredentials`.
+    // drift apart. `passthrough`/`impersonate` are Trino-only; `tokenExchange` is Trino or
+    // ADBC-with-an-OAuth-capable-driver (`cfg.driver`, only ever set for admin-API-created
+    // ADBC clusters — see `ClusterConfig::driver`).
     for (name, cfg) in &config.clusters {
         if let Some(mode) = &cfg.query_auth {
-            if let Err(msg) =
-                queryflux_core::config::query_auth_supported(cfg.engine.as_ref(), mode)
-            {
+            if let Err(msg) = queryflux_core::config::query_auth_supported(
+                cfg.engine.as_ref(),
+                cfg.driver.as_deref(),
+                mode,
+            ) {
                 anyhow::bail!("cluster '{name}': {msg}");
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-user OAuth token exchange for supported ADBC connections, including Snowflake.
  * Added support for persisting the selected ADBC driver with cluster configuration.
  * Preserved authentication when cancelling running or abandoned queries.

* **Bug Fixes**
  * Prevented token-exchange authentication from falling back to service-account credentials when exchange fails.
  * Added validation to reject unsupported query-authentication and engine combinations.

* **Warnings**
  * Added startup warnings for potentially unrestricted Trino passthrough authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->