### PR TITLE
docs: document Snowflake ADBC passthrough auth and session-scoped pooling

### DIFF
--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -89,7 +89,7 @@ clusters:
 | ClickHouse | ✅ | ❌ not yet wired | ✅ `EXECUTE AS` (self-hosted 25.11+ only, see below) | ❌ not yet wired |
 | StarRocks (MySQL wire) | ✅ | ✅ dedicated per-query LDAP connection (requires TLS; see below) | ❌ no wire mechanism | ❌ no wire mechanism |
 | StarRocks (HTTP, future) | ✅ | — | — | — |
-| Snowflake (ADBC) | ✅ | ❌ not yet wired | ❌ | ✅ per-identity connection pool |
+| Snowflake (ADBC) | ✅ | ✅ per-caller connection, fails closed if unverified (see below) | ❌ | ✅ per-identity connection pool |
 | Databricks (ADBC, future) | ✅ | ❌ not yet wired | ❌ | ❌ not yet wired |
 | DuckDB | ✅ (no-op) | — | — | — |
 
@@ -653,7 +653,25 @@ Poll and cancel requests don't repeat the client's original headers, so the reso
 - `tokenExchange` is wired: the resolved OAuth token is set via the driver's own connection options (`adbc.snowflake.sql.auth_type=auth_oauth`, `adbc.snowflake.sql.client_option.auth_token`), each user's token requiring its own `ManagedDatabase` (see the per-identity sub-pool design in the backend-identity plan's Phase 3a) since ADBC bakes connection options in at open time, not per-checkout
 - Service account (`serviceAccount` mode, Type 1) should use key-pair auth (RSA JWT), not password — Snowflake's recommended pattern for automated connections
 - Private keys must not be stored in config files in production; use `secretRef` to Secrets Manager
-- `passthrough` is not wired for ADBC in this release (only `tokenExchange`, only for the `snowflake` driver)
+- **`passthrough` is wired**, for deployments where a Snowflake-fronted caller already holds a real Snowflake identity and per-caller connections (not a shared service account) are what's wanted:
+  - The Snowflake **HTTP wire v1** login handler (`POST /session/v1/login-request`) captures the submitted username/password into session state, **unverified** — QueryFlux itself never checks this password against anything. The ADBC connection attempt the sub-pool builds *is* the verification: exactly what would happen connecting to Snowflake directly, and consistent with how `USE ROLE`/`USE WAREHOUSE` failures are already left to surface naturally rather than pre-validated.
+  - **Fails closed:** if a cluster is configured `queryAuth: passthrough` and no verified-at-connection-time username/password was captured for the session, the query is rejected outright rather than silently falling back to the service account.
+  - **SQL API v2** (stateless, Bearer-only) has no password to capture for this mode — a passthrough-configured cluster reached that way hits the same fail-closed path automatically.
+  - The captured credential is deliberately *not* routed through the `raw_password`/`enrich_session_for_passthrough` mechanism MySQL-wire/StarRocks passthrough use — that mechanism's contract requires the password to already be verified against the same backend the target authenticates against (LDAP-verified passwords, which StarRocks also trusts). Snowflake has no equivalent shared identity system QueryFlux can check at login time, so it uses its own namespaced `snowflake.passthrough_username`/`snowflake.passthrough_password` session keys instead of claiming a pre-verification guarantee it can't back up.
+
+#### Session-scoped pooling (`USE ROLE` / `USE WAREHOUSE` / `USE SCHEMA`, and per-identity tokens)
+
+An ADBC `ManagedDatabase` bakes its connection options in at open time — there's no way to swap credentials, role, warehouse, or schema on a connection already checked out of the shared pool. Two mechanisms build on the same scoped sub-pool machinery to work around that:
+
+- **`USE ROLE` / `USE WAREHOUSE` / `USE DATABASE` / `USE SCHEMA`** on the Snowflake HTTP wire v1 frontend are intercepted client-side and never forwarded as literal SQL — doing so against a connection shared across unrelated sessions would leak state between them. Instead they update the frontend's own session state and ack locally (mirroring the MySQL-wire frontend's `USE <db>` handling); the *next* real query on that session carries the requested role/warehouse/schema and dispatches through the scoped pool below.
+- **Token-scoped pools** (`tokenExchange`) work the same way, keyed by the resolved OAuth token instead of a role/warehouse/schema value.
+
+A distinct scope (`PoolScopeKey`: some combination of token, passthrough credential, role, warehouse, schema) only exists when it actually differs from the cluster's own base config — a `USE ROLE` naming the cluster's already-configured role is a no-op, not a new pool. Two important asymmetries:
+
+- **Per-identity scopes** (keyed by a token or a passthrough credential) are capped at 2 connections each — they exist to amortize connection-setup cost across the handful of queries one caller runs in quick succession, not to serve as a general-purpose pool.
+- **Role/warehouse/schema-only scopes** (no token or passthrough credential) are a *shared* resource across every session requesting that same combination — e.g. "every analyst using the `ANALYST` role" — so they get the cluster's own full configured pool size instead.
+
+Idle sub-pools are evicted after 15 minutes, and a hard ceiling of 500 distinct scoped sub-pools per cluster evicts the least-recently-used entry once reached — role/warehouse/schema values come straight from client `USE` statements with no check that they exist on the backend, so this bounds a client that cycles through many distinct (nonexistent or real) values in a loop from forcing unbounded backend connections before the idle sweep catches up.
 
 ### Trino
 - Implicit header forwarding works for same-IdP deployments

