### PR TITLE
fix: allow test: as a valid PR title type

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,11 +4,11 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|docs|chore|ui)!?(\\(.*\\))?!?:.*|^\\[Snyk\\].*|^Bump .+"
+    "regexp": "^(feat|fix|docs|chore|ui|test)!?(\\(.*\\))?!?:.*|^\\[Snyk\\].*|^Bump .+"
   },
   "MESSAGES": {
     "success": "PR title is valid",
     "failure": "PR title is invalid",
-    "notice": "PR title must match Conventional Commits (feat|fix|docs|chore|ui), or be a Snyk/Dependabot title ([Snyk]... / Bump ...)"
+    "notice": "PR title must match Conventional Commits (feat|fix|docs|chore|ui|test), or be a Snyk/Dependabot title ([Snyk]... / Bump ...)"
   }
 }


### PR DESCRIPTION
## Summary

`release-please-config.json` already declares a hidden `test` changelog section, but `pr-title-checker-config.json`'s regex only allows `feat|fix|docs|chore|ui`, so a valid `test:` PR title fails the title check even though release-please itself already recognizes the type (surfaced by #185, a test-only PR that had to be retitled `chore:` to pass CI).

Adds `test` to the allowed regex and the notice message.

## Test plan

- N/A — config-only change; the "PR title" check on this PR itself is now the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)