### PR TITLE
docs: showcase auth/authz and backend identity for the next release

### DIFF
--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -1,0 +1,130 @@
+---
+sidebar_position: 3
+sidebar_label: Authentication & identity
+title: Authentication, Authorization & Backend Identity
+description: Configure who can reach QueryFlux, what they can do, and which identity your queries run as on Trino, ClickHouse, StarRocks, and Snowflake.
+image: img/queryflux-hero-banner.png
+---
+# Authentication, authorization & backend identity
+
+QueryFlux separates three questions, each configured independently:
+
+| Question | Config key | Answers |
+| --- | --- | --- |
+| **Who is this client?** | `auth` | none, static users, OIDC, LDAP |
+| **What are they allowed to do?** | `authorization` | allow-all, per-group allow-lists, OpenFGA |
+| **Which identity reaches the backend engine?** | `clusters[].queryAuth` | the service account, the client's own credential, an impersonated user, or an exchanged token |
+
+The first two gate access to QueryFlux itself. The third — **backend identity** — decides what Trino, ClickHouse, StarRocks, or Snowflake see as the query's principal, which matters for the backend's own audit log, row-level security, and access control.
+
+---
+
+## Frontend authentication (`auth`)
+
+```yaml
+auth:
+  provider: oidc          # none | static | oidc | ldap
+  required: true
+  oidc:
+    issuer: https://keycloak.internal/realms/my-realm
+    jwksUri: https://keycloak.internal/realms/my-realm/protocol/openid-connect/certs
+    audience: queryflux
+    groupsClaim: groups
+    rolesClaim: roles
+```
+
+| Provider | Use when |
+| --- | --- |
+| `none` | Local development, or the network path to QueryFlux is already trusted (e.g. a private VPC with its own perimeter) |
+| `static` | A small, fixed set of service users — bcrypt-hashed passwords in config |
+| `oidc` | You already run an IdP (Keycloak, Okta, Auth0, Entra ID) and want SSO |
+| `ldap` | Active Directory / OpenLDAP-backed organizations |
+
+`auth.required: true` rejects unauthenticated requests on every enabled frontend. `AuthContext` (the verified identity — user, groups, roles, and the raw OIDC token when applicable) is what the rest of this page builds on.
+
+---
+
+## Authorization (`authorization`)
+
+```yaml
+authorization:
+  provider: none   # none | openfga
+
+clusterGroups:
+  analytics:
+    authorization:
+      allowGroups: [data-team, analysts]
+      allowUsers: [oncall-bot]
+```
+
+`provider: none` with no `allowGroups`/`allowUsers` on any group is **allow-all** — anyone who authenticates to QueryFlux can route to anything. Add per-group allow-lists to restrict that without standing up a full policy engine, or set `provider: openfga` for Zanzibar-style fine-grained authorization.
+
+:::warning
+`authorization` gates **routing** — which cluster group a client can reach. It does not decide which identity a query runs under on the backend; that's `queryAuth`, below. A client authorized to route to a `passthrough` cluster still only sees what its own backend credential is allowed to see.
+:::
+
+---
+
+## Backend identity (`queryAuth`)
+
+This is the piece that decides what the **engine itself** sees as the query's user — independent of how the client authenticated to QueryFlux.
+
+```yaml
+clusters:
+  trino-1:
+    engine: trino
+    endpoint: https://trino.internal:8443
+    auth:                      # Type 1 — QueryFlux's own service credential
+      type: basic
+      username: qf_svc
+      password: "..."
+    queryAuth:                 # Type 2 — which identity the query runs as
+      type: impersonate
+```
+
+| Mode | The backend sees | Engines |
+| --- | --- | --- |
+| `serviceAccount` *(default)* | QueryFlux's own service credential only — the user is known to QueryFlux for audit/routing, not proven to the backend | All |
+| `passthrough` | The client's own credential, forwarded unchanged | Trino, StarRocks (MySQL wire, LDAP-backed) |
+| `impersonate` | The service account authenticates; the real user is injected via an engine-specific mechanism (`X-Trino-User`, ClickHouse `EXECUTE AS`) | Trino, ClickHouse |
+| `tokenExchange` | A backend-scoped OAuth token, exchanged (RFC 8693) from the client's own token | Trino, Snowflake (ADBC) |
+
+### Which mode should I use?
+
+- **Same IdP on both sides, engine trusts bearer tokens directly** (Trino with JWT auth against the same Keycloak realm) → `passthrough`. Simplest — the engine validates the token itself, QueryFlux just forwards it.
+- **Engine needs a fixed service principal but you still want per-user attribution in its own audit log** (Trino/ClickHouse ACLs, `system.query_log`) → `impersonate`.
+- **Engine speaks OAuth but not your IdP's token format directly** (Snowflake external OAuth, a Trino cluster in a different trust domain) → `tokenExchange`.
+- **Engine has no per-user wire mechanism, or you haven't set any of this up yet** → `serviceAccount`. This is the default and always works; it's the starting point, not a fallback to be embarrassed about.
+
+Every mode other than `serviceAccount` **fails closed**: if the client has no forwardable credential, the exchange fails, or the caller is unauthenticated, the query is rejected — QueryFlux never silently downgrades to the service account and submits under the wrong principal.
+
+### Engine-specific requirements
+
+Backend identity needs a small amount of setup on the engine side — QueryFlux can't configure your engine's own access control for you:
+
+- **Trino `impersonate`** — requires file-based access control granting the service account impersonation rights (`http-server.access-control.config-files`). Trino denies impersonation by default.
+- **ClickHouse `impersonate`** — requires ClickHouse **25.11+, self-hosted** (not supported on ClickHouse Cloud), `access_control_improvements.allow_impersonate_user = 1`, and `GRANT IMPERSONATE ON {user} TO {service_account}`. Cancelling an impersonated query additionally needs `GRANT KILL QUERY ON *.*` on the service account.
+- **StarRocks `passthrough`** — authenticates each query on a dedicated connection as the target user via `authentication_ldap_simple`. Requires the cluster endpoint to use TLS (`?require_ssl=true`) and the passthrough user to hold `OPERATE` for `cancel_query` to work.
+- **Snowflake `tokenExchange`** — the exchanged token is sent as `adbc.snowflake.sql.client_option.auth_token` with `auth_type=auth_oauth`; register QueryFlux as an OAuth client in the same IdP as the target Snowflake OAuth integration.
+
+Full per-engine wiring, the resolver's fail-closed contract, and the `queryAuth` × engine compatibility matrix: **[Auth & authorization design](/docs/architecture/auth-authz-design)**.
+
+---
+
+## Try it
+
+**[`examples/with-keycloak-oidc`](https://github.com/lakeops-org/queryflux/tree/main/examples/with-keycloak-oidc)** is a runnable Docker Compose stack: Keycloak as the IdP, Trino as the backend, and three ready-to-swap configs — `config.yaml` (`passthrough`), `config-impersonate.yaml`, `config-token-exchange.yaml`.
+
+```bash
+cd examples/with-keycloak-oidc
+docker compose up -d --wait
+
+TOKEN=$(curl -s http://localhost:8180/realms/queryflux/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=queryflux \
+  -d username=alice -d password=alice | jq -r .access_token)
+
+curl -X POST http://localhost:8080/v1/statement \
+  -H "Authorization: Bearer $TOKEN" -d "SELECT current_user"
+```
+
+See the example's own README for the full walkthrough, including how to swap between the three `queryAuth` modes.

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -58,6 +58,34 @@ routers:
 routingFallback: trino-default
 ```
 
+## Authentication, authorization & backend identity
+
+```yaml
+auth:
+  provider: oidc              # none | static | oidc | ldap
+  required: true
+  oidc:
+    issuer: https://keycloak.internal/realms/my-realm
+    jwksUri: https://keycloak.internal/realms/my-realm/protocol/openid-connect/certs
+    audience: queryflux
+
+authorization:
+  provider: none               # none | openfga
+
+clusters:
+  trino-1:
+    engine: trino
+    endpoint: https://trino.internal:8443
+    auth:                      # Type 1 — QueryFlux's own service credential
+      type: basic
+      username: qf_svc
+      password: "..."
+    queryAuth:
+      type: impersonate         # serviceAccount | passthrough | impersonate | tokenExchange
+```
+
+`auth` controls who can authenticate to QueryFlux; `authorization` controls which cluster groups they can route to; `clusters[].queryAuth` controls which identity the query runs as on the backend engine — independent of the client's own credential. See **[Authentication & identity](./authentication)** for the full picture, a decision guide for `queryAuth` modes, and per-engine setup requirements.
+
 ## Admin API
 
 ```yaml

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -25,6 +25,7 @@ The ideas mirror what proxies like [ProxySQL](https://proxysql.com/documentation
 | --- | --- |
 | **[Getting started](/docs/getting-started)** | Run QueryFlux with Docker Compose, connect a SQL client, smoke-test Trino HTTP. |
 | **[QueryFlux Studio](/docs/studio)** | Use the web UI for clusters, routing, query history, and admin security. |
+| **[Authentication & identity](./authentication)** | Set up OIDC/LDAP client auth and choose a backend identity mode (passthrough, impersonate, token exchange). |
 | **[Configuration](/docs/configuration)** | Edit `config.yaml` — frontends, cluster groups, routers, persistence, admin API. |
 
 ---
@@ -99,7 +100,8 @@ Use these when you already know what you are looking for:
 | **Metrics and health** | **[Observability](/docs/architecture/observability)** |
 | **Wire protocols** | **[Frontends](/docs/architecture/frontends/overview)** |
 | **Extending engines** | **[Adding engine support](/docs/architecture/adding-engine-support)** |
-| **Auth model** | **[Auth & authorization design](/docs/architecture/auth-authz-design)** |
+| **Auth setup** | **[Authentication & identity](./authentication)** |
+| **Auth internals** | **[Auth & authorization design](/docs/architecture/auth-authz-design)** |
 
 ---
 

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -25,8 +25,9 @@ Everything below is implemented and available on the `main` branch.
 | **Backends** | Trino — async HTTP polling, transparent `nextUri` proxying |
 | | DuckDB — embedded, in-process, Arrow result sets |
 | | StarRocks — MySQL wire, sync Arrow path |
+| | ClickHouse — HTTP interface, sync Arrow path |
 | | Athena — AWS SDK async, `StartQueryExecution` → `GetQueryResults` |
-| | ADBC — generic Arrow Database Connectivity driver (Trino, DuckDB, and more) |
+| | ADBC — generic Arrow Database Connectivity driver (Trino, DuckDB, Snowflake, and more) |
 | **Routing** | `protocolBased`, `header`, `queryRegex`, `tags`, `pythonScript`, `compound` routers |
 | | Router chain with ordered evaluation and `routingFallback` |
 | | `route_with_trace` for per-request routing debug traces |
@@ -41,7 +42,8 @@ Everything below is implemented and available on the `main` branch.
 | | Schema migrations via Refinery (`queryflux migrate` + optional autoMigrate on start) |
 | **Auth** | Authentication providers: none, static, OIDC, LDAP |
 | | Authorization: allow-all, simple policy, OpenFGA |
-| | Backend identity resolution (`BackendIdentityResolver`) |
+| | Backend identity (`queryAuth`): `serviceAccount`, `passthrough`, `impersonate`, `tokenExchange` — see **[Authentication & identity](./authentication)** |
+| | Trino: all four modes. ClickHouse: `impersonate` (`EXECUTE AS`, self-hosted 25.11+). StarRocks: `passthrough` (LDAP, TLS-required). Snowflake (ADBC): `tokenExchange` (per-identity connection pool) |
 | **Observability** | Prometheus metrics: queries, duration, translation, running, queued |
 | | Grafana dashboard (auto-provisioned) |
 | | QueryFlux Studio — Next.js UI: clusters, query history, engine registry |
@@ -62,13 +64,9 @@ Today's translation is **dialect-only**: `sqlglot.transpile(sql, read=src, write
 
 The plan: wire `SchemaContext` (populated from catalog discovery via `EngineAdapterTrait::list_tables` / `describe_table`) into the dispatch path so the translator can call `sqlglot.optimizer.optimize` with a `MappingSchema`. Dialect-only remains the fallback when the schema is unavailable or optimization fails.
 
-### ClickHouse backend + HTTP frontend
+### ClickHouse HTTP frontend
 
-ClickHouse is a natural fit for the QueryFlux engine set — high-throughput columnar OLAP, HTTP-native protocol, wide adoption alongside Trino and StarRocks in modern lake deployments. The plan:
-
-- **Backend adapter**: ClickHouse HTTP protocol, sync Arrow path (similar to StarRocks).
-- **Frontend**: ClickHouse HTTP interface so native ClickHouse clients can connect to QueryFlux without any driver change.
-- **Dialect translation**: Trino → ClickHouse SQL via sqlglot.
+The ClickHouse **backend** adapter (HTTP protocol, sync Arrow path, `queryAuth: impersonate` via `EXECUTE AS`) is done. Still planned: a ClickHouse HTTP **frontend** so native ClickHouse clients can connect to QueryFlux directly, without any driver change — the same pattern the Snowflake frontend already uses for Snowflake-native clients.
 
 ### Routing telemetry in Studio
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -14,7 +14,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Guides',
       collapsed: false,
-      items: ['getting-started', 'studio'],
+      items: ['getting-started', 'studio', 'authentication'],
     },
     {
       type: 'category',


### PR DESCRIPTION
## Summary

Auth/authz was under-documented relative to how significant the feature is: the only coverage was a single, very technical internal design doc buried under a collapsed "Architecture" sidebar category, and the flagship config reference (`configuration.md`) never mentioned `auth`/`authorization`/`queryAuth` at all.

- **New guide**: [`website/docs/authentication.md`](website/docs/authentication.md), added to the top-level **Guides** section — the three-layer model (who can reach QueryFlux / what they can do / which identity reaches the backend), a `queryAuth` mode × engine compatibility table, a "which mode should I use" decision guide, per-engine setup requirements (Trino ACLs, ClickHouse `GRANT IMPERSONATE`/`KILL QUERY`, StarRocks TLS+LDAP, Snowflake OAuth), and a pointer to the runnable Keycloak OIDC example.
- **`intro.md`**: added to the Quick guides table and the reference manual table.
- **`configuration.md`**: new "Authentication, authorization & backend identity" section with a runnable YAML snippet.
- **`roadmap.md`**: updated the Auth "what is done" row to reflect the actual shipped `queryAuth` modes and per-engine coverage. Also fixed a stale entry — "ClickHouse backend + HTTP frontend" was still listed as near-term/planned, but the backend adapter shipped weeks ago (#105); only the HTTP frontend remains, so split that out.
- **`sidebars.ts`**: registered the new guide.

## Test plan

- [x] Verified with a real `docusaurus build` (not just visual review) — caught and fixed a real issue: this site has versioned docs, and absolute `/docs/authentication` links resolve against the latest *published* version, where the new page doesn't exist yet. Fixed the two new cross-links to use relative paths, matching the existing pattern elsewhere in the site.
- [x] Build succeeds clean after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)