--- a/website/docs/architecture/auth-authz-design.md
+++ b/website/docs/architecture/auth-authz-design.md
@@ -27,7 +27,7 @@ Every backend cluster has **two distinct credential relationships**, both config
 
 **Anonymous requests fail closed for explicit per-user modes.** An unauthenticated (`AuthContext.user == "anonymous"`) request only ever resolves to `serviceAccount` — there is no per-user credential to forward, impersonate, or exchange. If a cluster is explicitly configured with `passthrough`, `impersonate`, or `tokenExchange`, an anonymous request is rejected with an auth error rather than silently executing under the service account.
 
-`passthrough` forwards the client's own credential (Bearer/Basic) to the backend unchanged — the backend authenticates the user's own token, not a QueryFlux-vouched identity. It is **Trino-only in this release**; startup validation rejects it for engines whose adapters don't yet consume `QueryCredentials` (see the compatibility table below).
+`passthrough` forwards the client's own credential to the backend — a Bearer/Basic header unchanged for Trino, a dedicated per-query LDAP connection for StarRocks, a per-caller ADBC connection for Snowflake — so the backend authenticates the user's own credential, not a QueryFlux-vouched identity. Support is per-engine and per-adapter, not universal; startup validation rejects it for engines/drivers whose adapters don't yet consume `QueryCredentials` for this mode (see the compatibility table below).
 
 Before `passthrough` existed as an explicit type, the Trino adapter forwarded all headers stored in `SessionContext.extra` verbatim whenever a cluster had no HTTP-setting `auth` of its own — including the client's `Authorization` header — regardless of `queryAuth`. That implicit behavior is **deprecated but still supported** for `serviceAccount`/omitted `queryAuth` on Trino clusters, for backward compatibility (a startup warning is emitted). New configs should set `queryAuth.type: passthrough` explicitly instead of relying on the implicit fallback.
 
@@ -56,9 +56,10 @@ clusters:
     queryAuth:
       type: serviceAccount          # only viable option for ClickHouse
 
-  snowflake-prod:                   # future adapter
-    engine: snowflake
-    endpoint: https://myaccount.snowflakecomputing.com
+  snowflake-prod:                   # ADBC driver — see configuration.md for the full shape
+    engine: adbc
+    driver: snowflake
+    uri: qf_svc@myaccount/mydb/myschema
     auth:
       type: keyPair                 # RSA key-pair, Snowflake standard
       username: QF_SVC
@@ -567,7 +568,7 @@ QueryFlux cannot verify any of these remotely at startup — an unsupported vers
 
 **Only Trino and ClickHouse support `impersonate`.** StarRocks has no equivalent over MySQL wire (no trusted-proxy mechanism). Startup validation rejects `impersonate` for any other engine type.
 
-### Mode: `tokenExchange` (Trino only in this release)
+### Mode: `tokenExchange` (Trino, Snowflake in this release)
 
 QueryFlux exchanges the user's OIDC JWT (`auth_ctx.raw_token`) for a backend-specific OAuth access token via RFC 8693 token exchange. Requires `OidcAuthProvider` on the frontend (so `raw_token` is populated). **Fails closed:** if `raw_token` is absent or the exchange fails, the query is rejected with an auth error — it never silently falls back to `serviceAccount`, since that would submit the query under the wrong principal.
 
