### PR TITLE
fix(website): remove broken hero image on the homepage

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -40,13 +40,6 @@ html[data-theme='dark'] .heroGlow {
   margin-right: auto;
 }
 
-.heroImage {
-  display: block;
-  width: min(100%, 920px);
-  height: auto;
-  margin: 0 auto 1.5rem;
-}
-
 .heroTitle {
   font-size: clamp(2.05rem, 4.4vw, 2.75rem);
   font-weight: 700;
@@ -167,9 +160,5 @@ html[data-theme='dark'] .ctaGhost:hover {
 @media screen and (max-width: 996px) {
   .hero {
     padding: 2.25rem 0 3rem;
-  }
-
-  .heroImage {
-    margin-bottom: 1.25rem;
   }
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,11 +1,9 @@
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import ThemedImage from '@theme/ThemedImage';
 
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import HomepageUseCases from '@site/src/components/HomepageUseCases';
@@ -22,17 +20,6 @@ function HomepageHeader(): ReactNode {
     <header className={styles.hero}>
       <div className={styles.heroGlow} aria-hidden />
       <div className={clsx('container', styles.heroInner)}>
-        <ThemedImage
-          className={styles.heroImage}
-          sources={{
-            light: useBaseUrl('/img/queryflux-hero-cover-light.png'),
-            dark: useBaseUrl('/img/queryflux-hero-banner.svg'),
-          }}
-          alt="QueryFlux — multi-engine SQL routing in Rust, connecting clients to Trino, DuckDB, StarRocks, Snowflake, Databricks, and more"
-          width={1024}
-          height={682}
-          decoding="async"
-        />
         <Heading as="h1" className={styles.heroTitle}>
           <span className={styles.heroTitleQuery}>Query</span>
           <span className={styles.heroTitleFlux}>Flux</span>


### PR DESCRIPTION
## Summary

The homepage hero (`HomepageHeader` in `src/pages/index.tsx`) rendered a `ThemedImage` whose light-theme source pointed at `/img/queryflux-hero-cover-light.png`. That file was deleted back in b000d3e ("docs: switch logo", #24) along with `queryflux-hero-cover.png`, but the reference in `index.tsx` was never updated to match — every light-mode visit to the homepage has been rendering a broken image since.

- Removed the `ThemedImage` element entirely (not repointed to a different existing asset).
- Removed the now-unused `useBaseUrl`/`ThemedImage` imports.
- Removed the now-orphaned `.heroImage` CSS rule (base + the mobile breakpoint override).

## Test plan

- [x] `npm run build` succeeds clean.
- [x] Confirmed via `git log` that `queryflux-hero-cover-light.png` was deleted in #24 and never re-added; no other reference to it remains anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the homepage hero image.
  * Simplified the hero layout and eliminated image-specific responsive styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->