### PR TITLE
fix: reject double-bang PR titles like "feat!!: x"

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,7 +4,7 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|docs|chore|ui|test)!?(\\(.*\\))?!?:.*|^\\[Snyk\\].*|^Bump .+"
+    "regexp": "^(feat|fix|docs|chore|ui|test)(\\(.*\\))?!?:.*|^\\[Snyk\\].*|^Bump .+"
   },
   "MESSAGES": {
     "success": "PR title is valid",


### PR DESCRIPTION
## Summary

CodeRabbit review comment on #186: the regex `^(feat|fix|docs|chore|ui|test)!?(\(.*\))?!?:.*` has two independent `!?` groups, so titles like `feat!!: x` or `feat(scope)!!: x` matched despite Conventional Commits allowing only a single `!` immediately before the colon. Moves the optional scope group before the sole optional `!`.

#186 was merged before this follow-up commit landed on its branch, so it's a fresh PR against current `main`.

## Test plan

- Verified the fixed pattern against representative titles (single `!`, scoped, double `!`, scoped double `!`, no-bang, Snyk/Bump) with a Python regex check — double-bang forms now correctly rejected, everything else unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)