@@ -596,14 +597,14 @@ clusters:
       targetAudience: trino-client   # Keycloak target client ID
 ```
 
-#### Future: Snowflake, Databricks
+#### Snowflake (shipped), Databricks (future)
 
-Non-Trino OAuth-based engines are natural `tokenExchange` targets once their adapters consume `QueryCredentials::Bearer`:
+Non-Trino OAuth-based engines are natural `tokenExchange` targets once their adapters consume `QueryCredentials::Bearer`. Snowflake's ADBC adapter does today — see "Session-scoped pooling" under Engine-Specific Notes below for how the exchanged token is applied per-identity. Databricks has no ADBC adapter yet, so `tokenExchange` remains rejected at startup for it.
 
 | Provider | Grant type | Subject token type | Audience / scope |
 |----------|-----------|-------------------|-----------------|
 | Snowflake external OAuth | `urn:ietf:params:oauth:grant-type:token-exchange` | `urn:ietf:params:oauth:token-type:access_token` | `scope: session:role:&lt;ROLE&gt;` |
-| Databricks OAuth U2M | `urn:ietf:params:oauth:grant-type:token-exchange` | `urn:ietf:params:oauth:token-type:access_token` | `scope: all-apis` |
+| Databricks OAuth U2M *(future)* | `urn:ietf:params:oauth:grant-type:token-exchange` | `urn:ietf:params:oauth:token-type:access_token` | `scope: all-apis` |
 
 The same `queryAuth: tokenExchange` config shape applies — only the `targetAudience`/`scope` and the engine's own OAuth registration differ.
 

--- a/website/docs/authentication.md
+++ b/website/docs/authentication.md
@@ -85,7 +85,7 @@ clusters:
 | Mode | The backend sees | Engines |
 | --- | --- | --- |
 | `serviceAccount` *(default)* | QueryFlux's own service credential only — the user is known to QueryFlux for audit/routing, not proven to the backend | All |
-| `passthrough` | The client's own credential, forwarded unchanged | Trino, StarRocks (MySQL wire, LDAP-backed) |
+| `passthrough` | The client's own credential, forwarded unchanged | Trino, StarRocks (MySQL wire, LDAP-backed), Snowflake (ADBC, per-caller connection) |
 | `impersonate` | The service account authenticates; the real user is injected via an engine-specific mechanism (`X-Trino-User`, ClickHouse `EXECUTE AS`) | Trino, ClickHouse |
 | `tokenExchange` | A backend-scoped OAuth token, exchanged (RFC 8693) from the client's own token | Trino, Snowflake (ADBC) |
 
@@ -106,6 +106,7 @@ Backend identity needs a small amount of setup on the engine side — QueryFlux 
 - **ClickHouse `impersonate`** — requires ClickHouse **25.11+, self-hosted** (not supported on ClickHouse Cloud), `access_control_improvements.allow_impersonate_user = 1`, and `GRANT IMPERSONATE ON {user} TO {service_account}`. Cancelling an impersonated query additionally needs `GRANT KILL QUERY ON *.*` on the service account.
 - **StarRocks `passthrough`** — authenticates each query on a dedicated connection as the target user via `authentication_ldap_simple`. Requires the cluster endpoint to use TLS (`?require_ssl=true`) and the passthrough user to hold `OPERATE` for `cancel_query` to work.
 - **Snowflake `tokenExchange`** — the exchanged token is sent as `adbc.snowflake.sql.client_option.auth_token` with `auth_type=auth_oauth`; register QueryFlux as an OAuth client in the same IdP as the target Snowflake OAuth integration.
+- **Snowflake `passthrough`** — the caller's own Snowflake username/password (captured at HTTP wire v1 login) opens a dedicated per-caller connection; QueryFlux does not verify the password itself, the connection attempt is the verification. Not available over SQL API v2 (stateless, Bearer-only) — a passthrough cluster reached that way fails closed.
 
 Full per-engine wiring, the resolver's fail-closed contract, and the `queryAuth` × engine compatibility matrix: **[Auth & authorization design](/docs/architecture/auth-authz-design)**.
 

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -43,7 +43,8 @@ Everything below is implemented and available on the `main` branch.
 | **Auth** | Authentication providers: none, static, OIDC, LDAP |
 | | Authorization: allow-all, simple policy, OpenFGA |
 | | Backend identity (`queryAuth`): `serviceAccount`, `passthrough`, `impersonate`, `tokenExchange` — see **[Authentication & identity](./authentication)** |
-| | Trino: all four modes. ClickHouse: `impersonate` (`EXECUTE AS`, self-hosted 25.11+). StarRocks: `passthrough` (LDAP, TLS-required). Snowflake (ADBC): `tokenExchange` (per-identity connection pool) |
+| | Trino: all four modes. ClickHouse: `impersonate` (`EXECUTE AS`, self-hosted 25.11+). StarRocks: `passthrough` (LDAP, TLS-required). Snowflake (ADBC): `tokenExchange` and `passthrough` (both per-identity connection pools) |
+| | Snowflake (ADBC): session-scoped connection pooling for `USE ROLE`/`USE WAREHOUSE`/`USE SCHEMA`, intercepted client-side and applied per-session without leaking state across a shared pooled connection |
 | **Observability** | Prometheus metrics: queries, duration, translation, running, queued |
 | | Grafana dashboard (auto-provisioned) |
 | | QueryFlux Studio — Next.js UI: clusters, query history, engine registry |
@@ -85,12 +86,6 @@ The motivation doc describes the gap: without a routing layer that understands w
 - **Time-based routing** — route to cheaper scan-priced backends (Athena) during off-peak hours; reserve compute-priced clusters (StarRocks) for peak interactive traffic.
 - **Cost annotations on groups** — tag groups with a cost tier (`interactive`, `batch`, `serverless`) so routing rules can reference intent rather than engine names.
 
-### Snowflake backend
-
-Snowflake is one of the most common analytical systems in enterprise data stacks. Adding a Snowflake adapter would let organizations route overflow or exploratory traffic to Snowflake from the same QueryFlux proxy that serves Trino and StarRocks — without clients changing connection strings.
-
-Protocol: Snowflake's HTTP API or JDBC-compatible interface. Auth: key-pair or OAuth.
-
 ### BigQuery backend
 
 BigQuery on-demand pricing (bytes scanned) maps cleanly to the scan-priced routing tier described in the cost-aware routing section. A BigQuery adapter enables the pattern: route selective, cold-data exploration queries to BigQuery; route pre-aggregated, hot-data dashboard queries to StarRocks.
@@ -127,6 +122,6 @@ The roadmap reflects:
 
 1. **What unblocks the most deployments** — schema-aware translation and ClickHouse cover the most common next integration requests.
 2. **What delivers the cost/performance story end-to-end** — cost-aware routing closes the loop between the motivation (wrong engine for the workload) and the solution (QueryFlux routes it correctly).
-3. **What the open table format ecosystem needs** — Snowflake and BigQuery backends, federated planning, and cache complete the "compute interoperability" layer above Iceberg/Delta/Hudi.
+3. **What the open table format ecosystem needs** — a BigQuery backend, federated planning, and cache complete the "compute interoperability" layer above Iceberg/Delta/Hudi (Snowflake is already covered — see "What is done").
 
 Contributions are welcome — see [Contributing](/docs/contribute). If a feature here is blocking your use case, open an issue on [GitHub](https://github.com/lakeops-org/queryflux/issues) to help prioritize.


### PR DESCRIPTION
## Summary

Two Snowflake backend (ADBC) features shipped recently with no docs updates:

- **`queryAuth: passthrough` for ADBC/Snowflake** (#184) — `auth-authz-design.md`'s compatibility table and Snowflake section explicitly said this was *"not yet wired"*, which became false the moment #184 merged.
- **Session-scoped ADBC connection pooling for `USE ROLE`/`USE WAREHOUSE`/`USE SCHEMA`** (#182) — had zero documentation anywhere in `website/docs/`.

## Changes

- `auth-authz-design.md`: fixes the stale compatibility-table cell, rewrites the Snowflake passthrough bullet to describe the actual fail-closed behavior and SQL API v2 special case, and adds a new "Session-scoped pooling" subsection covering `PoolScopeKey`, the per-identity-vs-shared pool-size split, and idle/capacity eviction (15 min idle TTL, 500-entry LRU ceiling).
- `authentication.md`: adds Snowflake to the `passthrough` row of the queryAuth summary table, and a Snowflake `passthrough` bullet to the engine-specific setup list.
- `roadmap.md`: updates the Auth row of the "What is done" table for both features, and removes a stale "Snowflake backend" *planned*-roadmap entry that described the ADBC adapter as future work even though it's fully shipped (including key-pair, tokenExchange, and now passthrough auth).

No code changes.

## Test plan

- Docs-only change; `docs-build.yml` CI validates the Docusaurus build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)