### PR TITLE
feat: passthrough queryAuth mode for ADBC/Snowflake

### DIFF
--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1598,6 +1598,12 @@ pub enum QueryAuthConfig {
 /// list is what actually gates `tokenExchange` for ADBC clusters.
 const ADBC_TOKEN_EXCHANGE_DRIVERS: &[&str] = &["snowflake"];
 
+/// ADBC drivers whose adapter code knows how to route a query to a per-caller-credential
+/// sub-pool for `passthrough` (see `AdbcAdapter::execute_as_arrow`'s `PoolScopeKey`
+/// passthrough dimension). Every other ADBC driver is `serviceAccount`-only — same shape as
+/// [`ADBC_TOKEN_EXCHANGE_DRIVERS`], just for `passthrough` instead of `tokenExchange`.
+const ADBC_PASSTHROUGH_AUTH_DRIVERS: &[&str] = &["snowflake"];
+
 /// Centralizes the engine × `queryAuth` support matrix so YAML load, Studio PUT, and
 /// startup validation can't drift apart. Returns `Err` with an operator-facing message
 /// when `mode` is not implemented for `engine` (and, for ADBC, `driver`) yet.
@@ -1647,11 +1653,24 @@ pub fn query_auth_supported(
         {
             Ok(())
         }
+        // Passthrough here means a real per-caller Snowflake username/password, captured at
+        // Snowflake wire v1 login and routed to a dedicated sub-pool — see
+        // `AdbcAdapter::execute_as_arrow`. SQL API v2 (stateless, Bearer-only) has no password
+        // to capture, so a passthrough-configured cluster reached that way fails closed at
+        // dispatch time with a clear error instead of silently falling back to the service
+        // account — no separate check needed here for that case.
+        Some(EngineConfig::Adbc)
+            if matches!(mode, QueryAuthConfig::Passthrough)
+                && driver.is_some_and(|d| ADBC_PASSTHROUGH_AUTH_DRIVERS.contains(&d)) =>
+        {
+            Ok(())
+        }
         Some(EngineConfig::Adbc) => {
             let driver_name = driver.unwrap_or("<unknown>");
             Err(format!(
                 "queryAuth.type = {mode_name} is not supported for ADBC driver '{driver_name}' \
-                 in this release (only tokenExchange for {ADBC_TOKEN_EXCHANGE_DRIVERS:?})"
+                 in this release (only tokenExchange for {ADBC_TOKEN_EXCHANGE_DRIVERS:?}, or \
+                 passthrough for {ADBC_PASSTHROUGH_AUTH_DRIVERS:?})"
             ))
         }
         other => {
@@ -1661,7 +1680,7 @@ pub fn query_auth_supported(
             Err(format!(
                 "queryAuth.type = {mode_name} is only supported for Trino, ClickHouse \
                  (impersonate only), StarRocks (passthrough only), and ADBC/snowflake \
-                 (tokenExchange only) in this release, got {engine_name}"
+                 (tokenExchange or passthrough) in this release, got {engine_name}"
             ))
         }
     }
@@ -2098,19 +2117,34 @@ mod tests {
     }
 
     #[test]
-    fn adbc_passthrough_and_impersonate_rejected_even_for_snowflake_driver() {
-        // Only tokenExchange is wired for ADBC in this release — passthrough/impersonate
-        // are rejected regardless of driver.
+    fn adbc_impersonate_rejected_even_for_snowflake_driver() {
+        // No ADBC driver has an `impersonate` mechanism in this release.
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("snowflake"),
+            &QueryAuthConfig::Impersonate
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn adbc_passthrough_allowed_only_for_snowflake_driver() {
         assert!(query_auth_supported(
             Some(&EngineConfig::Adbc),
             Some("snowflake"),
             &QueryAuthConfig::Passthrough
         )
+        .is_ok());
+        assert!(query_auth_supported(
+            Some(&EngineConfig::Adbc),
+            Some("postgresql"),
+            &QueryAuthConfig::Passthrough
+        )
         .is_err());
         assert!(query_auth_supported(
             Some(&EngineConfig::Adbc),
-            Some("snowflake"),
-            &QueryAuthConfig::Impersonate
+            None,
+            &QueryAuthConfig::Passthrough
         )
         .is_err());
     }

--- a/crates/queryflux-engine-adapters/src/adbc/mod.rs
+++ b/crates/queryflux-engine-adapters/src/adbc/mod.rs
@@ -315,10 +315,20 @@ pub(crate) type AdbcPool = r2d2::Pool<AdbcConnectionManager<ManagedDatabase>>;
 /// `AdbcAdapter::scoped_pool_key` enforces that, not this type — so the all-`None` key (no
 /// override at all) never appears here; `execute_as_arrow` uses `self.pool` directly for that
 /// case instead of going through this map at all.
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Default)]
+/// No `Debug` derive: `passthrough` carries a real caller-supplied Snowflake password, and
+/// `token` carries an OAuth bearer token — neither should ever be printable via a stray
+/// `{:?}` (e.g. in a log line or panic message). Individual non-secret fields (`role`,
+/// `warehouse`, `schema`) are logged directly where needed instead of via this type's Debug.
+#[derive(Clone, PartialEq, Eq, Hash, Default)]
 struct PoolScopeKey {
     /// Bearer token for `tokenExchange` clusters (`QueryCredentials::Bearer`).
     token: Option<String>,
+    /// `(username, password)` for `passthrough` clusters (`QueryCredentials::Passthrough`) —
+    /// a real, caller-supplied Snowflake credential, captured at Snowflake wire v1 login and
+    /// **not verified by queryflux itself**; the ADBC connection attempt this key builds is
+    /// the actual verification, exactly as it would be if the caller connected to Snowflake
+    /// directly. See `compute_scoped_pool_key`.
+    passthrough: Option<(String, String)>,
     role: Option<String>,
     warehouse: Option<String>,
     schema: Option<String>,
@@ -327,6 +337,7 @@ struct PoolScopeKey {
 impl PoolScopeKey {
     fn is_empty(&self) -> bool {
         self.token.is_none()
+            && self.passthrough.is_none()
             && self.role.is_none()
             && self.warehouse.is_none()
             && self.schema.is_none()
@@ -353,6 +364,22 @@ fn compute_scoped_pool_key(
         queryflux_auth::QueryCredentials::Bearer { token } => Some(token.clone()),
         _ => None,
     };
+    // Captured at Snowflake wire v1 login (`snowflake.passthrough_username`/`_password` in
+    // `SessionContext.extra`), namespaced like the role/warehouse/schema keys below and for
+    // the same reason: unlike `passthrough_username`/`passthrough_password` (no `snowflake.`
+    // prefix), which the MySQL-wire/StarRocks passthrough path already owns and which carry
+    // an implicit "verified by a provider that checked the same backend" guarantee (see
+    // `AuthContext::raw_password`), a Snowflake password captured at login is *not*
+    // pre-verified by queryflux — the ADBC connection attempt this key builds is the actual
+    // verification. Using a distinct, honestly-named key avoids ever conflating the two.
+    let passthrough = match credentials {
+        queryflux_auth::QueryCredentials::Passthrough => session
+            .extra
+            .get("snowflake.passthrough_username")
+            .zip(session.extra.get("snowflake.passthrough_password"))
+            .map(|(u, p)| (u.clone(), p.clone())),
+        _ => None,
+    };
     let overridden = |field: &str| -> Option<String> {
         let requested = session.extra.get(&format!("snowflake.{field}"))?;
         let mapped_key = queryflux_core::config::variant_field_to_db_kwarg(driver, field)?;
@@ -361,6 +388,7 @@ fn compute_scoped_pool_key(
     };
     let key = PoolScopeKey {
         token,
+        passthrough,
         role: overridden("role"),
         warehouse: overridden("warehouse"),
         schema: overridden("schema"),
@@ -369,10 +397,11 @@ fn compute_scoped_pool_key(
 }
 
 /// Pure core of `AdbcAdapter::scoped_pool_size` — see its doc comment for the rationale
-/// (token-keyed scopes are per-individual-identity and stay small; role/warehouse/schema-only
-/// scopes are shared across sessions and need the base pool's own concurrency).
+/// (token- and passthrough-keyed scopes are per-individual-identity and stay small;
+/// role/warehouse/schema-only scopes are shared across sessions and need the base pool's own
+/// concurrency).
 fn compute_scoped_pool_size(key: &PoolScopeKey, base_pool_size: u32) -> u32 {
-    if key.token.is_some() {
+    if key.token.is_some() || key.passthrough.is_some() {
         IDENTITY_POOL_MAX_SIZE
     } else {
         base_pool_size
@@ -591,11 +620,15 @@ impl AdbcAdapter {
     }
 
     /// Connection-option overrides for a [`PoolScopeKey`] beyond `base_db_kwargs` — the OAuth
-    /// options for `key.token` (when present) plus whichever of role/warehouse/schema this
-    /// driver has a `dbKwargs` mapping for (`variant_field_to_db_kwarg`; today only Snowflake).
-    /// Not gated on `driver_name` directly — a driver with no field mapping just contributes
-    /// nothing here, so this naturally extends to other drivers if `variant_field_to_db_kwarg`
-    /// ever grows equivalent mappings for them, with no code change needed in this function.
+    /// options for `key.token` (when present), `Username`/`Password` set to the caller's own
+    /// credential for `key.passthrough` (when present — this *replaces* the cluster's own
+    /// service-account username/password for this sub-pool, it does not layer on top of it),
+    /// plus whichever of role/warehouse/schema this driver has a `dbKwargs` mapping for
+    /// (`variant_field_to_db_kwarg`; today only Snowflake). The role/warehouse/schema lookup
+    /// is not gated on `driver_name` directly — a driver with no field mapping just
+    /// contributes nothing here, so this naturally extends to other drivers if
+    /// `variant_field_to_db_kwarg` ever grows equivalent mappings for them, with no code
+    /// change needed in this function.
     fn scoped_pool_options(
         driver: &str,
         key: &PoolScopeKey,
@@ -603,6 +636,10 @@ impl AdbcAdapter {
         let mut opts = Vec::new();
         if let Some(token) = &key.token {
             opts.extend(oauth_token_options(driver, token)?);
+        }
+        if let Some((username, password)) = &key.passthrough {
+            opts.push((OptionDatabase::Username, username.clone().into()));
+            opts.push((OptionDatabase::Password, password.clone().into()));
         }
         for (field, value) in [
             ("role", &key.role),
@@ -623,10 +660,11 @@ impl AdbcAdapter {
         Ok(opts)
     }
 
-    /// Max connections for a scoped sub-pool. A `token`-keyed scope is per-individual-identity
-    /// (small, per [`IDENTITY_POOL_MAX_SIZE`]); a role/warehouse/schema-only scope is *shared*
-    /// across every session requesting that combination, so it needs the same concurrency as
-    /// the base pool, not the small per-identity size.
+    /// Max connections for a scoped sub-pool. A `token`- or `passthrough`-keyed scope is
+    /// per-individual-identity (small, per [`IDENTITY_POOL_MAX_SIZE`]); a
+    /// role/warehouse/schema-only scope is *shared* across every session requesting that
+    /// combination, so it needs the same concurrency as the base pool, not the small
+    /// per-identity size.
     fn scoped_pool_size(&self, key: &PoolScopeKey) -> u32 {
         compute_scoped_pool_size(key, self.base_pool_size)
     }
@@ -952,18 +990,38 @@ impl SyncAdapter for AdbcAdapter {
             attempt_id = %uuid::Uuid::new_v4(),
             "Executing ADBC query"
         );
-        // `Bearer` is the only non-serviceAccount `QueryCredentials` that reaches an ADBC
-        // adapter today — startup validation (`query_auth_supported`) rejects `passthrough`/
-        // `impersonate` for every ADBC driver. A session-requested role/warehouse/schema
-        // override (from a `USE ROLE`/`USE WAREHOUSE`/`USE SCHEMA` the Snowflake frontend
-        // tracked) is the other source of a non-trivial key. `scoped_pool_key` returns `None`
-        // for the common case (no token, no override), so the fast path below never touches
-        // the scoped-pool map at all. `scoped_pool_for` is a cheap `DashMap` lookup on cache
-        // hits; the miss path runs the blocking driver FFI call inside its own
-        // `spawn_blocking` with a timeout, not inline here.
-        let pool = match self.scoped_pool_key(session, credentials) {
-            Some(key) => self.scoped_pool_for(key).await?,
-            None => self.pool.clone(),
+        // `Bearer` (`tokenExchange`) and `Passthrough` are the only non-`ServiceAccount`
+        // `QueryCredentials` that reach an ADBC adapter today — startup validation
+        // (`query_auth_supported`) rejects `impersonate` for every ADBC driver, and
+        // `passthrough` for every ADBC driver except `snowflake`. A session-requested
+        // role/warehouse/schema override (from a `USE ROLE`/`USE WAREHOUSE`/`USE SCHEMA` the
+        // Snowflake frontend tracked) is the other source of a non-trivial key, and composes
+        // with either credential mode. `scoped_pool_key` returns `None` for the common case
+        // (no token, no passthrough, no override), so the fast path below never touches the
+        // scoped-pool map at all. `scoped_pool_for` is a cheap `DashMap` lookup on cache hits;
+        // the miss path runs the blocking driver FFI call inside its own `spawn_blocking` with
+        // a timeout, not inline here.
+        //
+        // `Passthrough` fails closed explicitly rather than falling through to `self.pool`:
+        // `scoped_pool_key` returning `None` here means no verified credential was found in
+        // the session (`QueryCredentials::Passthrough`'s own doc comment requires this — it
+        // must never silently degrade to the service account).
+        let pool = if matches!(credentials, queryflux_auth::QueryCredentials::Passthrough) {
+            match self.scoped_pool_key(session, credentials) {
+                Some(key) if key.passthrough.is_some() => self.scoped_pool_for(key).await?,
+                _ => {
+                    return Err(QueryFluxError::Auth(
+                        "ADBC passthrough requires a verified username/password captured at \
+                         Snowflake login — none was available for this session"
+                            .to_string(),
+                    ));
+                }
+            }
+        } else {
+            match self.scoped_pool_key(session, credentials) {
+                Some(key) => self.scoped_pool_for(key).await?,
+                None => self.pool.clone(),
+            }
         };
         let sql = sql.to_string();
         let param_batch = if params.is_empty() {
@@ -1425,6 +1483,77 @@ mod tests {
         .expect("token + role both present");
         assert_eq!(key.token.as_deref(), Some("tok"));
         assert_eq!(key.role.as_deref(), Some("ANALYST"));
+    }
+
+    #[test]
+    fn scoped_pool_key_picks_up_passthrough_credentials() {
+        let session = session_with(&[
+            ("snowflake.passthrough_username", "alice"),
+            ("snowflake.passthrough_password", "s3cr3t"),
+        ]);
+        let key =
+            compute_scoped_pool_key("snowflake", &[], &session, &QueryCredentials::Passthrough)
+                .expect("passthrough credentials present");
+        assert_eq!(
+            key.passthrough,
+            Some(("alice".to_string(), "s3cr3t".to_string()))
+        );
+        assert_eq!(key.token, None);
+    }
+
+    #[test]
+    fn scoped_pool_key_is_none_for_passthrough_without_captured_credentials() {
+        // Fail-closed check lives in `execute_as_arrow` (this returning `None` is what
+        // triggers it) — confirm the key computation itself doesn't silently invent a
+        // passthrough dimension from nothing.
+        let session = SessionContext::default();
+        let key =
+            compute_scoped_pool_key("snowflake", &[], &session, &QueryCredentials::Passthrough);
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn scoped_pool_key_ignores_passthrough_extra_for_non_passthrough_credentials() {
+        // If a session somehow retains passthrough_username/password (e.g. a cluster that
+        // used to be configured for passthrough) but the resolved credentials for this query
+        // are ServiceAccount, the passthrough dimension must not leak in — only `credentials`
+        // decides which dimensions apply, not whatever happens to be sitting in `extra`.
+        let session = session_with(&[
+            ("snowflake.passthrough_username", "alice"),
+            ("snowflake.passthrough_password", "s3cr3t"),
+        ]);
+        let key = compute_scoped_pool_key(
+            "snowflake",
+            &[],
+            &session,
+            &QueryCredentials::ServiceAccount,
+        );
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn scoped_pool_key_never_reads_unnamespaced_passthrough_keys() {
+        // The generic MySQL-wire/StarRocks passthrough mechanism (`enrich_session_for_passthrough`)
+        // uses unprefixed `passthrough_username`/`passthrough_password` keys and carries an
+        // implicit "verified against the same backend" guarantee that does not hold for a
+        // Snowflake password captured at login — the namespaced `snowflake.*` keys must be
+        // read instead, never the bare ones, so the two mechanisms can never be conflated.
+        let session = session_with(&[
+            ("passthrough_username", "alice"),
+            ("passthrough_password", "s3cr3t"),
+        ]);
+        let key =
+            compute_scoped_pool_key("snowflake", &[], &session, &QueryCredentials::Passthrough);
+        assert!(key.is_none());
+    }
+
+    #[test]
+    fn scoped_pool_size_is_small_for_passthrough_scopes() {
+        let key = PoolScopeKey {
+            passthrough: Some(("alice".to_string(), "pw".to_string())),
+            ..Default::default()
+        };
+        assert_eq!(compute_scoped_pool_size(&key, 20), IDENTITY_POOL_MAX_SIZE);
     }
 
     #[test]

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
@@ -153,7 +153,7 @@ pub async fn query_request(
     };
 
     // Validate session and extract stored context.
-    let (auth_ctx, group, mut database, mut schema_name, role, warehouse) = {
+    let (auth_ctx, group, mut database, mut schema_name, role, warehouse, password) = {
         match state.sessions.validate_session(&token) {
             Some((_, session)) => (
                 session.auth_ctx.clone(),
@@ -162,6 +162,7 @@ pub async fn query_request(
                 session.schema.clone().unwrap_or_default(),
                 session.role.clone(),
                 session.warehouse.clone(),
+                session.password.clone(),
             ),
             None => return unauthorized(),
         }
@@ -222,6 +223,19 @@ pub async fn query_request(
     }
     if !schema_name.is_empty() {
         extra.insert("snowflake.schema".to_string(), schema_name.clone());
+    }
+    // Only meaningful for `queryAuth: passthrough` clusters — `AdbcAdapter` fails closed if
+    // these are absent and the resolved credentials are `Passthrough`; harmless to include
+    // otherwise (any other credential mode just ignores them).
+    if let Some(password) = &password {
+        extra.insert(
+            "snowflake.passthrough_username".to_string(),
+            auth_ctx.user.clone(),
+        );
+        extra.insert(
+            "snowflake.passthrough_password".to_string(),
+            password.clone(),
+        );
     }
 
     let session_ctx = SessionContext {

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -45,6 +45,12 @@ pub async fn login_request(
         _ => return sf_error("390000", "Missing LOGIN_NAME"),
     };
     let password = data["PASSWORD"].as_str().unwrap_or("").to_string();
+    // Retained for `passthrough` mode (see `SnowflakeSession::password`) — unconditionally,
+    // since a login handler has no way to know yet whether the query group it's about to
+    // resolve will route to a `queryAuth: passthrough` cluster. Not verified by queryflux
+    // itself; the actual verification is the real Snowflake connection attempt this later
+    // enables (`AdbcAdapter`'s passthrough sub-pool), same as connecting to Snowflake directly.
+    let passthrough_password = (!password.is_empty()).then(|| password.clone());
     let database = data["DATABASE_NAME"].as_str().map(|s| s.to_string());
     let schema = data["SCHEMA_NAME"].as_str().map(|s| s.to_string());
     // Unlike database/schema, real Snowflake drivers send role/warehouse as query-string
@@ -143,6 +149,7 @@ pub async fn login_request(
         schema.clone(),
         role.clone(),
         warehouse.clone(),
+        passthrough_password,
     );
 
     let master_token = Uuid::new_v4().to_string();

--- a/crates/queryflux-frontend/src/snowflake/http/session_store.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/session_store.rs
@@ -56,6 +56,14 @@ pub struct SnowflakeSession {
     /// Captured at login (`warehouse` login-request query param) or updated mid-session by
     /// `USE WAREHOUSE`.
     pub warehouse: Option<String>,
+    /// The plaintext password submitted at login, retained for the session's lifetime —
+    /// **not verified by queryflux itself** — used only to build a `passthrough`-mode ADBC
+    /// sub-pool (`AdbcAdapter`'s `PoolScopeKey::passthrough`), where the real Snowflake
+    /// connection attempt is the actual verification. Harmless to capture unconditionally:
+    /// unused unless the session's queries route to a `queryAuth: passthrough` cluster.
+    /// Deliberately distinct from `AuthContext::raw_password`, which carries an implicit
+    /// "verified by a provider that checked the same backend" guarantee this does not have.
+    pub password: Option<String>,
     created_at: Instant,
     last_seen: Instant,
 }
@@ -109,6 +117,7 @@ impl SnowflakeSessionStore {
         schema: Option<String>,
         role: Option<String>,
         warehouse: Option<String>,
+        password: Option<String>,
     ) -> String {
         let token = Uuid::new_v4().to_string();
         let now = Instant::now();
@@ -122,6 +131,7 @@ impl SnowflakeSessionStore {
                 schema,
                 role,
                 warehouse,
+                password,
                 created_at: now,
                 last_seen: now,
             },
@@ -285,6 +295,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let result = store.validate_session(&token);
         assert!(result.is_some());
@@ -311,6 +322,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         store.remove_session(&token);
         assert!(store.validate_session(&token).is_none());
@@ -326,6 +338,7 @@ mod tests {
             "charlie".into(),
             make_auth(),
             ClusterGroupName("g".into()),
+            None,
             None,
             None,
             None,
@@ -350,6 +363,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         std::thread::sleep(Duration::from_millis(10));
         assert!(store.validate_session(&token).is_none());
@@ -365,6 +379,7 @@ mod tests {
             "eve".into(),
             make_auth(),
             ClusterGroupName("g".into()),
+            None,
             None,
             None,
             None,
@@ -392,6 +407,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let (remaining, _) = store.validate_session(&token).unwrap();
         assert_eq!(remaining, u64::MAX);
@@ -408,6 +424,7 @@ mod tests {
             None,
             Some("ANALYST".into()),
             Some("ANALYTICS_WH".into()),
+            None,
         );
         let (_, session) = store.validate_session(&token).unwrap();
         assert_eq!(session.role.as_deref(), Some("ANALYST"));
@@ -421,6 +438,7 @@ mod tests {
             "heidi".into(),
             make_auth(),
             ClusterGroupName("g".into()),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

Stacked on #182 (session-scoped pooling) — this PR's `PoolScopeKey` extension depends on that PR's type. Base branch will need retargeting to `main` once #182 merges.

- Adds `passthrough` `queryAuth` mode for ADBC/Snowflake clusters: for deployments where a Snowflake-fronted caller already holds a real Snowflake identity and per-caller connections (instead of a shared service account) are what's wanted.
- Mirrors the existing StarRocks LDAP passthrough pattern (`QueryCredentials::Passthrough`) and gates it per ADBC driver the same way `tokenExchange` already is (`ADBC_PASSTHROUGH_AUTH_DRIVERS`, snowflake-only for now).
- Folds into the `PoolScopeKey`/scoped-sub-pool mechanism from #182 rather than building a second cache — a passthrough credential is just another key dimension, sized like the token dimension (per-individual-identity, small).
- **Deliberately does not reuse** the existing `raw_password`/`enrich_session_for_passthrough` mechanism the MySQL-wire/StarRocks passthrough path uses. That mechanism's documented contract requires the password to already be verified against the same backend the target authenticates against (`LdapAuthProvider` verifies via LDAP, which StarRocks also trusts as its own identity backend). Snowflake has no equivalent shared identity system queryflux can check at login time, so labeling a Snowflake password "verified" there would misrepresent that field's contract. Instead: the Snowflake wire v1 login handler captures the submitted password into its own session state under clearly-namespaced, honestly-labeled `snowflake.passthrough_username`/`snowflake.passthrough_password` keys — explicitly unverified — and the real ADBC connection attempt this builds is the actual verification, exactly as it would be connecting to Snowflake directly. Consistent with how a bad `USE ROLE`/`USE WAREHOUSE` is already left to fail naturally rather than pre-validated.
- Fails closed: `execute_as_arrow` rejects `Passthrough` credentials outright if no captured username/password is available for the session, rather than silently falling back to the service-account pool.
- SQL API v2 (stateless, Bearer-only) has no password to capture for this mode — a passthrough-configured cluster reached that way automatically hits the same fail-closed path, no separate check needed.

## Test plan
- [x] `cargo test -p queryflux-core -p queryflux-engine-adapters -p queryflux-frontend -p queryflux-auth` — all passing, including new `PoolScopeKey` passthrough-dimension coverage (credential capture, fail-closed on missing creds, cross-mechanism isolation from the generic `passthrough_username`/`passthrough_password` keys, cross-protocol namespacing) and `query_auth_supported`'s new ADBC+passthrough+snowflake branch.
- [x] `cargo fmt --all -- --check` and `cargo clippy --workspace-scoped -- -D warnings` clean.
- [x] `cargo build --workspace` — no downstream breakage.
- [ ] Manual: configure a cluster with `queryAuth: passthrough`, log in as two different real Snowflake users with different role grants, confirm each session's queries run under its own identity and a missing/wrong credential fails closed — not done in this environment, needs a real Snowflake account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)