### PR TITLE
feat: ClickHouse impersonate via EXECUTE AS

### DIFF
--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1271,6 +1271,13 @@ pub fn query_auth_supported(
     };
     match engine {
         Some(EngineConfig::Trino) => Ok(()),
+        Some(EngineConfig::ClickHouse) if matches!(mode, QueryAuthConfig::Impersonate) => Ok(()),
+        Some(EngineConfig::ClickHouse) => Err(format!(
+            "queryAuth.type = {mode_name} is not supported for ClickHouse in this release \
+             (only impersonate, self-hosted ClickHouse 25.11+ with \
+             access_control_improvements.allow_impersonate_user = 1 and GRANT IMPERSONATE — \
+             not supported on ClickHouse Cloud)"
+        )),
         Some(EngineConfig::Adbc)
             if matches!(mode, QueryAuthConfig::TokenExchange(_))
                 && driver.is_some_and(|d| ADBC_TOKEN_EXCHANGE_DRIVERS.contains(&d)) =>
@@ -1289,8 +1296,9 @@ pub fn query_auth_supported(
                 .map(|e| format!("{e:?}"))
                 .unwrap_or_else(|| "<unknown>".to_string());
             Err(format!(
-                "queryAuth.type = {mode_name} is only supported for Trino (and tokenExchange \
-                 for ADBC/snowflake) in this release, got {engine_name}"
+                "queryAuth.type = {mode_name} is only supported for Trino, ClickHouse \
+                 (impersonate only), and ADBC/snowflake (tokenExchange only) in this release, \
+                 got {engine_name}"
             ))
         }
     }
