### PR TITLE
feat(admin): add /admin/route-explain dry-run routing preview

### DIFF
--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -317,7 +317,7 @@ impl TestHarness {
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
         let translation = Arc::new(TranslationService::disabled());
-        let router_chain = RouterChain::new(routers, fallback);
+        let router_chain = Arc::new(RouterChain::new(routers, fallback));
 
         let tmp = TcpListener::bind("127.0.0.1:0").await?;
         let port = tmp.local_addr()?.port();
@@ -560,7 +560,7 @@ impl WireTestHarness {
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
         let translation = Arc::new(TranslationService::disabled());
-        let router_chain = RouterChain::new(vec![router], group.clone());
+        let router_chain = Arc::new(RouterChain::new(vec![router], group.clone()));
 
         let tmp = TcpListener::bind("127.0.0.1:0").await?;
         let port = tmp.local_addr()?.port();
@@ -697,7 +697,7 @@ impl WireTestHarness {
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
         let translation = Arc::new(TranslationService::disabled());
-        let router_chain = RouterChain::new(vec![router], group.clone());
+        let router_chain = Arc::new(RouterChain::new(vec![router], group.clone()));
 
         let tmp = TcpListener::bind("127.0.0.1:0").await?;
         let port = tmp.local_addr()?.port();
@@ -854,7 +854,7 @@ impl ProtocolWireHarness {
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
         let translation = Arc::new(TranslationService::disabled());
-        let router_chain = RouterChain::new(vec![router], group.clone());
+        let router_chain = Arc::new(RouterChain::new(vec![router], group.clone()));
 
         let live_config = LiveConfig {
             router_chain,

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -9,7 +9,8 @@ use axum::{
     routing::{delete, get, patch, post},
     Json, Router,
 };
-use queryflux_auth::AdminCredentialsManager;
+use queryflux_auth::{AdminCredentialsManager, AuthContext, AuthorizationChecker};
+use queryflux_cluster_manager::ClusterGroupManager;
 use queryflux_core::{
     config::{
         AuthConfig, AuthProviderConfig, AuthorizationConfig, AuthorizationProviderConfig,
@@ -17,8 +18,14 @@ use queryflux_core::{
     },
     engine_registry::EngineRegistry,
     error::{QueryFluxError, Result},
-    query::{BackendQueryId, ClusterGroupName, ClusterName, ExecutingQuery, ProxyQueryId},
+    query::{
+        BackendQueryId, ClusterGroupName, ClusterName, EngineType, ExecutingQuery,
+        FrontendProtocol, ProxyQueryId,
+    },
+    session::SessionContext,
+    tags::{merge_tags, QueryTags},
 };
+use queryflux_guardrails::{GuardChain, GuardContext, GuardLayer};
 use queryflux_metrics::prometheus_store::PrometheusMetrics;
 use queryflux_persistence::{
     cluster_config::{
@@ -31,8 +38,10 @@ use queryflux_persistence::{
     },
     routing_json::{enrich_routers_for_api, resolve_routers_for_storage},
     script_library::{UpsertUserScript, UserScriptRecord, KIND_GUARD},
-    AdminStore,
+    AdminStore, GuardAction,
 };
+use queryflux_routing::{chain::RouterChain, chain::RoutingTrace, ChainRouteResult};
+use queryflux_translation::TranslationService;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
@@ -43,6 +52,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::{
+    routing_resolve::{check_group_authorized, resolve_routed_group},
     state::{AppState, LiveConfig},
     FrontendListenerTrait, ShutdownRx,
 };
@@ -127,6 +137,8 @@ pub struct ClusterStateDto {
         list_agents_handler,
         list_conversations_handler,
         get_conversation_handler,
+        // Routing preview
+        route_explain_handler,
     ),
     components(schemas(
         ClusterStateDto,
@@ -140,6 +152,9 @@ pub struct ClusterStateDto {
         UpsertUserScript,
         ProtocolFrontendDto,
         FrontendsStatusDto,
+        RouteExplainRequest,
+        RouteExplainResponse,
+        GroupCapacityDto,
         queryflux_persistence::cluster_config::ClusterConfigRecord,
         queryflux_persistence::cluster_config::UpsertClusterConfig,
         queryflux_persistence::cluster_config::ClusterGroupConfigRecord,
@@ -716,6 +731,8 @@ impl AdminFrontend {
             // Auth management endpoints
             .route("/admin/auth/status", get(auth_status_handler))
             .route("/admin/auth/change-password", post(change_password_handler))
+            // Routing preview — dry-run, no query is executed and no capacity is consumed
+            .route("/admin/route-explain", post(route_explain_handler))
             .layer(middleware::from_fn_with_state(
                 state.clone(),
                 admin_auth_middleware,
@@ -1355,6 +1372,311 @@ async fn get_conversation_handler(
         Ok(rows) => Json::<Vec<QuerySummary>>(rows).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Route explain — dry-run routing/guard/capacity preview
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /admin/route-explain`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RouteExplainRequest {
+    pub sql: String,
+    /// Wire protocol to route as — same values as `protocolBased` router config
+    /// (`trinoHttp`, `postgresWire`, `mysqlWire`, `clickhouseHttp`, `flightSql`,
+    /// `snowflakeHttp`, `snowflakeSqlApi`).
+    #[schema(value_type = String)]
+    pub protocol: FrontendProtocol,
+    /// Simulated identity for authorization-aware routing and guard preview.
+    /// **Not verified against any `AuthProvider`** — this endpoint answers "if a query came
+    /// in as this user, what would happen," which is what makes it useful for testing
+    /// `allowGroups`/`allowUsers` rules before rolling them out. Because it sits behind the
+    /// same admin Basic-auth gate as every other `/admin/*` route, an admin credential
+    /// holder can already probe outcomes for any simulated user — that is the intended use,
+    /// not a bypass of real authentication.
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(default)]
+    pub database: Option<String>,
+    /// Query tags, e.g. `{"team": "eng", "batch": null}` — same shape session tags use.
+    #[serde(default)]
+    pub tags: QueryTags,
+}
+
+/// Response body for `POST /admin/route-explain`. Nothing here is persisted — this is a
+/// pure computation over already-loaded config and live cluster state.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RouteExplainResponse {
+    /// Same shape Studio already renders for a historical query's `routing_trace`.
+    #[schema(value_type = Object)]
+    pub routing_trace: RoutingTrace,
+    /// Set when a router or authorization check would deny the query before it ever reaches
+    /// guardrails or dispatch. When set, `guard_actions` is empty and `capacity` is absent —
+    /// nothing downstream of the deny was evaluated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub denied: Option<String>,
+    /// Guard verdicts from the pre-dispatch guard pass (global chain, then the resolved
+    /// group's chain). Empty when no guardrails are configured for the resolved group.
+    #[schema(value_type = Vec<Object>)]
+    pub guard_actions: Vec<GuardAction>,
+    /// True if any guard action above was a deny — the query would never reach dispatch.
+    pub would_be_guard_blocked: bool,
+    /// Best-effort, moment-in-time capacity snapshot of the resolved group's members.
+    /// Unlike `routing_trace`/`guard_actions` (deterministic, config-driven — the same
+    /// answer whether you ask now or later), this reflects live runtime state that can
+    /// change before you act on it. It also doesn't check the group's `maxQueuedQueries`
+    /// admission limit — `would_queue: true` means "would not dispatch immediately," not
+    /// a guarantee the query would successfully queue rather than being rejected. Treat
+    /// this field as advisory; for authoritative live state, poll `GET /admin/clusters`.
+    /// Absent when `denied` is set (no group was resolved).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capacity: Option<GroupCapacityDto>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GroupCapacityDto {
+    pub group_name: String,
+    pub members: Vec<ClusterStateDto>,
+    /// True when no member is currently enabled, healthy, and under `max_running_queries` —
+    /// i.e. the query would not dispatch immediately, as of this snapshot. Best-effort: see
+    /// the caveat on `RouteExplainResponse::capacity`.
+    pub would_queue: bool,
+}
+
+fn empty_route_explain_response(mut trace: RoutingTrace, denied: String) -> RouteExplainResponse {
+    // route_with_trace already sets trace.denied for a router-level Deny, but
+    // resolve_routed_group and the unconditional authorization check below it never
+    // touch the trace — set it here too so RoutingTraceView (which branches on
+    // trace.denied, not on the top-level field) renders consistently with `denied`
+    // regardless of which stage produced the denial.
+    trace.denied = Some(denied.clone());
+    RouteExplainResponse {
+        routing_trace: trace,
+        denied: Some(denied),
+        guard_actions: Vec::new(),
+        would_be_guard_blocked: false,
+        capacity: None,
+    }
+}
+
+/// Preview where a query would route, whether it would be authorized, and whether any
+/// guardrail would block it — **without executing the query or consuming any capacity**.
+/// The primary, deterministic answer this endpoint exists to give: routing/authz/guardrail
+/// verdicts are config-driven, so the same request gives the same answer whether config
+/// hasn't changed since. Also includes a best-effort capacity snapshot as a bonus signal
+/// (see the caveat on `RouteExplainResponse::capacity`) — live runtime state, not something
+/// this endpoint tries to make authoritative.
+///
+/// Mirrors the real dispatch order exactly (route → fallback-resolve → authorize → guard
+/// preview → capacity), so the answer this endpoint gives matches what would actually
+/// happen. Never calls `ClusterGroupManager::acquire_cluster` — capacity is read via the
+/// same live snapshot `/admin/clusters` uses, so calling this endpoint has no side effects.
+#[utoipa::path(
+    post,
+    path = "/admin/route-explain",
+    tag = "admin",
+    request_body = RouteExplainRequest,
+    responses(
+        (status = 200, description = "Routing/guard/capacity preview", body = RouteExplainResponse),
+        (status = 500, description = "Internal error", body = str),
+    )
+)]
+async fn route_explain_handler(
+    State(state): State<Arc<AdminState>>,
+    Json(req): Json<RouteExplainRequest>,
+) -> impl IntoResponse {
+    // Snapshot everything needed from LiveConfig in one lock acquisition — same discipline
+    // dispatch_query uses — so no lock is held across the awaits in build_route_explain_response.
+    let (
+        router_chain,
+        authorization,
+        guard_chain,
+        group_guard_chains,
+        group_default_tags,
+        group_translation_scripts,
+        group_order,
+        cluster_manager,
+    ) = {
+        let live = state.live.read().await;
+        (
+            live.router_chain.clone(),
+            live.authorization.clone(),
+            live.guard_chain.clone(),
+            live.group_guard_chains.clone(),
+            live.group_default_tags.clone(),
+            live.group_translation_scripts.clone(),
+            live.group_order.clone(),
+            live.cluster_manager.clone(),
+        )
+    };
+
+    match build_route_explain_response(
+        router_chain.as_ref(),
+        authorization.as_ref(),
+        guard_chain.as_deref(),
+        &group_guard_chains,
+        &group_default_tags,
+        &group_translation_scripts,
+        &group_order,
+        cluster_manager.as_ref(),
+        state.app.translation.as_ref(),
+        &req,
+    )
+    .await
+    {
+        Ok(resp) => Json(resp).into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+/// Core logic behind [`route_explain_handler`], factored out so it can be unit-tested with
+/// lightweight fixtures instead of a full `AdminState`. Mirrors the real dispatch order
+/// exactly (route → fallback-resolve → authorize → guard preview → capacity) and never calls
+/// `ClusterGroupManager::acquire_cluster` — capacity is read via the same live snapshot
+/// `/admin/clusters` uses, so calling it has no side effects.
+#[allow(clippy::too_many_arguments)]
+async fn build_route_explain_response(
+    router_chain: &RouterChain,
+    authorization: &dyn AuthorizationChecker,
+    guard_chain: Option<&GuardChain>,
+    group_guard_chains: &HashMap<String, Arc<GuardChain>>,
+    group_default_tags: &HashMap<String, QueryTags>,
+    group_translation_scripts: &HashMap<String, Vec<String>>,
+    group_order: &[String],
+    cluster_manager: &dyn ClusterGroupManager,
+    translation: &TranslationService,
+    req: &RouteExplainRequest,
+) -> Result<RouteExplainResponse> {
+    let auth_ctx = AuthContext {
+        user: req.user.clone().unwrap_or_else(|| "anonymous".to_string()),
+        groups: req.groups.clone(),
+        ..Default::default()
+    };
+    let session = SessionContext {
+        user: req.user.clone(),
+        database: req.database.clone(),
+        tags: req.tags.clone(),
+        ..Default::default()
+    };
+
+    let (chain_result, mut trace) = router_chain
+        .route_with_trace(&req.sql, &session, &req.protocol, Some(&auth_ctx))
+        .await?;
+
+    let group = match chain_result {
+        ChainRouteResult::Denied { message } => {
+            return Ok(empty_route_explain_response(trace, message));
+        }
+        ChainRouteResult::Routed(group) => group,
+    };
+
+    // Fallback-only authorization-aware reroute — mirrors what frontends do today.
+    let group = match resolve_routed_group(group_order, authorization, group, &mut trace, &auth_ctx)
+        .await
+    {
+        Ok(g) => g,
+        Err(e) => return Ok(empty_route_explain_response(trace, e.to_string())),
+    };
+
+    // Unconditional per-group authorization check — dispatch enforces this for every
+    // resolved group, not just ones reached via fallback. Same helper dispatch_query and
+    // execute_to_sink use, so this can't quietly disagree with what they'd decide.
+    if let Some(msg) = check_group_authorized(authorization, &auth_ctx, &group).await {
+        return Ok(empty_route_explain_response(trace, msg));
+    }
+
+    // Live capacity — READ-ONLY. Never call acquire_cluster here: that mutates real state
+    // (increments a running-query counter with nothing to ever release it).
+    let all_states = cluster_manager.all_cluster_states().await?;
+    let members: Vec<_> = all_states
+        .into_iter()
+        .filter(|s| s.group_name.0 == group.0)
+        .collect();
+    // Guard dialect parsing needs a concrete engine type; the first member stands in for the
+    // group. Groups with heterogeneous engine types across members are not modeled here — a
+    // guard that would pass on one member's dialect but not another's is a known limitation.
+    let engine_type = members
+        .first()
+        .map(|m| m.engine_type.clone())
+        .unwrap_or(EngineType::Undispatched);
+    let would_queue = !members
+        .iter()
+        .any(|m| m.enabled && m.is_healthy && m.running_queries < m.max_running_queries);
+    let capacity = GroupCapacityDto {
+        group_name: group.0.clone(),
+        members: members
+            .into_iter()
+            .map(|s| ClusterStateDto {
+                group_name: s.group_name.0,
+                cluster_name: s.cluster_name.0,
+                engine_type: format!("{:?}", s.engine_type),
+                endpoint: s.endpoint,
+                running_queries: s.running_queries,
+                queued_queries: s.queued_queries,
+                max_running_queries: s.max_running_queries,
+                is_healthy: s.is_healthy,
+                enabled: s.enabled,
+            })
+            .collect(),
+        would_queue,
+    };
+
+    // Guard preview — same chain-run pattern production uses pre-dispatch, but with the
+    // resolved group's real engine type (more accurate than the placeholder engine type
+    // production uses before cluster selection has happened). dispatch_query runs guards
+    // *after* translation, against the final SQL (see "Guard chain: runs after translation"
+    // in dispatch.rs) — translate here too so a client-dialect query routed to a
+    // different-dialect engine is guard-checked against the SQL that would actually run,
+    // not against SQL in the client's dialect parsed as if it were the engine's.
+    let group_fixups = group_translation_scripts
+        .get(&group.0)
+        .cloned()
+        .unwrap_or_default();
+    let translated_sql = translation
+        .maybe_translate(
+            &req.sql,
+            &req.protocol.default_dialect(),
+            &engine_type.dialect(),
+            &queryflux_translation::SchemaContext::default(),
+            &group_fixups,
+        )
+        .await?;
+    let effective_tags = merge_tags(
+        &group_default_tags
+            .get(&group.0)
+            .cloned()
+            .unwrap_or_default(),
+        &session.tags,
+    );
+    let resolved_agent_ctx = session.resolved_agent_context();
+    let guard_ctx = GuardContext {
+        sql: &req.sql,
+        translated_sql: &translated_sql,
+        engine_type: &engine_type,
+        cluster_group: &group,
+        user: session.user(),
+        agent_context: resolved_agent_ctx.as_ref(),
+        query_tags: &effective_tags,
+    };
+    let group_guard_chain = group_guard_chains.get(&group.0).map(|c| c.as_ref());
+    // Same shared function dispatch_query and execute_to_sink_inner run their guard
+    // chains through — see queryflux_guardrails::run_guard_chains.
+    let (guard_actions, would_be_guard_blocked) = queryflux_guardrails::run_guard_chains(
+        [guard_chain, group_guard_chain],
+        &guard_ctx,
+        GuardLayer::Plan,
+    )
+    .await;
+
+    Ok(RouteExplainResponse {
+        routing_trace: trace,
+        denied: None,
+        guard_actions,
+        would_be_guard_blocked,
+        capacity: Some(capacity),
+    })
 }
 
 /// Dashboard stats for the last hour. Requires Postgres persistence.
@@ -2694,19 +3016,32 @@ async fn invalidate_group_cache_handler(
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_running_queries, delete_queued_if_exists, sql_preview, GuardrailsConfigDto,
-        SecurityConfigDto,
+        build_route_explain_response, collect_running_queries, delete_queued_if_exists,
+        sql_preview, GuardrailsConfigDto, RouteExplainRequest, SecurityConfigDto,
     };
     use chrono::Utc;
+    use queryflux_auth::{AllowAllAuthorization, AuthorizationChecker, SimpleAuthorizationPolicy};
+    use queryflux_cluster_manager::{
+        cluster_state::ClusterState,
+        simple::SimpleClusterGroupManager,
+        strategy::{ClusterSelectionStrategy, RoundRobinStrategy},
+        ClusterGroupManager,
+    };
     use queryflux_core::config::{
-        AuthConfig, AuthProviderConfig, AuthorizationConfig, StaticUserEntry, StaticUsersConfig,
+        AuthConfig, AuthProviderConfig, AuthorizationConfig, ClusterGroupAuthorizationConfig,
+        QueryRegexRule, RegexRouteAction, StaticUserEntry, StaticUsersConfig,
     };
     use queryflux_core::query::{
-        BackendQueryId, ClusterGroupName, ClusterName, ExecutingQuery, FrontendProtocol,
-        ProxyQueryId, QueuedQuery,
+        BackendQueryId, ClusterGroupName, ClusterName, EngineType, ExecutingQuery,
+        FrontendProtocol, ProxyQueryId, QueuedQuery,
     };
     use queryflux_core::session::SessionContext;
+    use queryflux_guardrails::{built_in::ReadOnlyGuard, GuardChain};
     use queryflux_persistence::{in_memory::InMemoryPersistence, Persistence};
+    use queryflux_routing::{
+        chain::RouterChain, implementations::query_regex::QueryRegexRouter, RouterTrait,
+    };
+    use queryflux_translation::TranslationService;
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -2931,5 +3266,274 @@ mod tests {
         }))
         .expect("shape should parse");
         assert!(ftp_url.validate().unwrap_err().contains("http or https"));
+    }
+
+    // -----------------------------------------------------------------
+    // route_explain_handler / build_route_explain_response
+    // -----------------------------------------------------------------
+
+    /// (cluster_name, max_running, running, enabled, healthy)
+    fn cluster_manager_with_members(
+        group: &str,
+        members: Vec<(&str, u64, u64, bool, bool)>,
+    ) -> Arc<dyn ClusterGroupManager> {
+        let group_name = ClusterGroupName(group.to_string());
+        let states: Vec<Arc<ClusterState>> = members
+            .into_iter()
+            .map(|(name, max_running, running, enabled, healthy)| {
+                let state = Arc::new(ClusterState::new(
+                    ClusterName(name.to_string()),
+                    group_name.clone(),
+                    None,
+                    None,
+                    EngineType::Trino,
+                    Some(format!("http://{name}.test:8080")),
+                    max_running,
+                    enabled,
+                ));
+                state.set_running_queries(running);
+                state.set_healthy(healthy);
+                state
+            })
+            .collect();
+        let mut groups = HashMap::new();
+        groups.insert(
+            group_name,
+            (
+                states,
+                Arc::new(RoundRobinStrategy::new()) as Arc<dyn ClusterSelectionStrategy>,
+            ),
+        );
+        Arc::new(SimpleClusterGroupManager::new(groups))
+    }
+
+    fn explain_request(sql: &str) -> RouteExplainRequest {
+        RouteExplainRequest {
+            sql: sql.to_string(),
+            protocol: FrontendProtocol::TrinoHttp,
+            user: None,
+            groups: vec![],
+            database: None,
+            tags: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn route_explain_denied_by_router_skips_capacity_and_guards() {
+        let router = QueryRegexRouter::from_rules(vec![QueryRegexRule {
+            regex: r"(?i)^\s*DROP".into(),
+            target_group: None,
+            action: RegexRouteAction::Deny,
+            error: Some("no drops".into()),
+        }]);
+        let routers: Vec<Box<dyn RouterTrait>> = vec![Box::new(router)];
+        let chain = RouterChain::new(routers, ClusterGroupName("default".into()));
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(AllowAllAuthorization::default());
+        let cluster_manager =
+            cluster_manager_with_members("default", vec![("c1", 5, 0, true, true)]);
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &["default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &explain_request("DROP TABLE t"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.denied.as_deref(), Some("no drops"));
+        assert!(resp.capacity.is_none());
+        assert!(resp.guard_actions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn route_explain_fallback_reroutes_to_authorized_group() {
+        // No routers match -> fallback fires -> resolve_routed_group picks the first
+        // group in group_order the simulated user is authorized for.
+        let chain = RouterChain::new(vec![], ClusterGroupName("default".into()));
+        let policies = HashMap::from([
+            (
+                "analytics".to_string(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-a".into()],
+                    allow_users: vec![],
+                },
+            ),
+            (
+                "default".to_string(),
+                ClusterGroupAuthorizationConfig {
+                    allow_groups: vec!["team-b".into()],
+                    allow_users: vec![],
+                },
+            ),
+        ]);
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(SimpleAuthorizationPolicy::new(policies));
+        let cluster_manager =
+            cluster_manager_with_members("analytics", vec![("c1", 5, 0, true, true)]);
+
+        let mut req = explain_request("SELECT 1");
+        req.groups = vec!["team-a".to_string()];
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &["analytics".to_string(), "default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &req,
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.denied.is_none());
+        assert_eq!(resp.routing_trace.final_group, "analytics");
+        assert!(resp.routing_trace.used_fallback);
+        assert_eq!(resp.capacity.unwrap().group_name, "analytics");
+    }
+
+    #[tokio::test]
+    async fn route_explain_read_only_guard_blocks_write() {
+        let chain = RouterChain::new(vec![], ClusterGroupName("default".into()));
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(AllowAllAuthorization::default());
+        let cluster_manager =
+            cluster_manager_with_members("default", vec![("c1", 5, 0, true, true)]);
+        let group_guard_chains: HashMap<String, Arc<GuardChain>> = HashMap::from([(
+            "default".to_string(),
+            Arc::new(GuardChain::new(vec![Box::new(ReadOnlyGuard)])),
+        )]);
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &group_guard_chains,
+            &HashMap::new(),
+            &HashMap::new(),
+            &["default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &explain_request("INSERT INTO t VALUES (1)"),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.denied.is_none());
+        assert!(resp.would_be_guard_blocked);
+        assert_eq!(resp.guard_actions.len(), 1);
+        assert_eq!(resp.guard_actions[0].action, "deny");
+        assert_eq!(
+            resp.guard_actions[0].code.as_deref(),
+            Some("READ_ONLY_VIOLATION")
+        );
+    }
+
+    #[tokio::test]
+    async fn route_explain_would_queue_true_when_group_is_full() {
+        let chain = RouterChain::new(vec![], ClusterGroupName("default".into()));
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(AllowAllAuthorization::default());
+        // Single member, at capacity (running == max).
+        let cluster_manager =
+            cluster_manager_with_members("default", vec![("c1", 2, 2, true, true)]);
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &["default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &explain_request("SELECT 1"),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.capacity.unwrap().would_queue);
+    }
+
+    #[tokio::test]
+    async fn route_explain_would_queue_false_with_one_healthy_member_under_capacity() {
+        let chain = RouterChain::new(vec![], ClusterGroupName("default".into()));
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(AllowAllAuthorization::default());
+        // One disabled member (would never be picked) plus one healthy, under-capacity member.
+        let cluster_manager = cluster_manager_with_members(
+            "default",
+            vec![("c1", 5, 5, false, true), ("c2", 5, 1, true, true)],
+        );
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &["default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &explain_request("SELECT 1"),
+        )
+        .await
+        .unwrap();
+
+        let capacity = resp.capacity.unwrap();
+        assert!(!capacity.would_queue);
+        assert_eq!(capacity.members.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn route_explain_auth_denial_sets_trace_denied_too() {
+        // Regression test: an authorization-stage denial (not a router-stage deny) must
+        // set routing_trace.denied, not just the top-level `denied` field — otherwise
+        // Studio's RoutingTraceView (which branches on trace.denied) renders a normal
+        // "Final group" success footer alongside a separate "would be denied" banner.
+        let chain = RouterChain::new(vec![], ClusterGroupName("default".into()));
+        let policies = HashMap::from([(
+            "default".to_string(),
+            ClusterGroupAuthorizationConfig {
+                allow_groups: vec!["nobody-has-this".into()],
+                allow_users: vec![],
+            },
+        )]);
+        let authorization: Arc<dyn AuthorizationChecker> =
+            Arc::new(SimpleAuthorizationPolicy::new(policies));
+        let cluster_manager =
+            cluster_manager_with_members("default", vec![("c1", 5, 0, true, true)]);
+
+        let resp = build_route_explain_response(
+            &chain,
+            authorization.as_ref(),
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &["default".to_string()],
+            cluster_manager.as_ref(),
+            &TranslationService::disabled(),
+            &explain_request("SELECT 1"),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.denied.is_some());
+        assert_eq!(resp.routing_trace.denied, resp.denied);
+        assert!(resp.capacity.is_none());
     }
 }

--- a/crates/queryflux-frontend/src/routing_resolve.rs
+++ b/crates/queryflux-frontend/src/routing_resolve.rs
@@ -36,6 +36,26 @@ pub async fn resolve_routed_group(
     )))
 }
 
+/// The unconditional per-group authorization check every dispatch path runs on the
+/// resolved group, regardless of whether it was reached via an explicit router match or
+/// the fallback-reroute in [`resolve_routed_group`]. Returns `Some(message)` when denied,
+/// `None` when authorized — callers decide what to do with a denial (return an error,
+/// write it to a sink, or report it in a dry-run preview).
+pub async fn check_group_authorized(
+    authorization: &dyn AuthorizationChecker,
+    auth_ctx: &AuthContext,
+    group: &ClusterGroupName,
+) -> Option<String> {
+    if authorization.check(auth_ctx, &group.0).await {
+        None
+    } else {
+        Some(format!(
+            "user '{}' is not authorized to run queries on cluster group '{}'",
+            auth_ctx.user, group.0
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -93,7 +113,7 @@ mod tests {
             ),
         );
         LiveConfig {
-            router_chain: RouterChain::new(vec![], default.clone()),
+            router_chain: Arc::new(RouterChain::new(vec![], default.clone())),
             guard_chain: None,
             group_guard_chains: HashMap::new(),
             cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),
@@ -247,5 +267,44 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(out.0, "analytics");
+    }
+
+    #[tokio::test]
+    async fn check_group_authorized_allows_when_policy_permits() {
+        let live = live_with_policies(HashMap::from([(
+            "analytics".into(),
+            ClusterGroupAuthorizationConfig {
+                allow_groups: vec!["team-a".into()],
+                allow_users: vec![],
+            },
+        )]));
+        let result = check_group_authorized(
+            live.authorization.as_ref(),
+            &auth("alice", &["team-a"]),
+            &ClusterGroupName("analytics".into()),
+        )
+        .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn check_group_authorized_denies_with_standard_message() {
+        let live = live_with_policies(HashMap::from([(
+            "analytics".into(),
+            ClusterGroupAuthorizationConfig {
+                allow_groups: vec!["team-a".into()],
+                allow_users: vec![],
+            },
+        )]));
+        let result = check_group_authorized(
+            live.authorization.as_ref(),
+            &auth("bob", &[]),
+            &ClusterGroupName("analytics".into()),
+        )
+        .await;
+        assert_eq!(
+            result.as_deref(),
+            Some("user 'bob' is not authorized to run queries on cluster group 'analytics'")
+        );
     }
 }

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -28,7 +28,10 @@ use queryflux_translation::TranslationService;
 /// that any handler can cheaply read a consistent snapshot, and a background
 /// task can atomically swap the whole bundle on each reload tick.
 pub struct LiveConfig {
-    pub router_chain: RouterChain,
+    /// `Arc`-wrapped (like `cluster_manager`/`authorization` below) so handlers that need to
+    /// call into it — e.g. the `/admin/route-explain` preview — can clone it out of the read
+    /// lock instead of holding the lock across the `await`.
+    pub router_chain: Arc<RouterChain>,
     /// Global guard chain — runs for every query regardless of cluster group.
     /// `None` means no global guardrails are configured.
     pub guard_chain: Option<Arc<GuardChain>>,
@@ -651,7 +654,7 @@ pub mod test_fixtures {
             ),
         );
         let live = LiveConfig {
-            router_chain: RouterChain::new(vec![], group_name.clone()),
+            router_chain: Arc::new(RouterChain::new(vec![], group_name.clone())),
             guard_chain: None,
             group_guard_chains: HashMap::new(),
             cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1616,7 +1616,7 @@ mod cancel_executing_statement_tests {
             ),
         );
         let live = LiveConfig {
-            router_chain: RouterChain::new(vec![], group_name.clone()),
+            router_chain: Arc::new(RouterChain::new(vec![], group_name.clone())),
             guard_chain: None,
             group_guard_chains: HashMap::new(),
             cluster_manager: Arc::new(SimpleClusterGroupManager::new(groups)),

--- a/crates/queryflux-guardrails/src/chain.rs
+++ b/crates/queryflux-guardrails/src/chain.rs
@@ -46,6 +46,32 @@ impl GuardChain {
     }
 }
 
+/// Runs each configured chain in order — typically the global chain, then a per-group
+/// chain — for the given layer, stopping at the first deny. Returns the combined actions
+/// across however many chains ran, and whether the last one to run denied.
+///
+/// This is the one place "what does it mean to guard-check a query" is defined. Every
+/// caller that needs a guard verdict (the sync dispatch path before engine submission, the
+/// async cache pre-check, and the `/admin/route-explain` dry-run preview) calls this so
+/// they can't quietly disagree about what running the guards means.
+pub async fn run_guard_chains<'a>(
+    chains: impl IntoIterator<Item = Option<&'a GuardChain>>,
+    ctx: &GuardContext<'_>,
+    layer: GuardLayer,
+) -> (Vec<GuardAction>, bool) {
+    let mut all_actions = Vec::new();
+    let mut was_blocked = false;
+    for chain in chains.into_iter().flatten() {
+        let (actions, blocked) = chain.run(ctx, layer.clone()).await;
+        all_actions.extend(actions);
+        if blocked {
+            was_blocked = true;
+            break;
+        }
+    }
+    (all_actions, was_blocked)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -180,6 +206,55 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[1].guard, "blocker");
         assert_eq!(actions[1].action, "deny");
+        assert!(blocked);
+    }
+
+    #[tokio::test]
+    async fn run_guard_chains_skips_none_entries() {
+        let tc = TestCtx::plan_select_fixture();
+        let (actions, blocked) = run_guard_chains([None, None], &tc.ctx(), GuardLayer::Plan).await;
+        assert!(actions.is_empty());
+        assert!(!blocked);
+    }
+
+    #[tokio::test]
+    async fn run_guard_chains_runs_global_then_group_and_combines_actions() {
+        let global = GuardChain::new(vec![Box::new(TestGuard {
+            name: "global",
+            layer: GuardLayer::Plan,
+            result: GuardResult::allow(),
+        })]);
+        let group = GuardChain::new(vec![Box::new(TestGuard {
+            name: "group",
+            layer: GuardLayer::Plan,
+            result: GuardResult::warn("careful"),
+        })]);
+        let tc = TestCtx::plan_select_fixture();
+        let (actions, blocked) =
+            run_guard_chains([Some(&global), Some(&group)], &tc.ctx(), GuardLayer::Plan).await;
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].guard, "global");
+        assert_eq!(actions[1].guard, "group");
+        assert!(!blocked);
+    }
+
+    #[tokio::test]
+    async fn run_guard_chains_stops_at_global_deny_without_running_group_chain() {
+        let global = GuardChain::new(vec![Box::new(TestGuard {
+            name: "global_blocker",
+            layer: GuardLayer::Plan,
+            result: GuardResult::deny("nope", "N"),
+        })]);
+        let group = GuardChain::new(vec![Box::new(TestGuard {
+            name: "never_runs",
+            layer: GuardLayer::Plan,
+            result: GuardResult::deny("should not run", "X"),
+        })]);
+        let tc = TestCtx::plan_select_fixture();
+        let (actions, blocked) =
+            run_guard_chains([Some(&global), Some(&group)], &tc.ctx(), GuardLayer::Plan).await;
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].guard, "global_blocker");
         assert!(blocked);
     }
 }

--- a/crates/queryflux-guardrails/src/lib.rs
+++ b/crates/queryflux-guardrails/src/lib.rs
@@ -4,7 +4,7 @@ pub mod config;
 pub mod context;
 pub mod external;
 
-pub use chain::GuardChain;
+pub use chain::{run_guard_chains, GuardChain};
 pub use config::{GuardChainConfig, GuardGroupConfig, GuardKind, GuardLayerConfig};
 pub use context::{GuardContext, GuardLayer, GuardResult};
 

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -658,7 +658,7 @@ async fn main() -> Result<()> {
         }
     }
 
-    let router_chain = RouterChain::new(routers, fallback);
+    let router_chain = Arc::new(RouterChain::new(routers, fallback));
 
     config
         .validate_startup_security()
@@ -2448,7 +2448,7 @@ async fn build_live_config(
             }
         }
     }
-    let router_chain = RouterChain::new(routers, fallback);
+    let router_chain = Arc::new(RouterChain::new(routers, fallback));
 
     let group_default_tags: HashMap<String, QueryTags> = cluster_groups
         .iter()

--- a/plans/route-explain-endpoint.md
+++ b/plans/route-explain-endpoint.md
@@ -1,0 +1,196 @@
+# Route-Explain Endpoint — Detailed Implementation Plan
+
+Phase 1 of [`plans/adaptive-routing-explainability-agent-access.md`](./adaptive-routing-explainability-agent-access.md), expanded to file/function-level detail.
+
+**Status: implemented** on `feat/route-explain-endpoint` (backend, Studio UI, and docs). A few decisions changed from the original plan during implementation — each section below is annotated with what actually shipped and why. Not yet committed. Tracked by [lakeops-org/queryflux#176](https://github.com/lakeops-org/queryflux/issues/176) — link the PR to that issue when it's opened.
+
+**Post-implementation review found and fixed three real bugs:**
+1. `routing_trace.denied` was never set for authorization-stage denials (only router-stage ones), so Studio rendered a contradictory "Final group: success" trace footer alongside a "would be denied" banner. Fixed in `empty_route_explain_response`; regression test added (`route_explain_auth_denial_sets_trace_denied_too`).
+2. Guard preview evaluated guards against **untranslated** SQL; real dispatch (`dispatch_query`) runs guards *after* translation, against the final SQL. Fixed — `build_route_explain_response` now calls `TranslationService::maybe_translate` before building `GuardContext`, same as production.
+3. `RoutingTraceView`'s extraction introduced a rendering regression: a matched-but-empty-result decision (reachable via a buggy `pythonScript` router returning `""`) rendered as "no match" instead of nothing extra. Fixed the ternary.
+
+**Known gap, deliberately not fixed (not planned):** `would_queue` doesn't check the group's `maxQueuedQueries` limit or current queue depth (that check lives behind a persistence call — `count_active_queued_before` — that the preview doesn't have wired up). A group at running capacity with an already-full queue reports `would_queue: true` when real dispatch would reject with `QueueFull`.
+
+On review, this was deliberately deprioritized rather than fixed: `routing_trace`/`guard_actions` are deterministic and config-driven (the same answer regardless of when you ask), which is the actual reason to reach for this endpoint — testing an `allowGroups` rule, debugging a routing decision, catching a guardrail before a client hits it. `capacity`/`would_queue` is fundamentally different — live runtime state that can change before the caller acts on it no matter how precisely it's computed. Spending effort making a field that's inherently stale-on-arrival slightly less wrong wasn't worth it; instead the docstrings, TS types, and Studio UI now label `capacity` explicitly as a best-effort, moment-in-time bonus signal, distinct from the config-driven verdicts that are this endpoint's actual purpose. This sub-item is tracked and closed as not planned in the [#176](https://github.com/lakeops-org/queryflux/issues/176) comment thread — the issue itself stays open as the feature's tracking issue.
+
+**Structural gap fixed: guard-running and authorization-check logic no longer duplicated across dispatch.rs and admin.rs.** `build_route_explain_response` originally hand-copied dispatch's guard-chain loop and authorization check — the same duplication that caused bugs #2 and (indirectly) #1 above. Rather than leave that standing risk in place, this was consolidated into two shared helpers used by *every* call site, not just this endpoint's:
+
+- `queryflux_guardrails::run_guard_chains` (new, in `queryflux-guardrails/src/chain.rs`) — runs a set of chains (global, then per-group) for a layer, stopping at the first deny. Now the single definition of "what does it mean to guard-check a query," used by `dispatch_query`, `run_plan_guards` (internally — its external signature is unchanged), `execute_to_sink_inner`, and `build_route_explain_response`.
+- `crate::routing_resolve::check_group_authorized` (new, alongside `resolve_routed_group`) — the unconditional per-group authorization check, previously copy-pasted with an identical message format in `dispatch_query`, `execute_to_sink`, and now `admin.rs`.
+
+This touches the hot dispatch path (`dispatch.rs`), so it was done as a **separate branch/PR** (`fix/consolidate-guard-authz-pipeline`, in a sibling git worktree at `../queryflux-guard-consolidation` based on `main`) rather than bundled into this one — a mistake in a shared helper used by every query has much higher blast radius than a mistake in an admin preview endpoint. Both branches were updated in lockstep (identical helper additions) so `feat/route-explain-endpoint`'s `admin.rs` already consumes the same shared functions; whichever branch merges first, the other picks them up cleanly. Full workspace test suite (106+ frontend tests, 73 guardrails tests) passes identically before and after in both branches — the refactor is behavior-preserving by construction (same loop body, same order, same break-on-deny semantics), not a rewrite.
+
+Deliberately *not* touched: the deeper asymmetry where `run_plan_guards`'s speculative pre-flight check (before cluster selection, using `EngineType::Cache` as a "no engine yet" marker) doesn't write an audit record on deny, while the authoritative check in `execute_to_sink_inner` does. That's a genuine pre-existing gap in dispatch.rs's cache pre-check path, unrelated to route-explain — noted here so it isn't lost, but out of scope for this consolidation.
+
+**Known gap, not yet resolved: heterogeneous engine types within a resolved group.** Confirmed mixed-engine cluster groups are a real, supported configuration. `build_route_explain_response` picks `members.first()`'s engine type to stand in for the whole group when translating SQL and guard-checking — but that "first" member is whatever order `all_cluster_states()` happens to return, not necessarily the member the group's load-balancing strategy would actually pick for a given request. For a homogeneous group this doesn't matter; for a mixed one, the guard verdict and shown translated SQL can be wrong for whichever member dispatch actually selects. Decided direction: check every *distinct* engine type present in the group (usually 1, occasionally more) — report a single verdict when they agree (the common case), and surface an explicit "this depends on which engine gets picked" breakdown when they don't, rather than silently guessing. Not yet implemented.
+
+This surfaced a deeper, separate question during discussion: *should guardrails even run after translation, or before it?* Guard policies like `read_only`/`row_limit` are arguably about client intent, independent of which engine executes the query — checking pre-translation, client-dialect SQL would make guard verdicts engine-independent and sidestep the mixed-engine ambiguity entirely for guard checks. But that would change real production dispatch behavior (what gets blocked/allowed for live queries), not just this preview endpoint, and risks missing violations introduced by the `pythonScript` post-translation fixup hook. Deliberately **not** decided or implemented as a side effect of this work — tracked separately as [#177](https://github.com/lakeops-org/queryflux/issues/177) for whoever owns guardrail semantics to weigh in on.
+
+## Goal
+
+Given SQL text plus a hypothetical caller identity, answer "where would this query go, and what would happen to it" **without executing it or consuming any capacity**. Every question mark in the query lifecycle answered by this one call:
+
+- Which router matched (or did the fallback fire)?
+- Would authorization allow it, for this user/groups?
+- Would any guardrail rewrite, warn on, or block it?
+- Is the resolved cluster group actually able to take it right now, or would it queue?
+
+## Non-goals (v1)
+
+- Not a query cost estimator — that's Phase 2 (size-aware routing) and depends on new adapter plumbing (`EXPLAIN` support) this phase doesn't need.
+- ~~Not a SQL dialect preview — guard evaluation uses the same un-translated SQL...~~ — **superseded by the post-implementation review fix**: guard evaluation now does call `TranslationService`, same as real dispatch. See the fix log at the top of this doc.
+- Not query-plan `EXPLAIN` against a backend engine — nothing here touches an adapter or a live cluster; every signal comes from in-memory config/state already loaded into `LiveConfig`.
+
+## Why this is cheap
+
+Every piece this endpoint needs already exists and is already reachable from `AdminState`:
+
+| Need | Existing source |
+|---|---|
+| Run the router chain and get a full trace | `RouterChain::route_with_trace` (`crates/queryflux-routing/src/chain.rs`) |
+| Authorization-aware fallback resolution | `routing_resolve::resolve_routed_group` (`crates/queryflux-frontend/src/routing_resolve.rs`) — already `pub` |
+| Non-fallback authorization enforcement | `LiveConfig.authorization: Arc<dyn AuthorizationChecker>` |
+| Guard preview (read-only, no engine call) | `run_plan_guards` in `crates/queryflux-frontend/src/dispatch.rs` — currently private, needs `pub(crate)` |
+| Tag merging | `queryflux_core::tags::merge_tags` — already `pub` |
+| Live capacity per cluster | `ClusterGroupManager::all_cluster_states()` — already used by `clusters_handler` |
+
+So this phase is almost entirely glue code in `admin.rs`: no new trait methods, no new crate, no new background task, no new config schema.
+
+---
+
+## Request / response contract
+
+Following the existing admin-DTO convention (see `ClusterStateDto`): core types are converted to plain strings/JSON at the API boundary rather than adding `utoipa::ToSchema` to `queryflux-core` types.
+
+```rust
+/// POST /admin/route-explain
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RouteExplainRequest {
+    pub sql: String,
+    /// One of: trinoHttp, postgresWire, mysqlWire, clickhouseHttp, flightSql,
+    /// snowflakeHttp, snowflakeSqlApi. Same wire values as elsewhere in the admin API.
+    pub protocol: String,
+    /// Simulated identity for authorization-aware routing/guard preview.
+    /// Not verified against any AuthProvider — see "Simulated identity" below.
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(default)]
+    pub database: Option<String>,
+    /// Query tags, e.g. {"team": "eng", "batch": null} — same shape as QueryTags.
+    #[serde(default)]
+    pub tags: HashMap<String, Option<String>>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RouteExplainResponse {
+    /// Same shape Studio already renders for historical queries' routing_trace.
+    pub routing_trace: RoutingTrace,
+    /// Present only when a router or authorization check would deny the query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub denied: Option<String>,
+    /// Guard verdicts from the pre-dispatch guard pass (global + per-group chain),
+    /// same shape as QueryRecord.guard_actions. Empty if no guards configured.
+    pub guard_actions: Vec<queryflux_persistence::GuardAction>,
+    /// True if any guard action was a deny (query would never reach dispatch).
+    pub would_be_guard_blocked: bool,
+    /// Live capacity snapshot of the resolved group's members at the moment of the call.
+    /// Absent when routing itself was denied (no group was resolved).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capacity: Option<GroupCapacityDto>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GroupCapacityDto {
+    pub group_name: String,
+    pub members: Vec<ClusterStateDto>,  // reuse the existing DTO from clusters_handler
+    /// True if no member is currently enabled+healthy+under max_running_queries —
+    /// i.e. the query would sit in the queue (or hit sync retry-with-backoff) rather
+    /// than dispatch immediately.
+    pub would_queue: bool,
+}
+```
+
+---
+
+## Handler flow (as implemented)
+
+This mirrors the real dispatch order exactly, so the answer this endpoint gives matches what would actually happen. Order matters — routing, then fallback resolution, then authorization, then guards, then capacity, same as `dispatch_query` / `execute_to_sink`.
+
+**Shipped shape, differs from the original sketch in two ways** (both discovered while implementing, both improvements):
+
+1. **The handler is a thin wrapper.** `route_explain_handler` only does the `LiveConfig` snapshot (one lock acquisition, matching `dispatch_query`'s discipline) and then delegates to a pure(-ish) helper, `build_route_explain_response(router_chain, authorization, guard_chain, group_guard_chains, group_default_tags, group_order, cluster_manager, &req) -> Result<RouteExplainResponse>`, which takes every dependency as an explicit parameter instead of an `AdminState`. This was done specifically so the routing/authz/guard/capacity logic could be unit-tested with lightweight fixtures (`SimpleClusterGroupManager` + `RoundRobinStrategy` + `ClusterState`, the same pattern `routing_resolve.rs`'s own tests use) instead of constructing a full `AdminState` (which has no existing test-construction helper anywhere in `admin.rs` — see "Testing" below).
+2. **Guard preview does not reuse `run_plan_guards`.** See "Code changes needed" #1 — grounding the plan against the real `dispatch.rs` turned up three independent guard-running call sites, not one shared function, and the resolved group's *real* engine type was already sitting in the same `all_cluster_states()` call the capacity check needs. Using it is both simpler (no `dispatch.rs` changes at all) and more accurate than the placeholder one particular call site uses pre-cluster-selection.
+
+Protocol parsing needed no custom code: `RouteExplainRequest.protocol` is typed as `FrontendProtocol` directly (it already derives `Deserialize` with the right camelCase rename), so an invalid protocol string is rejected by axum's `Json<T>` extractor with a 400 before the handler body even runs — the planned `parse_frontend_protocol` helper turned out to be unnecessary.
+
+---
+
+## Code changes made
+
+### 1. `crates/queryflux-frontend/src/dispatch.rs` — **not touched**
+
+The original plan called for making `run_plan_guards` `pub(crate)` and changing its return type. During implementation this turned out to be unnecessary: grounding the plan against the real `dispatch.rs` showed guard evaluation isn't centralized behind one function at all — there are **three** independent guard-running call sites (an inline block in `dispatch_query`, the `run_plan_guards` function used only by `execute_to_sink`'s cache-check branch, and another inline block in `execute_to_sink_inner`), and only one of them (`run_plan_guards`) uses the `EngineType::Cache` placeholder the original plan assumed was universal.
+
+Since the capacity check already needs to call `all_cluster_states()` and filter to the resolved group, that same call also yields the group's **real** `engine_type` (from the first member) — more accurate for guard dialect parsing than any placeholder, and free. So the shipped guard preview is a small inline loop in `admin.rs` (same `for chain in [guard_chain, group_guard_chain].flatten() { chain.run(...) }` shape all three existing call sites share) using the real engine type, and `dispatch.rs` has zero changes.
+
+### 2. `crates/queryflux-frontend/src/admin.rs`
+
+- Added `RouteExplainRequest`, `RouteExplainResponse`, `GroupCapacityDto` (protocol field typed as `FrontendProtocol` directly with `#[schema(value_type = String)]` for the OpenAPI doc, rather than a raw `String` + manual parser).
+- Added `route_explain_handler` (thin wrapper) and `build_route_explain_response` (the testable core — see "Handler flow" above).
+- Added `empty_route_explain_response(trace, denied) -> RouteExplainResponse` helper — the deny path is hit from three places (router deny, fallback-resolve error, per-group authz check) and always builds the same shape.
+- Registered `.route("/admin/route-explain", post(route_explain_handler))` in the `protected` router (same Basic-auth gate as every other admin endpoint) and added it to `#[openapi(paths(...))]` + `components(schemas(...))`.
+- No `parse_frontend_protocol` helper needed — see "Handler flow" above.
+
+### 3. `RouterChain` clonability — resolved as **(b)**, `Arc`-wrapped
+
+`LiveConfig.router_chain` is now `Arc<RouterChain>`, matching `cluster_manager`/`authorization`. All five construction sites were updated (`main.rs` ×2, `state.rs` test fixture, `routing_resolve.rs` test fixture, `trino_http/handlers.rs` test fixture) plus four more found in `queryflux-e2e-tests/src/harness.rs` that the original plan didn't know about (grep for `LiveConfig {` across the workspace, not just `queryflux-frontend`, would have caught these up front). All six existing read call sites (`live.router_chain.route(...)` / `.route_with_trace(...)` in the five frontend protocol handlers) needed zero changes — method calls resolve through `Arc`'s `Deref` transparently. `cargo check --workspace` was the way this got verified, not manual inspection.
+
+### 4. Studio (`queryflux-studio`) — done, as its own nav page rather than embedded
+
+Shipped as a dedicated **Route Explain** page (`app/route-explain/`) in the left nav, not embedded in the Clusters page — it didn't fit naturally as a sub-panel there and a dedicated page keeps the (fairly busy) Clusters page uncluttered. `RoutingTraceView` was extracted out of `query-detail.tsx` into `components/routing-trace-view.tsx` so the historical-query view and the dry-run preview render identically; it also gained deny-message rendering (`RoutingDecision.deny_message`, `RoutingTrace.denied`) which the Rust side already produced but the TS types and renderer didn't expose yet — a small pre-existing gap, fixed as part of this since the explain panel's "denied by router" case needed it to be useful at all.
+
+### 5. CLI (`queryflux-cli`) — deferred
+
+Not built in this phase. Low cost if wanted later, but nothing in Phase 1's scope depended on it and the Studio page covers the interactive use case.
+
+---
+
+## Correctness pitfalls to design around
+
+1. **Never call `ClusterGroupManager::acquire_cluster`.** It's not a query — it's `Pick a cluster and increment its running count`. Calling it from an explain endpoint would silently consume real capacity that's never released (there's no matching query to trigger `release_cluster`), inflating `running_queries` until the next restart or a manual fix. `all_cluster_states()` is the only capacity read this endpoint should ever touch.
+2. **Guard evaluation uses the resolved group's real engine type, not a placeholder — a deliberate improvement over the original plan.** Some of production's own pre-dispatch guard-evaluation call sites use `EngineType::Cache` as a placeholder because they run *before* cluster selection. The explain endpoint doesn't have that constraint — it already resolves a group and reads its members' live state for the capacity check, so the same data gives it the real `engine_type` for guard dialect parsing too. SQL is now translated before guard evaluation (fixed post-review — see top of doc), using that same real engine type as the translation target. One remaining documented limitation: a group with heterogeneous engine types across members only sees the first member's dialect for both translation and guard parsing.
+3. **Simulated identity is a documented capability, not a bug.** `user`/`groups` in the request body are never checked against a real `AuthProvider` — this endpoint answers "if a query came in as user X with groups Y, what would happen," which is exactly what makes it useful for testing authorization rules. Because the endpoint sits behind the same Basic-auth admin gate as every other `/admin/*` route, this means **admin credential holders can probe authorization outcomes for any simulated user**. That's the intended use (testing `allowGroups`/`allowUsers` rules before rolling them out) — call it out explicitly in the endpoint's doc comment and in Studio's UI copy so it isn't mistaken for real per-user authentication.
+4. **Timeouts.** All current router implementations are fast except `pythonScript` (arbitrary user code) — no new timeout is needed for this phase since production doesn't have one either, but if a Python router has an unbounded loop, this endpoint inherits that risk exactly as query dispatch already does. Not a new problem introduced here, just worth knowing it isn't solved by this phase.
+
+---
+
+## Testing — as implemented
+
+Five `#[tokio::test]`s in `admin.rs`'s existing test module, calling `build_route_explain_response` directly (not the HTTP handler — there's no existing pattern anywhere in `admin.rs` for constructing a full `AdminState` in tests, since every other test in the file exercises pure helpers or async functions with narrow dependencies, not full handlers; matching that convention is what made extracting `build_route_explain_response` the right call, not just a testability nicety):
+
+- `route_explain_denied_by_router_skips_capacity_and_guards` — a `queryRegex` deny rule → `denied` is set, `capacity`/`guard_actions` are empty.
+- `route_explain_fallback_reroutes_to_authorized_group` — empty router list (fallback fires) + a `SimpleAuthorizationPolicy` that excludes the fallback group but allows another → resolves to the authorized group, `used_fallback: true`.
+- `route_explain_read_only_guard_blocks_write` — `ReadOnlyGuard` on the group, `INSERT ...` → `would_be_guard_blocked: true`, guard action has `code: "READ_ONLY_VIOLATION"`.
+- `route_explain_would_queue_true_when_group_is_full` — single member at `running == max` → `would_queue: true`.
+- `route_explain_would_queue_false_with_one_healthy_member_under_capacity` — one disabled + one healthy-under-capacity member → `would_queue: false`, both still listed.
+
+Fixtures reuse the exact pattern `routing_resolve.rs`'s own tests already use (`SimpleClusterGroupManager` + `RoundRobinStrategy` + `ClusterState`, `AllowAllAuthorization`/`SimpleAuthorizationPolicy`) — no new test infrastructure needed. `ClusterState::set_running_queries`/`set_healthy`/`set_enabled` (all pre-existing) made the capacity fixtures straightforward.
+
+Not done: an integration test asserting the explain endpoint's answer matches a *real* dispatched query's outcome. Worth adding once `queryflux-e2e-tests` has a scenario this could hook into — flagged as a gap, not silently dropped.
+
+---
+
+## Rollout
+
+No config schema changes, no migration, no new background task — this is purely additive (`admin.rs` handler is fine to release without a feature flag). Restarting or hot-reloading is unaffected. Safe to ship in a normal release without a phased rollout.
+
+---
+
+## Open questions
+
+1. ~~Lock-holding option~~ — **resolved**: `Arc<RouterChain>` (option b), see "Code changes made" #3.
+2. **Should `/admin/route-explain` require the caller to *already* be authorized for the resolved group** (i.e., should this itself be gated by something beyond admin Basic auth)? Shipped as: no — the whole point is letting an admin check routing for *other* users. Still open: whether calls should be audit-logged (reusing `QueryRecord`-adjacent patterns) — not done, since this endpoint deliberately persists nothing (see "does this need a migration" below).
+3. ~~Does Studio's trace component assume a `QueryRecord`?~~ — **resolved**: it didn't; extraction to `components/routing-trace-view.tsx` needed no `QueryRecord`-shaped input, only a `RoutingTrace`.
+4. **No integration test** verifying explain output matches real dispatch output — see "Testing" above. Would need a `queryflux-e2e-tests` scenario; not blocking for v1 since the same code paths (`route_with_trace`, `resolve_routed_group`, `GuardChain::run`) are already covered by their own unit tests elsewhere.

--- a/queryflux-studio/app/client-shell.tsx
+++ b/queryflux-studio/app/client-shell.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import {
   Bot,
   BookOpen,
+  Compass,
   FileCode,
   LayoutDashboard,
   List,
@@ -30,6 +31,7 @@ const nav = [
   { href: "/guardrails", label: "Guardrails", icon: ShieldCheck },
   { href: "/protocols", label: "Protocols", icon: Radio },
   { href: "/routing", label: "Routing", icon: Route },
+  { href: "/route-explain", label: "Route Explain", icon: Compass },
   { href: "/swagger", label: "API Reference", icon: BookOpen },
 ];
 

--- a/queryflux-studio/app/queries/query-detail.tsx
+++ b/queryflux-studio/app/queries/query-detail.tsx
@@ -4,6 +4,7 @@ import { X, Clock, Server, User, Rows3, Hash, ArrowRight, Fingerprint, Cpu, Data
 import type { QueryHistoryRecord, RoutingTrace } from "@/lib/api-types";
 import { StatusBadge, EngineBadge, formatDuration, formatDateTime } from "@/components/ui-helpers";
 import { GuardActionsList } from "@/components/guard-actions-list";
+import { RoutingTraceView } from "@/components/routing-trace-view";
 
 /** Reusable detail body — used both in the slide-over panel and inline in agent conversations. */
 export function QueryDetailContent({ query }: { query: QueryHistoryRecord }) {
@@ -266,46 +267,3 @@ function EngineStatsView({ query }: { query: QueryHistoryRecord }) {
   );
 }
 
-function RoutingTraceView({ trace }: { trace: RoutingTrace }) {
-  return (
-    <div className="space-y-2">
-      {trace.decisions.map((d, i) => (
-        <div
-          key={i}
-          className={`flex items-start gap-3 rounded-xl p-3 text-xs border ${
-            d.matched
-              ? "bg-indigo-50 border-indigo-100 text-indigo-800"
-              : "bg-slate-50 border-slate-100 text-slate-500"
-          }`}
-        >
-          <span className={`mt-0.5 w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold flex-shrink-0 ${
-            d.matched ? "bg-indigo-200 text-indigo-700" : "bg-slate-200 text-slate-500"
-          }`}>
-            {i + 1}
-          </span>
-          <div className="min-w-0 flex items-center gap-2 flex-wrap">
-            <span className="font-semibold">{d.router_type}</span>
-            {d.matched && d.result && (
-              <span className="flex items-center gap-1 text-indigo-600">
-                <ArrowRight size={10} />
-                <span className="font-mono">{d.result}</span>
-              </span>
-            )}
-            {!d.matched && <span className="text-slate-400 italic">no match</span>}
-          </div>
-        </div>
-      ))}
-      <div className="flex items-center gap-2 pt-2 text-xs border-t border-slate-100 mt-2">
-        <span className="text-slate-400 font-medium">Final group</span>
-        <span className="font-mono font-semibold text-indigo-700 bg-indigo-50 px-2 py-0.5 rounded-md">
-          {trace.final_group}
-        </span>
-        {trace.used_fallback && (
-          <span className="text-amber-600 text-[11px] bg-amber-50 px-1.5 py-0.5 rounded-md border border-amber-100">
-            fallback
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}

--- a/queryflux-studio/app/route-explain/page.tsx
+++ b/queryflux-studio/app/route-explain/page.tsx
@@ -1,0 +1,25 @@
+import { Compass } from "lucide-react";
+import { RouteExplainPanel } from "./route-explain-panel";
+
+export default function RouteExplainPage() {
+  return (
+    <div className="p-6 sm:p-8 space-y-6 max-w-5xl mx-auto">
+      <div className="rounded-2xl border border-slate-200 bg-gradient-to-br from-white via-white to-indigo-50/60 px-6 py-5 shadow-xs">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200 text-xs font-medium">
+            <Compass size={12} />
+            Dry run
+          </span>
+          <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Route Explain</h1>
+        </div>
+        <p className="text-sm text-slate-500 mt-2 max-w-2xl">
+          See which cluster group a query would hit, whether it would be authorized, whether any
+          guardrail would block it, and whether that group has room for it right now — without
+          running the query or consuming any capacity.
+        </p>
+      </div>
+
+      <RouteExplainPanel />
+    </div>
+  );
+}

--- a/queryflux-studio/app/route-explain/route-explain-panel.tsx
+++ b/queryflux-studio/app/route-explain/route-explain-panel.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { Play, ShieldX, Clock3, Loader2, AlertTriangle } from "lucide-react";
+import { explainRoute } from "@/lib/api";
+import type { RouteExplainResponse } from "@/lib/api-types";
+import { RoutingTraceView } from "@/components/routing-trace-view";
+import { GuardActionsList } from "@/components/guard-actions-list";
+
+const PROTOCOLS = [
+  { value: "trinoHttp", label: "Trino HTTP" },
+  { value: "postgresWire", label: "Postgres wire" },
+  { value: "mysqlWire", label: "MySQL wire" },
+  { value: "clickhouseHttp", label: "ClickHouse HTTP" },
+  { value: "flightSql", label: "Flight SQL" },
+  { value: "snowflakeHttp", label: "Snowflake HTTP" },
+  { value: "snowflakeSqlApi", label: "Snowflake SQL API v2" },
+];
+
+const inputClass =
+  "h-9 w-full px-3 rounded-lg border border-slate-200 text-sm bg-slate-50 text-slate-700 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400 focus:bg-white transition-all";
+
+export function RouteExplainPanel() {
+  const [sql, setSql] = useState("SELECT 1");
+  const [protocol, setProtocol] = useState("trinoHttp");
+  const [user, setUser] = useState("");
+  const [groups, setGroups] = useState("");
+  const [tags, setTags] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RouteExplainResponse | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const resp = await explainRoute({
+        sql,
+        protocol,
+        user: user.trim() || undefined,
+        groups: groups
+          .split(",")
+          .map((g) => g.trim())
+          .filter(Boolean),
+        tags: parseTags(tags),
+      });
+      setResult(resp);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-xl border border-slate-200 p-5 shadow-xs space-y-4"
+      >
+        <div>
+          <label className="text-xs font-medium text-slate-500 mb-1.5 block">SQL</label>
+          <textarea
+            value={sql}
+            onChange={(e) => setSql(e.target.value)}
+            rows={5}
+            className="w-full px-3 py-2 rounded-lg border border-slate-200 text-sm font-mono bg-slate-50 text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-indigo-400 focus:bg-white transition-all resize-y"
+            placeholder="SELECT * FROM prod.orders WHERE …"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs font-medium text-slate-500 mb-1.5 block">Protocol</label>
+            <select
+              value={protocol}
+              onChange={(e) => setProtocol(e.target.value)}
+              className={`${inputClass} cursor-pointer`}
+            >
+              {PROTOCOLS.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs font-medium text-slate-500 mb-1.5 block">
+              Simulated user
+            </label>
+            <input
+              value={user}
+              onChange={(e) => setUser(e.target.value)}
+              placeholder="anonymous"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="text-xs font-medium text-slate-500 mb-1.5 block">
+              Simulated groups
+            </label>
+            <input
+              value={groups}
+              onChange={(e) => setGroups(e.target.value)}
+              placeholder="team-a, analytics"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-slate-500 mb-1.5 block">
+              Tags <span className="text-slate-300">(k:v, k:v)</span>
+            </label>
+            <input
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="team:eng, batch"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <p className="text-[11px] text-slate-400 leading-relaxed">
+          The simulated user and groups above are not verified against any auth provider — this
+          previews what routing/authorization/guardrails would do <em>if</em> a query came in
+          with this identity. Nothing here is executed or persisted.
+        </p>
+
+        <button
+          type="submit"
+          disabled={loading || !sql.trim()}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm transition-colors"
+        >
+          {loading ? <Loader2 size={15} className="animate-spin" /> : <Play size={15} />}
+          Explain routing
+        </button>
+      </form>
+
+      {/* Result */}
+      <div className="space-y-4">
+        {error && (
+          <div className="bg-red-50 border border-red-100 rounded-xl p-4 flex items-start gap-2.5">
+            <AlertTriangle size={15} className="text-red-500 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {!error && !result && (
+          <div className="bg-white rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">
+            Submit a query to preview its routing decision.
+          </div>
+        )}
+
+        {result && (
+          <>
+            <div className="bg-white rounded-xl border border-slate-200 p-5 shadow-xs">
+              <SectionLabel>Routing trace</SectionLabel>
+              <RoutingTraceView trace={result.routing_trace} />
+            </div>
+
+            {result.denied && (
+              <div className="bg-red-50 border border-red-100 rounded-xl p-4 flex items-start gap-2.5">
+                <ShieldX size={15} className="text-red-500 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm font-medium text-red-800">Query would be denied</p>
+                  <p className="text-xs text-red-600 mt-0.5">{result.denied}</p>
+                </div>
+              </div>
+            )}
+
+            {!result.denied && result.guard_actions.length > 0 && (
+              <div className="bg-white rounded-xl border border-slate-200 p-5 shadow-xs">
+                <SectionLabel>
+                  Guard actions{" "}
+                  {result.would_be_guard_blocked && (
+                    <span className="ml-1.5 text-red-600 font-normal normal-case tracking-normal">
+                      — would block
+                    </span>
+                  )}
+                </SectionLabel>
+                <GuardActionsList actions={result.guard_actions} />
+              </div>
+            )}
+
+            {result.capacity && (
+              <div className="bg-white rounded-xl border border-slate-200 p-5 shadow-xs">
+                <SectionLabel>
+                  Capacity (live snapshot) —{" "}
+                  <span className="font-mono normal-case tracking-normal text-slate-600">
+                    {result.capacity.group_name}
+                  </span>
+                </SectionLabel>
+                <p className="text-[11px] text-slate-400 mb-3 -mt-1.5">
+                  Unlike the routing/guard verdicts above, this reflects live state at the
+                  moment of this call and can change before you act on it — treat as advisory.
+                </p>
+                {result.capacity.would_queue && (
+                  <div className="flex items-center gap-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mb-3">
+                    <Clock3 size={12} />
+                    No member has room right now — would not dispatch immediately (this doesn't
+                    check the queue-admission limit, so it could also be rejected outright).
+                  </div>
+                )}
+                <div className="space-y-1.5">
+                  {result.capacity.members.map((m) => (
+                    <div
+                      key={m.cluster_name}
+                      className="flex items-center justify-between text-xs px-3 py-2 rounded-lg bg-slate-50 border border-slate-100"
+                    >
+                      <span className="font-mono text-slate-700">{m.cluster_name}</span>
+                      <div className="flex items-center gap-3 text-slate-500">
+                        <span>{m.running_queries}/{m.max_running_queries} running</span>
+                        <span className={m.is_healthy ? "text-emerald-600" : "text-red-600"}>
+                          {m.is_healthy ? "healthy" : "unhealthy"}
+                        </span>
+                        <span className={m.enabled ? "text-slate-500" : "text-slate-400"}>
+                          {m.enabled ? "enabled" : "disabled"}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-[11px] font-semibold uppercase tracking-widest mb-3 text-slate-400">
+      {children}
+    </p>
+  );
+}
+
+/** Parses "k:v, k2, k3:v3" into QueryTags shape — key-only entries get a null value. */
+function parseTags(raw: string): Record<string, string | null> {
+  const tags: Record<string, string | null> = {};
+  for (const part of raw.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.indexOf(":");
+    if (idx === -1) {
+      tags[trimmed] = null;
+    } else {
+      tags[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+    }
+  }
+  return tags;
+}

--- a/queryflux-studio/components/routing-trace-view.tsx
+++ b/queryflux-studio/components/routing-trace-view.tsx
@@ -1,0 +1,78 @@
+import { ArrowRight, ShieldX } from "lucide-react";
+import type { RoutingTrace } from "@/lib/api-types";
+
+/** Reusable trace renderer — used by the query history detail panel and the
+ * route-explain preview panel, so a historical trace and a dry-run trace look identical. */
+export function RoutingTraceView({ trace }: { trace: RoutingTrace }) {
+  return (
+    <div className="space-y-2">
+      {trace.decisions.map((d, i) => (
+        <div
+          key={i}
+          className={`flex items-start gap-3 rounded-xl p-3 text-xs border ${
+            d.deny_message
+              ? "bg-red-50 border-red-100 text-red-800"
+              : d.matched
+              ? "bg-indigo-50 border-indigo-100 text-indigo-800"
+              : "bg-slate-50 border-slate-100 text-slate-500"
+          }`}
+        >
+          <span
+            className={`mt-0.5 w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold flex-shrink-0 ${
+              d.deny_message
+                ? "bg-red-200 text-red-700"
+                : d.matched
+                ? "bg-indigo-200 text-indigo-700"
+                : "bg-slate-200 text-slate-500"
+            }`}
+          >
+            {i + 1}
+          </span>
+          <div className="min-w-0 flex-1 space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-semibold">{d.router_type}</span>
+              {d.deny_message ? (
+                <span className="flex items-center gap-1 text-red-600">
+                  <ShieldX size={10} />
+                  denied
+                </span>
+              ) : d.matched ? (
+                d.result && (
+                  <span className="flex items-center gap-1 text-indigo-600">
+                    <ArrowRight size={10} />
+                    <span className="font-mono">{d.result}</span>
+                  </span>
+                )
+              ) : (
+                <span className="text-slate-400 italic">no match</span>
+              )}
+            </div>
+            {d.deny_message && <p className="text-[11px] text-red-700">{d.deny_message}</p>}
+          </div>
+        </div>
+      ))}
+      <div className="flex items-center gap-2 pt-2 text-xs border-t border-slate-100 mt-2 flex-wrap">
+        {trace.denied ? (
+          <>
+            <span className="text-slate-400 font-medium">Result</span>
+            <span className="text-red-700 bg-red-50 px-2 py-0.5 rounded-md border border-red-100">
+              denied — {trace.denied}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="text-slate-400 font-medium">Final group</span>
+            <span className="font-mono font-semibold text-indigo-700 bg-indigo-50 px-2 py-0.5 rounded-md">
+              {trace.final_group}
+            </span>
+            {trace.used_fallback && (
+              <span className="text-amber-600 text-[11px] bg-amber-50 px-1.5 py-0.5 rounded-md border border-amber-100">
+                fallback
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -148,12 +148,56 @@ export interface RoutingTrace {
   decisions: RoutingDecision[];
   final_group: string;
   used_fallback: boolean;
+  /** Present when routing ended in a deny (final_group may be empty). */
+  denied?: string | null;
 }
 
 export interface RoutingDecision {
   router_type: string;
   matched: boolean;
   result?: string | null;
+  /** Present when this router denied the query. */
+  deny_message?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Route explain (POST /admin/route-explain) — dry-run routing/guard/capacity preview
+// ---------------------------------------------------------------------------
+
+export interface RouteExplainRequest {
+  sql: string;
+  protocol: string;
+  user?: string | null;
+  groups?: string[];
+  database?: string | null;
+  tags?: Record<string, string | null>;
+}
+
+export interface GroupCapacityDto {
+  group_name: string;
+  members: ClusterStateDto[];
+  /**
+   * True when no member is currently enabled, healthy, and under max_running_queries —
+   * i.e. would not dispatch immediately, as of this snapshot. Best-effort: doesn't check
+   * the group's maxQueuedQueries admission limit, so `true` isn't a guarantee the query
+   * would successfully queue rather than being rejected.
+   */
+  would_queue: boolean;
+}
+
+export interface RouteExplainResponse {
+  routing_trace: RoutingTrace;
+  /** Set when a router or authorization check would deny the query. */
+  denied?: string | null;
+  guard_actions: GuardAction[];
+  would_be_guard_blocked: boolean;
+  /**
+   * Best-effort, moment-in-time capacity snapshot — unlike routing_trace/guard_actions
+   * (deterministic, config-driven), this reflects live runtime state that can change
+   * before you act on it. Treat as advisory; poll GET /admin/clusters for authoritative
+   * live state. Absent when `denied` is set — no group was resolved.
+   */
+  capacity?: GroupCapacityDto | null;
 }
 
 /** Per-cluster-group aggregated stats from `GET /admin/group-stats`. */

--- a/queryflux-studio/lib/api.ts
+++ b/queryflux-studio/lib/api.ts
@@ -11,6 +11,8 @@ import type {
   GuardrailsConfig,
   QueryHistoryRecord,
   QueryListParams,
+  RouteExplainRequest,
+  RouteExplainResponse,
 } from "./api-types";
 import {
   SESSION_COOKIE_NAME,
@@ -428,6 +430,14 @@ export async function testClusterConfig(
 }
 
 // ---------------------------------------------------------------------------
+// Route explain — dry-run routing/guard/capacity preview
+// ---------------------------------------------------------------------------
+
+export async function explainRoute(body: RouteExplainRequest): Promise<RouteExplainResponse> {
+  return apiPost("/admin/route-explain", body);
+}
+
+// ---------------------------------------------------------------------------
 // Auth management
 // ---------------------------------------------------------------------------
 
@@ -469,10 +479,13 @@ export type {
   OpenFgaConfigDto,
   QueryHistoryRecord,
   QueryListParams,
+  RouteExplainRequest,
+  RouteExplainResponse,
   RouterConfigEntry,
   RoutingConfigDto,
   RoutingTrace,
   RoutingDecision,
+  GroupCapacityDto,
   SecurityConfigDto,
   UpsertClusterConfig,
   UpsertClusterGroupConfig,

--- a/website/docs/architecture/observability.md
+++ b/website/docs/architecture/observability.md
@@ -103,6 +103,7 @@ or remap Grafana in `docker-compose.yml` (`ports: ["3001:3000"]`).
 | Clusters | All cluster groups and member clusters — health, running/queued counts, enable/disable, max concurrency |
 | Queries | Searchable, filterable query history — SQL, status, duration, engine, routing trace |
 | Engines | Engine registry — supported engines, connection types, config fields |
+| Route Explain | Dry-run routing/guard/capacity preview for a SQL string + simulated identity — no execution, no persistence |
 
 Studio requires **Postgres persistence** to be configured — query history, cluster config, and dashboard stats are read from the DB. Without Postgres, the clusters page works (from in-memory state) but history pages return empty.
 
@@ -132,6 +133,7 @@ The admin API is served on port 9000 alongside `/metrics`. An OpenAPI spec is av
 | `GET` | `/admin/config/groups` | List all persisted group configs |
 | `DELETE` | `/admin/cache` | Invalidate all cached query results |
 | `DELETE` | `/admin/cache/{group}` | Invalidate cached results for a group |
+| `POST` | `/admin/route-explain` | Dry-run routing/guard/capacity preview — no execution, nothing persisted. See [Route explain](./routing-and-clusters#route-explain-dry-run) |
 | `GET` | `/openapi.json` | OpenAPI spec |
 | `GET` | `/docs` | Swagger UI |
 

--- a/website/docs/architecture/routing-and-clusters.md
+++ b/website/docs/architecture/routing-and-clusters.md
@@ -127,7 +127,48 @@ def route(query: str, ctx: dict) -> str | None:
 
 ## Routing trace
 
-`route_with_trace` records each router’s decision (`matched`, optional `result`) and whether the **fallback** group was used. This supports debugging and future UI/metrics (see `RoutingTrace` in `queryflux_routing::chain`).
+`route_with_trace` records each router’s decision (`matched`, optional `result`, and — when a `queryRegex` deny rule fires — `deny_message`) and whether the **fallback** group was used (see `RoutingTrace` in `queryflux_routing::chain`). Every dispatched query's trace is persisted with its `QueryRecord` and rendered in Studio's Queries page. The same trace type also powers the **route-explain** preview below, so a historical trace and a dry-run trace render identically.
+
+## Route explain (dry run)
+
+`POST /admin/route-explain` answers "where would this query go, and what would happen to it" **without executing the query or consuming any capacity**. It mirrors the real dispatch order exactly — route → fallback-resolve → authorize → guard preview → capacity — so the answer matches what would actually happen if the query were submitted for real.
+
+**Request:**
+
+```json
+{
+  "sql": "SELECT * FROM prod.orders",
+  "protocol": "trinoHttp",
+  "user": "alice",
+  "groups": ["team-a"],
+  "database": null,
+  "tags": { "team": "eng" }
+}
+```
+
+`user`/`groups` are a **simulated identity** — they are not verified against any `AuthProvider`. This is what makes the endpoint useful for testing `allowGroups`/`allowUsers` rules before rolling them out: "if a query came in as this user, what would happen?" Because the endpoint sits behind the same admin Basic-auth gate as every other `/admin/*` route, an admin credential holder can already probe outcomes for any simulated user — that is the intended use, not a bypass of real authentication.
+
+**Response:**
+
+```json
+{
+  "routing_trace": { "decisions": [...], "final_group": "team-a-cluster", "used_fallback": false },
+  "denied": null,
+  "guard_actions": [{ "guard": "read_only", "action": "allow", "reason": null, "code": null }],
+  "would_be_guard_blocked": false,
+  "capacity": {
+    "group_name": "team-a-cluster",
+    "members": [{ "cluster_name": "trino-1", "running_queries": 2, "max_running_queries": 10, "is_healthy": true, "enabled": true }],
+    "would_queue": false
+  }
+}
+```
+
+- **`denied`** is set when a router (e.g. a `queryRegex` deny rule) or the per-group authorization check would reject the query. When set, `guard_actions` is empty and `capacity` is absent — nothing downstream of the deny was evaluated.
+- **`guard_actions`** / **`would_be_guard_blocked`** come from running the resolved group's guard chain (global chain, then the group's chain) against the translated SQL — the same way and same order the real pre-dispatch guard pass runs, using the resolved group's real engine type (from the first member) as the translation target. Groups with heterogeneous engine types across members are not modeled here — the first member stands in for the whole group.
+- **`capacity`** is a deliberately best-effort, moment-in-time signal — different in kind from `routing_trace`/`guard_actions`. Routing, authorization, and guardrail verdicts are config-driven: the same request gives the same answer regardless of when you ask, which is what makes them worth previewing. Capacity is live runtime state — it can change before you act on it no matter how accurately it's computed, so this endpoint doesn't try to make it authoritative. `would_queue: true` means "no member is currently enabled, healthy, and under `maxRunningQueries`" — i.e. would not dispatch immediately as of this snapshot — but it does **not** check the group's `maxQueuedQueries` admission limit, so it isn't a guarantee the query would successfully queue rather than being rejected outright with `QueueFull`. For authoritative live state, poll `GET /admin/clusters` (which this endpoint also reads from — it never calls `acquire_cluster`, so calling it has no side effects and consumes no capacity).
+
+Studio exposes this as the **Route Explain** page (left nav) — a form for SQL/protocol/simulated identity/tags that renders the same trace, guard, and capacity views used elsewhere in Studio.
 
 ## Cluster group configuration (actual shape)
 


### PR DESCRIPTION
## Summary
- Adds `POST /admin/route-explain` — given SQL and a simulated caller identity, previews which cluster group the query would route to, whether it would be authorized, whether any guardrail would block it, and the resolved group's live capacity, without executing the query or persisting anything.
- Mirrors the real dispatch order (route → fallback-resolve → authorize → guard preview → capacity) so the preview matches what dispatch would actually do.
- Consolidates guard-chain execution and the per-group authorization check — previously duplicated across three call sites in `dispatch.rs` — into two shared helpers (`queryflux_guardrails::run_guard_chains`, `routing_resolve::check_group_authorized`) so this new preview path can't quietly drift from real dispatch. Behavior-preserving for existing call sites (same loop, same order, same break-on-deny semantics).
- Adds a **Route Explain** page to Studio, and docs in `routing-and-clusters.md` / `observability.md`.
- Full implementation history, decisions, and known/deferred limitations are recorded in `plans/route-explain-endpoint.md`.

Draft PR — the hot-path guard/authz consolidation this depends on is being split into its own separate PR (`fix/consolidate-guard-authz-pipeline`) given the higher blast radius of touching `dispatch.rs`; this PR currently includes that same consolidation directly since it was developed in lockstep. Marking draft until that's settled and a couple of known follow-ups (heterogeneous-engine-group handling, tracked in the plan doc) are resolved.

Closes #176. Related: #177 (separate design question, not resolved here).

## Test plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy -p queryflux-frontend -p queryflux-guardrails` clean
- [x] `cargo test --workspace --lib` — all passing (112 in queryflux-frontend, 73 in queryflux-guardrails, including new tests for the endpoint and the two shared helpers)
- [x] Studio: `tsc --noEmit`, `eslint`, and `next build` all clean
- [ ] Manual smoke test against a running proxy (not yet done in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)