@@ -1617,7 +1625,7 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_impersonate_token_exchange_allowed_only_for_trino() {
+    fn passthrough_impersonate_token_exchange_allowed_for_trino() {
         for mode in [
             QueryAuthConfig::Passthrough,
             QueryAuthConfig::Impersonate,
@@ -1628,14 +1636,32 @@ mod tests {
                 "Trino should support {mode:?}"
             );
             assert!(
-                query_auth_supported(Some(&EngineConfig::ClickHouse), None, &mode).is_err(),
-                "ClickHouse should not support {mode:?} in this release"
-            );
-            assert!(
                 query_auth_supported(None, None, &mode).is_err(),
                 "an unknown engine should not support {mode:?}"
             );
         }
+    }
+
+    #[test]
+    fn clickhouse_allows_only_impersonate() {
+        assert!(query_auth_supported(
+            Some(&EngineConfig::ClickHouse),
+            None,
+            &QueryAuthConfig::Impersonate
+        )
+        .is_ok());
+        assert!(query_auth_supported(
+            Some(&EngineConfig::ClickHouse),
+            None,
+            &QueryAuthConfig::Passthrough
+        )
+        .is_err());
+        assert!(query_auth_supported(
+            Some(&EngineConfig::ClickHouse),
+            None,
+            &token_exchange_mode()
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1225,8 +1225,10 @@ pub enum QueryAuthConfig {
     /// until their adapters are wired (see `query_auth_supported`).
     #[serde(rename = "passthrough")]
     Passthrough,
-    /// Service account authenticates to the backend; user identity injected via `X-Trino-User`.
-    /// **Trino only** — startup validation rejects this for other engines.
+    /// Service account authenticates to the backend; user identity injected via an
+    /// engine-specific mechanism — Trino's `X-Trino-User` header, or ClickHouse's
+    /// `EXECUTE AS {user} {sql}` (self-hosted 25.11+ only, requires `GRANT IMPERSONATE`).
+    /// **Trino and ClickHouse** — startup validation rejects this for other engines.
     #[serde(rename = "impersonate")]
     Impersonate,
     /// Exchange the user's OIDC JWT (RFC 8693) for a backend-scoped OAuth token.
@@ -1234,8 +1236,8 @@ pub enum QueryAuthConfig {
     /// **Fails closed**: if `raw_token` is absent or the exchange fails, the query is
     /// rejected with an auth error — it never silently falls back to `serviceAccount`,
     /// since that would submit the query under the wrong principal.
-    /// **Trino only in this release** — startup validation rejects this for other engines
-    /// until their adapters are wired (see `query_auth_supported`).
+    /// **Trino, and ADBC/Snowflake** in this release — startup validation rejects this for
+    /// other engines/drivers until their adapters are wired (see `query_auth_supported`).
     #[serde(rename = "tokenExchange")]
     TokenExchange(TokenExchangeConfig),
 }

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -508,6 +508,22 @@ fn escape_ident(ident: &str) -> String {
     format!("`{}`", ident.replace('\\', "\\\\").replace('`', "``"))
 }
 
+/// Wrap `sql` in `EXECUTE AS {user} {sql}` for `queryAuth: impersonate`.
+///
+/// Requires ClickHouse 25.11+ with `access_control_improvements.allow_impersonate_user = 1`
+/// and `GRANT IMPERSONATE ON {user} TO {service_account}` — QueryFlux cannot verify either
+/// remotely, so an unsupported/ungranted server surfaces this as an ordinary ClickHouse
+/// query error (caught by the normal error path in `execute_as_arrow`), not a startup
+/// failure. **Self-hosted only** — not supported on ClickHouse Cloud.
+///
+/// Only safe for a single statement: `EXECUTE AS` applies to the one query that follows it,
+/// so multi-statement `sql` would only impersonate the first statement while running the
+/// rest as the service account. QueryFlux's ClickHouse HTTP path already sends one
+/// statement per request, so this holds today but would need revisiting if that changes.
+fn wrap_execute_as(user: &str, sql: &str) -> String {
+    format!("EXECUTE AS {} {}", escape_ident(user), sql.trim())
+}
+
 /// True when `id` is safe to interpolate into `KILL QUERY WHERE query_id = '…'`.
 /// QueryFlux mints UUIDs; this also rejects anything a confused caller might pass.
 fn is_safe_query_id(id: &str) -> bool {
@@ -537,7 +553,7 @@ impl crate::SyncAdapter for ClickHouseAdapter {
         &self,
         sql: &str,
         session: &SessionContext,
-        _credentials: &queryflux_auth::QueryCredentials,
+        credentials: &queryflux_auth::QueryCredentials,
         tags: &QueryTags,
         // Dispatch interpolates params into the SQL before calling — this
         // adapter reports `supports_native_params() == false` (the default).
@@ -546,7 +562,14 @@ impl crate::SyncAdapter for ClickHouseAdapter {
     ) -> Result<SyncExecution> {
         let query_id = uuid::Uuid::new_v4().to_string();
         id_slot.publish(query_id.clone());
-        let mut req = self.query_request_with_id(sql, "ArrowStream", &query_id);
+        // `passthrough`/`tokenExchange` never reach here — startup validation
+        // (`query_auth_supported`) rejects them for ClickHouse, and `serviceAccount` is a
+        // no-op below. `impersonate` is the only mode ClickHouse adapts SQL for.
+        let effective_sql = match credentials {
+            queryflux_auth::QueryCredentials::Impersonate { user } => wrap_execute_as(user, sql),
+            _ => sql.to_string(),
+        };
+        let mut req = self.query_request_with_id(&effective_sql, "ArrowStream", &query_id);
         if let Some(db) = session.database() {
             req = req.query(&[("database", db)]);
         }
@@ -1060,6 +1083,30 @@ mod tests {
         assert_eq!(escape_ident("db"), "`db`");
         assert_eq!(escape_ident("we`ird"), "`we``ird`");
         assert_eq!(escape_ident(r"back\slash"), r"`back\\slash`");
+    }
+
+    #[test]
+    fn execute_as_wraps_sql_with_backtick_quoted_user() {
+        assert_eq!(
+            wrap_execute_as("alice", "SELECT 1"),
+            "EXECUTE AS `alice` SELECT 1"
+        );
+    }
+
+    #[test]
+    fn execute_as_quotes_a_user_needing_escaping() {
+        assert_eq!(
+            wrap_execute_as("we`ird", "SELECT 1"),
+            "EXECUTE AS `we``ird` SELECT 1"
+        );
+    }
+
+    #[test]
+    fn execute_as_trims_surrounding_whitespace_from_sql() {
+        assert_eq!(
+            wrap_execute_as("alice", "  SELECT 1  \n"),
+            "EXECUTE AS `alice` SELECT 1"
+        );
     }
 
     #[test]

--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -553,7 +553,7 @@ This is high operator burden. For OIDC deployments where Trino is configured wit
 The adapter wraps the outgoing SQL as `EXECUTE AS {user} {sql}` — the service account (`cluster.auth`) still authenticates the HTTP request; `EXECUTE AS` re-scopes just that one query to run as `user`. Only safe for a single statement per request, which matches how QueryFlux's ClickHouse HTTP path already works.
 
 **ClickHouse-side requirements**, verified against the current upstream docs and changelog (not guessed):
-- **ClickHouse 25.11 or newer** — `EXECUTE AS` was added in that release ([clickhouse#39048](https://github.com/ClickHouse/ClickHouse/issues/39048)).
+- **ClickHouse 25.11 or newer** — `EXECUTE AS` was added in that release ([`EXECUTE AS` documentation](https://clickhouse.com/docs/sql-reference/statements/execute_as), [25.11 release notes](https://clickhouse.com/blog/clickhouse-release-25-11)).
 - **Self-hosted only** — the current ClickHouse docs state `EXECUTE AS` is not supported on ClickHouse Cloud.
 - Server setting `access_control_improvements.allow_impersonate_user = 1`.
 - `GRANT IMPERSONATE ON {user} TO {service_account}` (or `GRANT IMPERSONATE ON * TO {service_account}` for all users).

--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -86,10 +86,11 @@ clusters:
 | Engine | `serviceAccount` | `passthrough` | `impersonate` | `tokenExchange` |
 |--------|:---:|:---:|:---:|:---:|
 | Trino | ✅ | ✅ | ✅ `X-Trino-User` (needs Trino file-based ACL) | ✅ |
-| ClickHouse | ✅ | ❌ not yet wired | ❌ no trusted proxy mechanism | ❌ not yet wired |
+| ClickHouse | ✅ | ❌ not yet wired | ✅ `EXECUTE AS` (self-hosted 25.11+ only, see below) | ❌ not yet wired |
 | StarRocks (MySQL wire) | ✅ | ❌ no wire mechanism | ❌ no wire mechanism | ❌ no wire mechanism |
 | StarRocks (HTTP, future) | ✅ | — | — | — |
-| Snowflake / Databricks (ADBC, future) | ✅ | ❌ not yet wired | ❌ | ❌ not yet wired |
+| Snowflake (ADBC) | ✅ | ❌ not yet wired | ❌ | ✅ per-identity connection pool |
+| Databricks (ADBC, future) | ✅ | ❌ not yet wired | ❌ | ❌ not yet wired |
 | DuckDB | ✅ (no-op) | — | — | — |
 
 "Not yet wired" means the adapter does not yet consume `QueryCredentials` for that mode — startup validation rejects the config rather than silently accepting it and doing nothing. See the backend-identity plan for the phase that adds each one.
@@ -121,10 +122,12 @@ fn resolve(auth_ctx: &AuthContext, cluster: &ClusterConfig, type1: &ClusterAuth)
             // Use Type 1 credentials on the wire; inject user identity separately.
             // IMPORTANT: suppress the client's Authorization header — do NOT forward it.
             // Only Type 1 (service account) auth reaches the backend.
-            // User identity is injected via engine-specific header AFTER authentication.
+            // User identity is injected via an engine-specific mechanism AFTER
+            // authentication: Trino sets X-Trino-User; ClickHouse wraps the SQL as
+            // `EXECUTE AS {user} {sql}`.
             ImpersonateCreds {
                 service_auth: type1.clone(),  // resolved profile or cluster.auth
-                user: auth_ctx.user.clone(),    // injected as X-Trino-User (Trino only)
+                user: auth_ctx.user.clone(),
             }
 
         tokenExchange =>
@@ -524,11 +527,12 @@ Forward the client's own credential unchanged: the value already captured in `Se
 
 Startup validation rejects `passthrough` for engines whose adapters don't yet consume `QueryCredentials` — see the compatibility table above.
 
-### Mode: `impersonate` (Trino only)
+### Mode: `impersonate` (Trino, ClickHouse)
 
-Service account authenticates to the backend; user identity injected via `X-Trino-User` header.
+Service account authenticates to the backend; user identity injected via an engine-specific mechanism — a header for Trino, a SQL prefix for ClickHouse.
 
-**Authorization header handling:**
+**Trino:**
+
 1. Remove client's `Authorization` header from the outgoing request
 2. Apply `cluster.auth` (Type 1, Basic or Bearer) as the backend authentication
 3. Set `X-Trino-User: {auth_ctx.user}` header
@@ -544,7 +548,19 @@ http-server.access-control.config-files=/etc/trino/rules.json
 
 This is high operator burden. For OIDC deployments where Trino is configured with JWT auth pointing to the same IdP, prefer explicit `queryAuth: passthrough` over `impersonate` — omitting `queryAuth` relies on the deprecated implicit forwarding path (see above); new configs should never depend on it.
 
-**Only Trino supports `impersonate`.** ClickHouse's `X-ClickHouse-User` is an auth username requiring a matching password — it is not an impersonation header and has no trusted-proxy mechanism. StarRocks has no equivalent over MySQL wire. Startup validation rejects `impersonate` for any other engine type.
+**ClickHouse:**
+
+The adapter wraps the outgoing SQL as `EXECUTE AS {user} {sql}` — the service account (`cluster.auth`) still authenticates the HTTP request; `EXECUTE AS` re-scopes just that one query to run as `user`. Only safe for a single statement per request, which matches how QueryFlux's ClickHouse HTTP path already works.
+
+**ClickHouse-side requirements**, verified against the current upstream docs and changelog (not guessed):
+- **ClickHouse 25.11 or newer** — `EXECUTE AS` was added in that release ([clickhouse#39048](https://github.com/ClickHouse/ClickHouse/issues/39048)).
+- **Self-hosted only** — the current ClickHouse docs state `EXECUTE AS` is not supported on ClickHouse Cloud.
+- Server setting `access_control_improvements.allow_impersonate_user = 1`.
+- `GRANT IMPERSONATE ON {user} TO {service_account}` (or `GRANT IMPERSONATE ON * TO {service_account}` for all users).
+
+QueryFlux cannot verify any of these remotely at startup — an unsupported version, a Cloud endpoint, or a missing grant all surface as an ordinary ClickHouse query error at run time (not a startup failure), since `EXECUTE AS` is just SQL syntax as far as the adapter is concerned.
+
+**Only Trino and ClickHouse support `impersonate`.** StarRocks has no equivalent over MySQL wire (no trusted-proxy mechanism). Startup validation rejects `impersonate` for any other engine type.
 
 ### Mode: `tokenExchange` (Trino only in this release)
 

--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -560,6 +560,8 @@ The adapter wraps the outgoing SQL as `EXECUTE AS {user} {sql}` — the service 
 
 QueryFlux cannot verify any of these remotely at startup — an unsupported version, a Cloud endpoint, or a missing grant all surface as an ordinary ClickHouse query error at run time (not a startup failure), since `EXECUTE AS` is just SQL syntax as far as the adapter is concerned.
 
+**Cancelling an impersonated query needs `KILL QUERY` too.** `EXECUTE AS` re-scopes the query to run as `user`, so ClickHouse attributes it to `user`, not the service account. `cancel_query` issues `KILL QUERY WHERE query_id = …` using the service account's own connection (it doesn't re-apply per-query wire auth — there's nothing to re-apply for `impersonate`, since the identity is baked into the SQL text at submit time, not carried as a separate credential). By default, ClickHouse's `KILL QUERY` privilege only lets a user kill their *own* queries; killing a different user's requires the global `KILL QUERY` privilege, granted with `GRANT KILL QUERY ON *.* TO {service_account}`. Without it, cancelling an impersonated query fails server-side (`User {service_account} attempts to kill query created by {user}`) — caught by the existing best-effort cancel error handling (logged, ignored), so the query keeps running until it finishes on its own.
+
 **Only Trino and ClickHouse support `impersonate`.** StarRocks has no equivalent over MySQL wire (no trusted-proxy mechanism). Startup validation rejects `impersonate` for any other engine type.
 
 ### Mode: `tokenExchange` (Trino only in this release)


### PR DESCRIPTION
## Summary
- Wires `queryAuth: impersonate` into the ClickHouse adapter by wrapping outgoing SQL as `EXECUTE AS {user} {sql}` — the service account still authenticates the HTTP request via `cluster.auth`; `EXECUTE AS` re-scopes just that one query to run as the target user.
- `passthrough`/`tokenExchange` stay rejected for ClickHouse — no mechanism for either.
- Verified against current upstream docs/changelog (not guessed) after an earlier plan review flagged conflicting signals on Cloud-vs-self-hosted support:
  - `EXECUTE AS` added in ClickHouse **25.11** (2025-11-27), resolving [clickhouse#39048](https://github.com/ClickHouse/ClickHouse/issues/39048) — confirmed via the official changelog.
  - Confirmed **unsupported on ClickHouse Cloud**, self-hosted only, per the current `EXECUTE AS` docs page.
  - Requires server setting `access_control_improvements.allow_impersonate_user = 1` and `GRANT IMPERSONATE ON {user} TO {service_account}`.
- QueryFlux can't verify version/setting/grant remotely at startup — an unsupported deployment surfaces as an ordinary ClickHouse query error at run time, not a startup failure.
- `query_auth_supported` now allows ClickHouse + `impersonate` only.

## Test plan
- [x] Unit tests for `wrap_execute_as` (backtick-quoting, escaping, whitespace trimming)
- [x] `query_auth_supported` tests: ClickHouse allows impersonate, rejects passthrough/tokenExchange
- [x] Full workspace build + fmt --check + clippy -D warnings clean
- [x] 420 tests pass across queryflux-core/auth/engine-adapters/frontend/queryflux
- [ ] No live ClickHouse 25.11+ integration test (needs a real server with the impersonate grant configured — out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickHouse support for impersonation authentication.
  * Impersonated queries now execute under the selected user’s identity.
  * Added validation to ensure unsupported ClickHouse authentication modes are rejected.

* **Documentation**
  * Documented ClickHouse impersonation requirements, supported query behavior, and runtime limitations.
  * Updated authentication compatibility information for Trino, ClickHouse, Snowflake, and Databricks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->