### PR TITLE
feat: MCP (Model Context Protocol) frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,8 +1512,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -1525,14 +1541,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1696,6 +1736,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -3062,7 +3108,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck",
  "num-bigint",
  "proc-macro-crate",
@@ -3080,7 +3126,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66f62cad7623a9cb6f8f64037f0c4f69c8db8e82914334a83c9788201c2c1bfa"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck",
  "num-bigint",
  "proc-macro-crate",
@@ -3495,6 +3541,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-slash"
@@ -4100,11 +4152,13 @@ dependencies = [
  "queryflux-core",
  "queryflux-engine-adapters",
  "queryflux-frontend",
+ "queryflux-guardrails",
  "queryflux-metrics",
  "queryflux-persistence",
  "queryflux-routing",
  "queryflux-translation",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "tokio",
@@ -4187,11 +4241,14 @@ dependencies = [
  "queryflux-routing",
  "queryflux-translation",
  "reqwest 0.12.28",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic 0.14.5",
  "tower",
  "tower-http",
@@ -4492,6 +4549,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "refinery"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,7 +4724,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -4661,6 +4738,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4680,12 +4758,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4730,6 +4810,52 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "indexmap",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "reqwest 0.13.2",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4979,6 +5105,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,6 +5220,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5479,6 +5642,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +5730,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6458,6 +6645,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,14 @@ queryflux:
     #   enabled: false
     #   port: 8445
     #   sessionAffinityAcknowledged: false
+    # MCP (Model Context Protocol) streamable-HTTP frontend for AI agent tool calls.
+    # Authenticates via `Authorization: Bearer <token>` like other HTTP frontends — see
+    # the `auth` section below. Guardrails (read-only, row limits, etc.) are configured
+    # the same way as for every other frontend, via the top-level `guardrails` /
+    # per-group guard config — nothing MCP-specific is enforced by default.
+    # mcp:
+    #   enabled: false
+    #   port: 8811
   persistence:
     type: inMemory
   # --- Postgres persistence examples (pick one style) ---

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -288,6 +288,11 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
             enabled_frontends.push((FrontendProtocol::SnowflakeHttp, SqlDialect::Snowflake));
         }
     }
+    if let Some(ref f) = config.queryflux.frontends.mcp {
+        if f.enabled {
+            enabled_frontends.push((FrontendProtocol::Mcp, SqlDialect::Generic));
+        }
+    }
 
     if enabled_frontends.is_empty() {
         return false;

--- a/crates/queryflux-cli/src/lib.rs
+++ b/crates/queryflux-cli/src/lib.rs
@@ -196,6 +196,7 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
                 flight_sql,
                 snowflake_http,
                 snowflake_sql_api,
+                mcp,
             } => {
                 if let Some(g) = trino_http {
                     target_groups.push(g.clone());
@@ -216,6 +217,9 @@ fn config_requires_translation(config: &ProxyConfig) -> bool {
                     target_groups.push(g.clone());
                 }
                 if let Some(g) = snowflake_sql_api {
+                    target_groups.push(g.clone());
+                }
+                if let Some(g) = mcp {
                     target_groups.push(g.clone());
                 }
             }

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -737,6 +737,9 @@ pub struct FrontendsConfig {
     pub flight_sql: Option<FrontendConfig>,
     #[serde(default)]
     pub snowflake_http: Option<SnowflakeHttpFrontendConfig>,
+    /// MCP (Model Context Protocol) streamable-HTTP frontend for AI agent tool calls.
+    #[serde(default)]
+    pub mcp: Option<FrontendConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1739,6 +1742,8 @@ pub enum RouterConfig {
         snowflake_http: Option<String>,
         #[serde(default)]
         snowflake_sql_api: Option<String>,
+        #[serde(default)]
+        mcp: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
     Header {

--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -222,6 +222,54 @@ impl SqlDialect {
             }
         }
     }
+
+    /// Parse a dialect name (case-insensitive) back into a known `SqlDialect` variant.
+    /// Inverse of [`Self::sqlglot_name`], plus a couple of common aliases (`postgresql`,
+    /// `mssql`, `presto`). Returns `None` for anything not in [`Self::KNOWN_DIALECT_NAMES`] —
+    /// callers taking this from an untrusted source (e.g. an MCP tool argument) should
+    /// reject unknown input rather than falling back to [`SqlDialect::Sqlglot`], since that
+    /// would silently accept typos as "any sqlglot dialect name, unvalidated."
+    pub fn from_known_name(name: &str) -> Option<Self> {
+        Some(match name.to_ascii_lowercase().as_str() {
+            "trino" => Self::Trino,
+            "athena" | "presto" => Self::Athena,
+            "duckdb" => Self::DuckDb,
+            "starrocks" => Self::StarRocks,
+            "clickhouse" => Self::ClickHouse,
+            "mysql" => Self::MySql,
+            "postgres" | "postgresql" => Self::Postgres,
+            "sqlite" => Self::Sqlite,
+            "snowflake" => Self::Snowflake,
+            "bigquery" => Self::BigQuery,
+            "databricks" => Self::Databricks,
+            "tsql" | "mssql" => Self::MsSql,
+            "redshift" => Self::Redshift,
+            "exasol" => Self::Exasol,
+            "generic" => Self::Generic,
+            _ => return None,
+        })
+    }
+
+    /// Canonical dialect names accepted by [`Self::from_known_name`] — the set to show a
+    /// caller (e.g. in an MCP tool description) so their input maps onto a real variant
+    /// instead of guessing at sqlglot's own naming.
+    pub const KNOWN_DIALECT_NAMES: &'static [&'static str] = &[
+        "trino",
+        "athena",
+        "duckdb",
+        "starrocks",
+        "clickhouse",
+        "mysql",
+        "postgres",
+        "sqlite",
+        "snowflake",
+        "bigquery",
+        "databricks",
+        "tsql",
+        "redshift",
+        "exasol",
+        "generic",
+    ];
 }
 
 // --- Incoming query (before routing) ---
@@ -499,5 +547,57 @@ mod submitted_by_serde_tests {
         v["session"] = serde_json::to_value(SessionContext::default()).unwrap();
         let q: QueuedQuery = serde_json::from_value(v).expect("legacy queued row");
         assert!(q.submitted_by.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod sql_dialect_tests {
+    use super::*;
+
+    #[test]
+    fn from_known_name_round_trips_every_named_variant() {
+        for name in SqlDialect::KNOWN_DIALECT_NAMES {
+            let parsed =
+                SqlDialect::from_known_name(name).unwrap_or_else(|| panic!("{name} should parse"));
+            assert_ne!(
+                parsed,
+                SqlDialect::Sqlglot(String::new()),
+                "{name} should map to a named variant, not the escape hatch"
+            );
+        }
+    }
+
+    #[test]
+    fn from_known_name_is_case_insensitive() {
+        assert_eq!(
+            SqlDialect::from_known_name("TRINO"),
+            Some(SqlDialect::Trino)
+        );
+        assert_eq!(
+            SqlDialect::from_known_name("BigQuery"),
+            Some(SqlDialect::BigQuery)
+        );
+    }
+
+    #[test]
+    fn from_known_name_accepts_common_aliases() {
+        assert_eq!(
+            SqlDialect::from_known_name("postgresql"),
+            Some(SqlDialect::Postgres)
+        );
+        assert_eq!(
+            SqlDialect::from_known_name("mssql"),
+            Some(SqlDialect::MsSql)
+        );
+        assert_eq!(
+            SqlDialect::from_known_name("presto"),
+            Some(SqlDialect::Athena)
+        );
+    }
+
+    #[test]
+    fn from_known_name_rejects_unknown_input() {
+        assert_eq!(SqlDialect::from_known_name("not-a-real-dialect"), None);
+        assert_eq!(SqlDialect::from_known_name(""), None);
     }
 }

--- a/crates/queryflux-core/src/query.rs
+++ b/crates/queryflux-core/src/query.rs
@@ -71,6 +71,8 @@ pub enum FrontendProtocol {
     SnowflakeHttp,
     /// Snowflake SQL REST API v2 (`/api/v2/statements`).
     SnowflakeSqlApi,
+    /// Model Context Protocol (streamable HTTP) — MCP tool calls from AI agents.
+    Mcp,
 }
 
 impl FrontendProtocol {
@@ -81,7 +83,7 @@ impl FrontendProtocol {
             FrontendProtocol::PostgresWire => SqlDialect::Postgres,
             FrontendProtocol::MySqlWire => SqlDialect::MySql,
             FrontendProtocol::ClickHouseHttp => SqlDialect::ClickHouse,
-            FrontendProtocol::FlightSql => SqlDialect::Generic,
+            FrontendProtocol::FlightSql | FrontendProtocol::Mcp => SqlDialect::Generic,
             FrontendProtocol::SnowflakeHttp | FrontendProtocol::SnowflakeSqlApi => {
                 SqlDialect::Snowflake
             }

--- a/crates/queryflux-e2e-tests/Cargo.toml
+++ b/crates/queryflux-e2e-tests/Cargo.toml
@@ -20,6 +20,7 @@ queryflux-translation = { workspace = true }
 queryflux-metrics = { workspace = true }
 queryflux-routing = { workspace = true }
 queryflux-auth = { workspace = true }
+queryflux-guardrails = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }
@@ -57,4 +58,9 @@ futures = { workspace = true }
 # Query params e2e tests — decode Snowflake rowsetBase64 (Arrow IPC + base64)
 arrow = { workspace = true }
 base64 = "0.22"
+
+[dev-dependencies]
+# Real MCP client (streamable HTTP) for mcp_tests.rs — drives the McpFrontend with the
+# actual protocol instead of hand-rolled JSON-RPC.
+rmcp = { version = "3", features = ["client", "transport-streamable-http-client", "transport-streamable-http-client-reqwest"] }
 

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -38,6 +38,7 @@ use queryflux_engine_adapters::{
 };
 use queryflux_frontend::{
     flight_sql::FlightSqlFrontend,
+    mcp::McpFrontend,
     mysql_wire::MysqlWireFrontend,
     postgres_wire::PostgresWireFrontend,
     snowflake::SnowflakeFrontend,
@@ -312,6 +313,7 @@ impl TestHarness {
             flight_sql: None,
             snowflake_http: Some(duckdb_group.clone()),
             snowflake_sql_api: Some(duckdb_group),
+            mcp: None,
         }));
         // Route compatibility:
         // - `X-Qf-Group` is our internal E2E routing header (legacy tests).
@@ -573,6 +575,7 @@ impl WireTestHarness {
             flight_sql: None,
             snowflake_http: Some(duckdb_group.clone()),
             snowflake_sql_api: Some(duckdb_group),
+            mcp: None,
         });
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
@@ -715,6 +718,7 @@ impl WireTestHarness {
             flight_sql: None,
             snowflake_http: Some(sr_group.clone()),
             snowflake_sql_api: Some(sr_group),
+            mcp: None,
         });
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
@@ -825,11 +829,22 @@ pub struct ProtocolWireHarness {
     pub mysql_port: u16,
     pub postgres_port: u16,
     pub flight_port: u16,
+    pub mcp_port: u16,
+    records: Arc<Mutex<Vec<QueryRecord>>>,
     _shutdown_tx: tokio::sync::watch::Sender<bool>,
 }
 
 impl ProtocolWireHarness {
     pub async fn new() -> Result<Self> {
+        Self::new_with_guard_chain(None).await
+    }
+
+    /// Same as `new()`, but installs `guard_chain` as the global guard chain — lets tests
+    /// exercise guardrail enforcement (e.g. `read_only`) end-to-end through a real frontend
+    /// instead of only unit-testing the `Guard` trait in isolation.
+    pub async fn new_with_guard_chain(
+        guard_chain: Option<Arc<queryflux_guardrails::GuardChain>>,
+    ) -> Result<Self> {
         let _ = tracing_subscriber::fmt()
             .with_env_filter("error")
             .try_init();
@@ -877,6 +892,7 @@ impl ProtocolWireHarness {
             flight_sql: Some(duckdb_group.clone()),
             snowflake_http: None,
             snowflake_sql_api: None,
+            mcp: Some(duckdb_group.clone()),
         });
 
         let cluster_manager = Arc::new(SimpleClusterGroupManager::new(group_states));
@@ -885,7 +901,7 @@ impl ProtocolWireHarness {
 
         let live_config = LiveConfig {
             router_chain,
-            guard_chain: None,
+            guard_chain,
             group_guard_chains: HashMap::new(),
             cluster_manager,
             adapters,
@@ -905,12 +921,15 @@ impl ProtocolWireHarness {
                 as Arc<dyn AuthorizationChecker>,
         };
 
+        let records: Arc<Mutex<Vec<QueryRecord>>> = Arc::new(Mutex::new(Vec::new()));
         let state = Arc::new(AppState {
             external_address: "http://127.0.0.1:0".to_string(),
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
-            metrics: Arc::new(NullMetrics),
+            metrics: Arc::new(CapturingMetrics {
+                records: records.clone(),
+            }),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
             queue_coordinator: None,
@@ -925,6 +944,7 @@ impl ProtocolWireHarness {
         let mysql_port = bind_ephemeral_port().await?;
         let postgres_port = bind_ephemeral_port().await?;
         let flight_port = bind_ephemeral_port().await?;
+        let mcp_port = bind_ephemeral_port().await?;
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -937,9 +957,10 @@ impl ProtocolWireHarness {
             shutdown_rx.clone(),
         );
         spawn_wire_frontend(
-            FlightSqlFrontend::new(state, flight_port, None),
-            shutdown_rx,
+            FlightSqlFrontend::new(state.clone(), flight_port, None),
+            shutdown_rx.clone(),
         );
+        spawn_wire_frontend(McpFrontend::new(state, mcp_port, None), shutdown_rx);
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -947,8 +968,36 @@ impl ProtocolWireHarness {
             mysql_port,
             postgres_port,
             flight_port,
+            mcp_port,
+            records,
             _shutdown_tx: shutdown_tx,
         })
+    }
+
+    pub fn clear_records(&self) {
+        self.records.lock().expect("lock records").clear();
+    }
+
+    pub async fn wait_for_record<F>(&self, predicate: F) -> Option<QueryRecord>
+    where
+        F: Fn(&QueryRecord) -> bool,
+    {
+        // `AppState::record_query` schedules `MetricsStore::record_query` via `tokio::spawn`.
+        // On slow shared runners the task can land after several hundred ms; keep a generous window.
+        for _ in 0..150 {
+            if let Some(record) = self
+                .records
+                .lock()
+                .expect("lock records")
+                .iter()
+                .find(|r| predicate(r))
+                .cloned()
+            {
+                return Some(record);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        None
     }
 }
 

--- a/crates/queryflux-e2e-tests/tests/mcp_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/mcp_tests.rs
@@ -352,7 +352,10 @@ async fn agent_context_defaults_when_absent() {
     let client = connect(h.mcp_port).await;
 
     let result = client
-        .call_tool(call("execute_query", serde_json::json!({ "sql": "SELECT 1" })))
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1" }),
+        ))
         .await
         .expect("call_tool execute_query");
     assert!(!is_error(&result), "unexpected tool error: {result:?}");
@@ -371,7 +374,10 @@ async fn agent_context_defaults_when_absent() {
         .expect("conversation_id should default to the Mcp-Session-Id");
 
     let result2 = client
-        .call_tool(call("execute_query", serde_json::json!({ "sql": "SELECT 2" })))
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 2" }),
+        ))
         .await
         .expect("call_tool execute_query");
     assert!(!is_error(&result2), "unexpected tool error: {result2:?}");

--- a/crates/queryflux-e2e-tests/tests/mcp_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/mcp_tests.rs
@@ -108,6 +108,51 @@ async fn execute_query_respects_max_rows() {
 }
 
 #[tokio::test]
+async fn execute_query_rejects_unknown_dialect() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    // An unknown `dialect` value must fail loudly (protocol-level error) rather than
+    // being passed through to sqlglot unvalidated.
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1", "dialect": "not-a-real-dialect" }),
+        ))
+        .await;
+    assert!(
+        result.is_err(),
+        "expected an unknown dialect to be rejected before execution"
+    );
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn execute_query_accepts_an_explicit_known_dialect() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    // The harness only routes to DuckDB, so this doesn't exercise a real cross-dialect
+    // rewrite — dispatch::resolve_src_dialect_tests covers that logic directly. This
+    // proves the MCP-level plumbing (param -> validation -> session.extra -> dispatch)
+    // works end-to-end over the real wire protocol without breaking execution.
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1 AS n", "dialect": "duckdb" }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let payload = result_json(&result);
+    assert_eq!(payload["rows"][0]["n"], serde_json::json!(1));
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
 async fn list_schemas_returns_schema_names() {
     let h = ProtocolWireHarness::new().await.expect("harness");
     let client = connect(h.mcp_port).await;

--- a/crates/queryflux-e2e-tests/tests/mcp_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/mcp_tests.rs
@@ -439,3 +439,65 @@ async fn agent_context_defaults_when_absent() {
 
     let _ = client.cancel().await;
 }
+
+/// Proves the actual "copy it forward" mechanism, not just implicit session-based
+/// grouping: extract `conversation_id` from a tool's JSON response (what an agent would
+/// read from its own context) and pass that exact value as the explicit `conversation_id`
+/// argument on a *new*, otherwise-unrelated MCP connection — the resulting query must
+/// still land in the same conversation. This is the behavior the response hint exists to
+/// make reliable even when a client doesn't preserve any transport-level session across
+/// calls (e.g. reconnects between tool calls).
+#[tokio::test]
+async fn execute_query_response_conversation_id_can_be_reused_on_a_new_connection() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    h.clear_records();
+
+    let client1 = connect(h.mcp_port).await;
+    let result1 = client1
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1" }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result1), "unexpected tool error: {result1:?}");
+
+    let payload1 = result_json(&result1);
+    let conversation_id = payload1["conversation_id"]
+        .as_str()
+        .expect("response should include conversation_id")
+        .to_string();
+    assert!(
+        !conversation_id.is_empty(),
+        "conversation_id should not be empty"
+    );
+    assert!(
+        payload1["_hint"].is_string(),
+        "response should include a hint telling the caller to reuse conversation_id"
+    );
+    let _ = client1.cancel().await;
+
+    // A brand new connection — no shared Mcp-Session-Id with the first one — reuses the
+    // conversation_id it read out of the first call's response.
+    let client2 = connect(h.mcp_port).await;
+    let result2 = client2
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 2", "conversation_id": conversation_id }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result2), "unexpected tool error: {result2:?}");
+
+    let record2 = h
+        .wait_for_record(|r| r.sql_preview.contains("SELECT 2"))
+        .await
+        .expect("expected a QueryRecord for the second call");
+    assert_eq!(
+        record2.conversation_id.as_deref(),
+        Some(conversation_id.as_str()),
+        "the id copied from the first response should group the second call with the first"
+    );
+
+    let _ = client2.cancel().await;
+}

--- a/crates/queryflux-e2e-tests/tests/mcp_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/mcp_tests.rs
@@ -338,3 +338,53 @@ async fn agent_context_via_headers_wins_over_params() {
 
     let _ = client.cancel().await;
 }
+
+/// When the caller supplies no agent params/headers at all, MCP must not drop agent
+/// context entirely (that would make the call invisible on the Agents page) — it
+/// defaults `agent_id` from the authenticated identity and `conversation_id` from the
+/// transport's `Mcp-Session-Id`, which the `rmcp` client transparently attaches after
+/// `initialize`. Two calls on the same client/session should therefore share one
+/// `conversation_id`, proving the session-based grouping actually works.
+#[tokio::test]
+async fn agent_context_defaults_when_absent() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    h.clear_records();
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call("execute_query", serde_json::json!({ "sql": "SELECT 1" })))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let record = h
+        .wait_for_record(|r| r.agent_id.is_some())
+        .await
+        .expect("expected a QueryRecord with a defaulted agent_id");
+    // The harness wires a `NoneAuthProvider(required = false)`, and MCP's `authenticate`
+    // never supplies a username, so the authenticated identity is deterministically
+    // "anonymous" here.
+    assert_eq!(record.agent_id.as_deref(), Some("anonymous"));
+    let conversation_id = record
+        .conversation_id
+        .clone()
+        .expect("conversation_id should default to the Mcp-Session-Id");
+
+    let result2 = client
+        .call_tool(call("execute_query", serde_json::json!({ "sql": "SELECT 2" })))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result2), "unexpected tool error: {result2:?}");
+
+    let record2 = h
+        .wait_for_record(|r| r.sql_preview.contains("SELECT 2"))
+        .await
+        .expect("expected a QueryRecord for the second call");
+    assert_eq!(
+        record2.conversation_id.as_deref(),
+        Some(conversation_id.as_str()),
+        "calls on the same MCP session should share the session-derived conversation_id"
+    );
+
+    let _ = client.cancel().await;
+}

--- a/crates/queryflux-e2e-tests/tests/mcp_tests.rs
+++ b/crates/queryflux-e2e-tests/tests/mcp_tests.rs
@@ -1,0 +1,340 @@
+//! E2e tests for the MCP (Model Context Protocol) frontend.
+//!
+//! Uses an in-process `ProtocolWireHarness` backed by DuckDB (no docker) and a real
+//! `rmcp` streamable-HTTP client — not hand-rolled JSON-RPC — so these tests exercise
+//! the actual MCP wire protocol, not just the tool-handler functions directly.
+//!
+//! Run with: `cargo test -p queryflux-e2e-tests --test mcp_tests`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use queryflux_e2e_tests::harness::ProtocolWireHarness;
+use queryflux_guardrails::{
+    built_in::{Guard, ReadOnlyGuard},
+    GuardChain,
+};
+use rmcp::{
+    model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation},
+    transport::{
+        streamable_http_client::StreamableHttpClientTransportConfig, StreamableHttpClientTransport,
+    },
+    ServiceExt,
+};
+
+fn mcp_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/mcp")
+}
+
+async fn connect(
+    port: u16,
+) -> rmcp::service::RunningService<rmcp::RoleClient, rmcp::model::InitializeRequestParams> {
+    let transport = StreamableHttpClientTransport::from_uri(mcp_url(port));
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("queryflux-e2e-tests", "0.0.1"),
+    );
+    client_info
+        .serve(transport)
+        .await
+        .expect("connect to MCP server")
+}
+
+fn call(name: &'static str, args: serde_json::Value) -> CallToolRequestParams {
+    CallToolRequestParams::new(name).with_arguments(args.as_object().cloned().unwrap_or_default())
+}
+
+fn result_text(result: &rmcp::model::CallToolResult) -> String {
+    let v = serde_json::to_value(result).expect("serialize CallToolResult");
+    v["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn result_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    serde_json::from_str(&result_text(result)).unwrap_or(serde_json::Value::Null)
+}
+
+fn is_error(result: &rmcp::model::CallToolResult) -> bool {
+    result.is_error.unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Tool happy paths
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn execute_query_select_one() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1 AS n" }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let payload = result_json(&result);
+    assert_eq!(payload["rows"][0]["n"], serde_json::json!(1));
+    assert_eq!(payload["truncated"], serde_json::json!(false));
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn execute_query_respects_max_rows() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let sql = "SELECT * FROM (VALUES (1), (2), (3), (4), (5)) AS t(n)";
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": sql, "max_rows": 2 }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let payload = result_json(&result);
+    assert_eq!(payload["row_count"], serde_json::json!(2));
+    assert_eq!(payload["truncated"], serde_json::json!(true));
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn list_schemas_returns_schema_names() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call("list_schemas", serde_json::json!({})))
+        .await
+        .expect("call_tool list_schemas");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+    let payload = result_json(&result);
+    assert!(payload["columns"].is_array());
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn describe_table_with_sample_rows() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    // A table DuckDB always has: information_schema.tables.
+    let result = client
+        .call_tool(call(
+            "describe_table",
+            serde_json::json!({
+                "schema": "information_schema",
+                "table": "tables",
+                "sample_rows": 1,
+            }),
+        ))
+        .await
+        .expect("call_tool describe_table");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let payload = result_json(&result);
+    assert!(payload["columns"]["columns"].is_array());
+    assert!(!payload["sample"].is_null());
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn explain_query_returns_plan() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "explain_query",
+            serde_json::json!({ "sql": "SELECT 1" }),
+        ))
+        .await
+        .expect("call_tool explain_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn get_query_status_reports_not_found_for_unknown_id() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "get_query_status",
+            serde_json::json!({ "query_id": "does-not-exist" }),
+        ))
+        .await
+        .expect("call_tool get_query_status");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+    let payload = result_json(&result);
+    assert_eq!(
+        payload["status"],
+        serde_json::json!("not_found_or_completed")
+    );
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn cancel_query_rejects_unknown_id() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "cancel_query",
+            serde_json::json!({ "query_id": "does-not-exist" }),
+        ))
+        .await;
+    // Unknown id is an MCP-level `invalid_params` error (Err), not a tool-level CallToolResult error.
+    assert!(
+        result.is_err(),
+        "expected cancel_query to error on unknown id"
+    );
+
+    let _ = client.cancel().await;
+}
+
+// ---------------------------------------------------------------------------
+// Guardrails — proves MCP flows through the exact same GuardChain as every other
+// frontend, using ordinary user-configured guards. No MCP-specific guard code exists;
+// this test would fail if that stopped being true.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn execute_query_denied_by_read_only_guard() {
+    let guard_chain = Arc::new(GuardChain::new(vec![
+        Box::new(ReadOnlyGuard) as Box<dyn Guard>
+    ]));
+    let h = ProtocolWireHarness::new_with_guard_chain(Some(guard_chain))
+        .await
+        .expect("harness");
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "DELETE FROM information_schema.tables" }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(is_error(&result), "expected read_only guard to deny DELETE");
+    assert!(
+        result_text(&result)
+            .to_lowercase()
+            .contains("not permitted"),
+        "expected a read_only-style denial reason, got: {}",
+        result_text(&result)
+    );
+
+    // A normal SELECT through the same guard chain is unaffected.
+    let ok = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({ "sql": "SELECT 1" }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&ok), "read_only guard should not block SELECT");
+
+    let _ = client.cancel().await;
+}
+
+// ---------------------------------------------------------------------------
+// Agent context — proves both propagation paths (HTTP headers and explicit tool
+// parameters) land in the persisted QueryRecord, mirroring session_context_tests.rs's
+// coverage for the other wire protocols.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn agent_context_via_tool_params() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    h.clear_records();
+    let client = connect(h.mcp_port).await;
+
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({
+                "sql": "SELECT 1",
+                "agent_id": "agent-params",
+                "conversation_id": "conv-params",
+                "step_index": 3,
+                "query_intent": "lookup",
+            }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let record = h
+        .wait_for_record(|r| r.agent_id.as_deref() == Some("agent-params"))
+        .await
+        .expect("expected a QueryRecord with agent_id=agent-params");
+    assert_eq!(record.conversation_id.as_deref(), Some("conv-params"));
+    assert_eq!(record.step_index, Some(3));
+    assert_eq!(record.query_intent.as_deref(), Some("lookup"));
+
+    let _ = client.cancel().await;
+}
+
+#[tokio::test]
+async fn agent_context_via_headers_wins_over_params() {
+    let h = ProtocolWireHarness::new().await.expect("harness");
+    h.clear_records();
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        reqwest::header::HeaderName::from_static("x-agent-id"),
+        reqwest::header::HeaderValue::from_static("agent-header"),
+    );
+    headers.insert(
+        reqwest::header::HeaderName::from_static("x-conversation-id"),
+        reqwest::header::HeaderValue::from_static("conv-header"),
+    );
+    let config =
+        StreamableHttpClientTransportConfig::with_uri(mcp_url(h.mcp_port)).custom_headers(headers);
+    let transport = StreamableHttpClientTransport::from_config(config);
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("queryflux-e2e-tests", "0.0.1"),
+    );
+    let client = client_info.serve(transport).await.expect("connect");
+
+    // agent_id supplied both via header (agent-header) and tool param (agent-param) —
+    // the header must win, per the documented precedence.
+    let result = client
+        .call_tool(call(
+            "execute_query",
+            serde_json::json!({
+                "sql": "SELECT 1",
+                "agent_id": "agent-param",
+                "conversation_id": "conv-param",
+            }),
+        ))
+        .await
+        .expect("call_tool execute_query");
+    assert!(!is_error(&result), "unexpected tool error: {result:?}");
+
+    let record = h
+        .wait_for_record(|r| r.agent_id.is_some())
+        .await
+        .expect("expected a QueryRecord with agent context");
+    assert_eq!(record.agent_id.as_deref(), Some("agent-header"));
+    assert_eq!(record.conversation_id.as_deref(), Some("conv-header"));
+
+    let _ = client.cancel().await;
+}

--- a/crates/queryflux-frontend/Cargo.toml
+++ b/crates/queryflux-frontend/Cargo.toml
@@ -43,3 +43,6 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 flate2 = "1"
 anyhow = { workspace = true }
+rmcp = { version = "3", features = ["server", "transport-streamable-http-server", "transport-streamable-http-server-session"] }
+schemars = "1"
+tokio-util = "0.7"

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -351,6 +351,12 @@ pub fn build_frontends_status(
                 port: Some(c.port),
             },
         },
+        opt_fe(
+            "mcp",
+            "MCP",
+            "Model Context Protocol streamable-HTTP tool calls for AI agents.",
+            frontends.mcp.as_ref(),
+        ),
     ];
 
     FrontendsStatusDto {
@@ -1084,14 +1090,14 @@ async fn collect_running_queries(
 }
 
 /// Admin cancel path for a queued query (claim release handled by caller).
-async fn delete_queued_if_exists(
+pub(crate) async fn delete_queued_if_exists(
     persistence: &dyn queryflux_persistence::Persistence,
     id: &str,
 ) -> queryflux_core::error::Result<Option<queryflux_core::query::QueuedQuery>> {
     persistence.take_queued(&ProxyQueryId(id.to_string())).await
 }
 
-async fn find_executing_query(
+pub(crate) async fn find_executing_query(
     persistence: &dyn queryflux_persistence::Persistence,
     id: &str,
 ) -> queryflux_core::error::Result<Option<ExecutingQuery>> {
@@ -1187,17 +1193,38 @@ async fn cancel_executing(
     state: &AdminState,
     executing: queryflux_core::query::ExecutingQuery,
 ) -> Response {
-    let Some(adapter) = state.app.adapter(&executing.cluster_name.0).await else {
+    match cancel_executing_query(
+        &state.app,
+        queryflux_core::query::FrontendProtocol::TrinoHttp,
+        &executing,
+        "admin cancelled",
+    )
+    .await
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
+    }
+}
+
+/// Cancel an in-flight executing query on its backend and record the outcome.
+///
+/// Shared by the admin `DELETE /admin/queries/{id}` handler (above, no ownership check —
+/// admin credentials are already full-privilege) and the MCP `cancel_query` tool (which
+/// checks `require_query_owner` before calling this, since MCP callers authenticate as a
+/// regular user, not an admin).
+pub(crate) async fn cancel_executing_query(
+    app: &Arc<AppState>,
+    protocol: queryflux_core::query::FrontendProtocol,
+    executing: &queryflux_core::query::ExecutingQuery,
+    reason: &str,
+) -> std::result::Result<(), String> {
+    let Some(adapter) = app.adapter(&executing.cluster_name.0).await else {
         warn!(
             id = %executing.id,
             cluster = %executing.cluster_name,
-            "Admin cancel: no adapter for cluster"
+            "Cancel: no adapter for cluster"
         );
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to cancel query on backend",
-        )
-            .into_response();
+        return Err("failed to cancel query on backend".to_string());
     };
     if let Err(e) = adapter
         .cancel_query(&executing.backend_query_id, executing.wire_auth.as_ref())
@@ -1206,44 +1233,33 @@ async fn cancel_executing(
         warn!(
             id = %executing.id,
             backend = %executing.backend_query_id,
-            "Admin adapter cancel failed: {e}"
+            "Adapter cancel failed: {e}"
         );
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "failed to cancel query on backend",
-        )
-            .into_response();
+        return Err("failed to cancel query on backend".to_string());
     }
-    state.app.record_executing_cancelled(
-        &executing,
-        queryflux_core::query::FrontendProtocol::TrinoHttp,
+    app.record_executing_cancelled(
+        executing,
+        protocol,
         adapter.engine_type(),
         adapter.translation_target_dialect(),
-        "admin cancelled",
+        reason,
     );
-    state
-        .app
-        .release_query_slot(
-            &executing.cluster_group,
-            &executing.cluster_name,
-            &executing.id.0,
-        )
-        .await;
-    if let Err(e) = state
-        .app
-        .persistence
-        .delete(&executing.backend_query_id)
-        .await
-    {
-        return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+    app.release_query_slot(
+        &executing.cluster_group,
+        &executing.cluster_name,
+        &executing.id.0,
+    )
+    .await;
+    if let Err(e) = app.persistence.delete(&executing.backend_query_id).await {
+        return Err(e.to_string());
     }
     info!(
         id = %executing.id,
         backend = %executing.backend_query_id,
         owner = %executing.submitted_by,
-        "Admin cancelled executing query"
+        "Cancelled executing query"
     );
-    StatusCode::NO_CONTENT.into_response()
+    Ok(())
 }
 
 /// Distinct agents that have run queries, with aggregate stats.

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -33,29 +33,40 @@ use tracing::{debug, info, warn};
 
 use crate::state::{AppState, QueryContext, QueryOutcome};
 
-/// Resolve the source dialect used for translation.
+/// Resolve the source dialect to record for this query.
 ///
 /// An explicit `session.extra["dialect"]` override — set by the MCP frontend when the
-/// caller declares a dialect via the `dialect` tool parameter or an `X-Sql-Dialect`
-/// header — always wins. Otherwise falls back to the protocol's wire-implied default,
-/// *except* for MCP: unlike every other frontend, MCP has no wire protocol that implies
-/// a dialect (an LLM agent can write SQL in anything), so guessing `SqlDialect::Generic`
-/// risks sqlglot parsing/rewriting under its own opinionated base dialect when the SQL
-/// was actually already correct for the target engine. Defaulting to the *target*
-/// dialect instead makes translation a no-op by default (the common case), rather than
-/// a guess that can silently produce wrong SQL.
-fn resolve_src_dialect(
-    session: &SessionContext,
-    protocol: &FrontendProtocol,
-    tgt_dialect: &SqlDialect,
-) -> SqlDialect {
+/// caller declares a dialect via the `dialect` tool parameter — always wins. Otherwise
+/// falls back to the protocol's wire-implied default (`SqlDialect::Generic` for MCP,
+/// same as `FlightSql` — see `FrontendProtocol::default_dialect`). This value is purely
+/// descriptive (what gets persisted on the query record); it does **not** by itself
+/// determine whether translation actually runs — see `should_attempt_translation`. We
+/// deliberately do not infer "the SQL is probably already in the target engine's
+/// dialect" here: that's a guess, and recording a guessed dialect as if the caller
+/// declared it would make the audit trail wrong, not just the translation.
+fn resolve_src_dialect(session: &SessionContext, protocol: &FrontendProtocol) -> SqlDialect {
     if let Some(name) = session.extra.get("dialect") {
         return SqlDialect::Sqlglot(name.clone());
     }
-    if matches!(protocol, FrontendProtocol::Mcp) {
-        return tgt_dialect.clone();
-    }
     protocol.default_dialect()
+}
+
+/// Whether translation (and therefore sqlglot) should be invoked at all for this query.
+///
+/// Every protocol except MCP has a wire-implied dialect, so translation always at least
+/// attempts to run for them (`TranslationService::maybe_translate` itself no-ops when
+/// `src`/`tgt` turn out compatible and no fixup scripts are configured). MCP is the one
+/// case where, absent an explicit `dialect` override, we genuinely don't know the source
+/// dialect — and calling sqlglot with a guessed dialect risks mis-parsing SQL that was
+/// already correct for the target engine. Note that simply recording `Generic` here does
+/// *not* make `maybe_translate` skip on its own: `SqlDialect::Generic.is_compatible_with`
+/// a real target dialect is false, so it would still call sqlglot with an empty `read`
+/// dialect — the exact problem we're avoiding. So when MCP has no override, we skip
+/// calling `maybe_translate` entirely: no dialect is passed to sqlglot, and no configured
+/// fixup scripts run either, since those need a real dialect to parse under too. The SQL
+/// passes through completely unmodified.
+fn should_attempt_translation(session: &SessionContext, protocol: &FrontendProtocol) -> bool {
+    !matches!(protocol, FrontendProtocol::Mcp) || session.extra.contains_key("dialect")
 }
 
 // ---------------------------------------------------------------------------
@@ -339,26 +350,30 @@ pub async fn dispatch_query(
     };
 
     let tgt_dialect = adapter_kind.translation_target_dialect();
-    let src_dialect = resolve_src_dialect(&session, &protocol, &tgt_dialect);
+    let src_dialect = resolve_src_dialect(&session, &protocol);
     let engine_type = adapter_kind.engine_type();
     let original_sql = sql.clone();
-    let sql = match state
-        .translation
-        .maybe_translate(
-            &sql,
-            &src_dialect,
-            &tgt_dialect,
-            &SchemaContext::default(),
-            &group_fixups,
-        )
-        .await
-    {
-        Ok(t) => t,
-        Err(e) => {
-            warn!(id = %query_id, "Translation error: {e}");
-            slot.release().await;
-            return Err(e);
+    let sql = if should_attempt_translation(&session, &protocol) {
+        match state
+            .translation
+            .maybe_translate(
+                &sql,
+                &src_dialect,
+                &tgt_dialect,
+                &SchemaContext::default(),
+                &group_fixups,
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(id = %query_id, "Translation error: {e}");
+                slot.release().await;
+                return Err(e);
+            }
         }
+    } else {
+        sql
     };
     let was_translated = sql != original_sql;
     if was_translated {
@@ -589,11 +604,7 @@ pub async fn dispatch_query(
                     slot.disarm();
                     info!(id = %query_id, backend = %backend_query_id, cluster = %cluster_name, "Query completed on submit");
                     let was_translated = executing.translated_sql.is_some();
-                    let src_dialect = resolve_src_dialect(
-                        &session,
-                        &protocol,
-                        &adapter.translation_target_dialect(),
-                    );
+                    let src_dialect = resolve_src_dialect(&session, &protocol);
                     let ctx = QueryContext {
                         query_id: executing.id.clone(),
                         sql: executing
@@ -1385,64 +1396,70 @@ async fn setup_sync_query(
     );
 
     let tgt_dialect = adapter.translation_target_dialect();
-    let src_dialect = resolve_src_dialect(&session, &protocol, &tgt_dialect);
+    let src_dialect = resolve_src_dialect(&session, &protocol);
     let engine_type = adapter.engine_type();
     let start = Instant::now();
 
     // Translate SQL. On failure: record the query, release the slot, propagate the error.
-    // The caller (execute_to_sink) will notify the sink via on_error.
-    let translated = match state
-        .translation
-        .maybe_translate(
-            &sql,
-            &src_dialect,
-            &tgt_dialect,
-            &SchemaContext::default(),
-            &group_fixups,
-        )
-        .await
-    {
-        Ok(t) => t,
-        Err(e) => {
-            let err_msg = e.to_string();
-            warn!(id = %query_id, "Translation error: {err_msg}");
-            let ctx = QueryContext {
-                query_id: query_id.clone(),
-                sql: sql.clone(),
-                session: session.clone(),
-                protocol: protocol.clone(),
-                group: group.clone(),
-                cluster: cluster_name.clone(),
-                cluster_group_config_id,
-                cluster_config_id,
-                engine_type: engine_type.clone(),
-                src_dialect: src_dialect.clone(),
-                tgt_dialect: tgt_dialect.clone(),
-                was_translated: false,
-                translated_sql: None,
-                query_tags: effective_tags,
-                query_params: params,
-                agent_context: session.resolved_agent_context(),
-            };
-            state.record_query(
-                &ctx,
-                QueryOutcome {
-                    backend_query_id: None,
-                    status: QueryStatus::Failed,
-                    execution_ms: start.elapsed().as_millis() as u64,
-                    rows: None,
-                    error: Some(err_msg),
-                    routing_trace: None,
-                    engine_stats: None,
-                    guard_actions: vec![],
-                    was_guard_blocked: false,
-                    queue_duration_ms: 0,
-                    cache_hit: false,
-                },
-            );
-            slot.release().await;
-            return Err(e);
+    // The caller (execute_to_sink) will notify the sink via on_error. Skipped entirely
+    // (sqlglot never invoked) when should_attempt_translation is false — see its doc
+    // comment for why MCP without a declared dialect takes this path.
+    let translated = if should_attempt_translation(&session, &protocol) {
+        match state
+            .translation
+            .maybe_translate(
+                &sql,
+                &src_dialect,
+                &tgt_dialect,
+                &SchemaContext::default(),
+                &group_fixups,
+            )
+            .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                let err_msg = e.to_string();
+                warn!(id = %query_id, "Translation error: {err_msg}");
+                let ctx = QueryContext {
+                    query_id: query_id.clone(),
+                    sql: sql.clone(),
+                    session: session.clone(),
+                    protocol: protocol.clone(),
+                    group: group.clone(),
+                    cluster: cluster_name.clone(),
+                    cluster_group_config_id,
+                    cluster_config_id,
+                    engine_type: engine_type.clone(),
+                    src_dialect: src_dialect.clone(),
+                    tgt_dialect: tgt_dialect.clone(),
+                    was_translated: false,
+                    translated_sql: None,
+                    query_tags: effective_tags,
+                    query_params: params,
+                    agent_context: session.resolved_agent_context(),
+                };
+                state.record_query(
+                    &ctx,
+                    QueryOutcome {
+                        backend_query_id: None,
+                        status: QueryStatus::Failed,
+                        execution_ms: start.elapsed().as_millis() as u64,
+                        rows: None,
+                        error: Some(err_msg),
+                        routing_trace: None,
+                        engine_stats: None,
+                        guard_actions: vec![],
+                        was_guard_blocked: false,
+                        queue_duration_ms: 0,
+                        cache_hit: false,
+                    },
+                );
+                slot.release().await;
+                return Err(e);
+            }
         }
+    } else {
+        sql.clone()
     };
 
     let was_translated = translated != sql;
@@ -2464,20 +2481,18 @@ mod resolve_src_dialect_tests {
     use queryflux_core::session::SessionContext;
 
     #[test]
-    fn mcp_defaults_to_target_dialect_not_generic() {
+    fn mcp_without_override_records_generic_not_a_guess() {
+        // No inference here — Generic is the honest "we don't know" value, same as
+        // FlightSql's own default_dialect(). It is not the target engine's dialect.
         let session = SessionContext::default();
-        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp, &SqlDialect::Trino);
-        assert_eq!(resolved, SqlDialect::Trino);
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp);
+        assert_eq!(resolved, SqlDialect::Generic);
     }
 
     #[test]
     fn non_mcp_protocol_uses_its_own_wire_implied_default() {
         let session = SessionContext::default();
-        let resolved = resolve_src_dialect(
-            &session,
-            &FrontendProtocol::PostgresWire,
-            &SqlDialect::DuckDb,
-        );
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::PostgresWire);
         assert_eq!(resolved, SqlDialect::Postgres);
     }
 
@@ -2487,7 +2502,7 @@ mod resolve_src_dialect_tests {
         session
             .extra
             .insert("dialect".to_string(), "bigquery".to_string());
-        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp, &SqlDialect::Trino);
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp);
         assert_eq!(resolved, SqlDialect::Sqlglot("bigquery".to_string()));
     }
 
@@ -2497,8 +2512,51 @@ mod resolve_src_dialect_tests {
         session
             .extra
             .insert("dialect".to_string(), "snowflake".to_string());
-        let resolved =
-            resolve_src_dialect(&session, &FrontendProtocol::TrinoHttp, &SqlDialect::DuckDb);
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::TrinoHttp);
         assert_eq!(resolved, SqlDialect::Sqlglot("snowflake".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod should_attempt_translation_tests {
+    use super::should_attempt_translation;
+    use queryflux_core::query::FrontendProtocol;
+    use queryflux_core::session::SessionContext;
+
+    #[test]
+    fn mcp_without_override_skips_translation() {
+        let session = SessionContext::default();
+        assert!(!should_attempt_translation(
+            &session,
+            &FrontendProtocol::Mcp
+        ));
+    }
+
+    #[test]
+    fn mcp_with_explicit_override_attempts_translation() {
+        let mut session = SessionContext::default();
+        session
+            .extra
+            .insert("dialect".to_string(), "postgres".to_string());
+        assert!(should_attempt_translation(&session, &FrontendProtocol::Mcp));
+    }
+
+    #[test]
+    fn every_other_protocol_always_attempts_translation() {
+        let session = SessionContext::default();
+        for protocol in [
+            FrontendProtocol::TrinoHttp,
+            FrontendProtocol::PostgresWire,
+            FrontendProtocol::MySqlWire,
+            FrontendProtocol::ClickHouseHttp,
+            FrontendProtocol::FlightSql,
+            FrontendProtocol::SnowflakeHttp,
+            FrontendProtocol::SnowflakeSqlApi,
+        ] {
+            assert!(
+                should_attempt_translation(&session, &protocol),
+                "{protocol:?} should always attempt translation (maybe_translate no-ops on its own when compatible)"
+            );
+        }
     }
 }

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -16,7 +16,8 @@ use queryflux_core::{
     error::{QueryFluxError, Result},
     query::{
         ClusterGroupName, ClusterName, ExecutingQuery, FrontendProtocol, ProxyQueryId,
-        QueryEngineStats, QueryExecution, QueryStats, QueryStatus, QueuedQuery, StoredWireAuth,
+        QueryEngineStats, QueryExecution, QueryStats, QueryStatus, QueuedQuery, SqlDialect,
+        StoredWireAuth,
     },
     session::SessionContext,
 };
@@ -31,6 +32,31 @@ use queryflux_translation::SchemaContext;
 use tracing::{debug, info, warn};
 
 use crate::state::{AppState, QueryContext, QueryOutcome};
+
+/// Resolve the source dialect used for translation.
+///
+/// An explicit `session.extra["dialect"]` override — set by the MCP frontend when the
+/// caller declares a dialect via the `dialect` tool parameter or an `X-Sql-Dialect`
+/// header — always wins. Otherwise falls back to the protocol's wire-implied default,
+/// *except* for MCP: unlike every other frontend, MCP has no wire protocol that implies
+/// a dialect (an LLM agent can write SQL in anything), so guessing `SqlDialect::Generic`
+/// risks sqlglot parsing/rewriting under its own opinionated base dialect when the SQL
+/// was actually already correct for the target engine. Defaulting to the *target*
+/// dialect instead makes translation a no-op by default (the common case), rather than
+/// a guess that can silently produce wrong SQL.
+fn resolve_src_dialect(
+    session: &SessionContext,
+    protocol: &FrontendProtocol,
+    tgt_dialect: &SqlDialect,
+) -> SqlDialect {
+    if let Some(name) = session.extra.get("dialect") {
+        return SqlDialect::Sqlglot(name.clone());
+    }
+    if matches!(protocol, FrontendProtocol::Mcp) {
+        return tgt_dialect.clone();
+    }
+    protocol.default_dialect()
+}
 
 // ---------------------------------------------------------------------------
 // ResultSink — universal streaming output interface
@@ -312,8 +338,8 @@ pub async fn dispatch_query(
         }
     };
 
-    let src_dialect = protocol.default_dialect();
     let tgt_dialect = adapter_kind.translation_target_dialect();
+    let src_dialect = resolve_src_dialect(&session, &protocol, &tgt_dialect);
     let engine_type = adapter_kind.engine_type();
     let original_sql = sql.clone();
     let sql = match state
@@ -563,7 +589,11 @@ pub async fn dispatch_query(
                     slot.disarm();
                     info!(id = %query_id, backend = %backend_query_id, cluster = %cluster_name, "Query completed on submit");
                     let was_translated = executing.translated_sql.is_some();
-                    let src_dialect = protocol.default_dialect();
+                    let src_dialect = resolve_src_dialect(
+                        &session,
+                        &protocol,
+                        &adapter.translation_target_dialect(),
+                    );
                     let ctx = QueryContext {
                         query_id: executing.id.clone(),
                         sql: executing
@@ -1354,8 +1384,8 @@ async fn setup_sync_query(
         query_id.0.clone(),
     );
 
-    let src_dialect = protocol.default_dialect();
     let tgt_dialect = adapter.translation_target_dialect();
+    let src_dialect = resolve_src_dialect(&session, &protocol, &tgt_dialect);
     let engine_type = adapter.engine_type();
     let start = Instant::now();
 
@@ -2424,5 +2454,51 @@ mod capacity_wait_tests {
             }
             other => panic!("expected CapacityWaitTimeout, got {other}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod resolve_src_dialect_tests {
+    use super::resolve_src_dialect;
+    use queryflux_core::query::{FrontendProtocol, SqlDialect};
+    use queryflux_core::session::SessionContext;
+
+    #[test]
+    fn mcp_defaults_to_target_dialect_not_generic() {
+        let session = SessionContext::default();
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp, &SqlDialect::Trino);
+        assert_eq!(resolved, SqlDialect::Trino);
+    }
+
+    #[test]
+    fn non_mcp_protocol_uses_its_own_wire_implied_default() {
+        let session = SessionContext::default();
+        let resolved = resolve_src_dialect(
+            &session,
+            &FrontendProtocol::PostgresWire,
+            &SqlDialect::DuckDb,
+        );
+        assert_eq!(resolved, SqlDialect::Postgres);
+    }
+
+    #[test]
+    fn explicit_session_override_wins_for_mcp() {
+        let mut session = SessionContext::default();
+        session
+            .extra
+            .insert("dialect".to_string(), "bigquery".to_string());
+        let resolved = resolve_src_dialect(&session, &FrontendProtocol::Mcp, &SqlDialect::Trino);
+        assert_eq!(resolved, SqlDialect::Sqlglot("bigquery".to_string()));
+    }
+
+    #[test]
+    fn explicit_session_override_wins_for_other_protocols_too() {
+        let mut session = SessionContext::default();
+        session
+            .extra
+            .insert("dialect".to_string(), "snowflake".to_string());
+        let resolved =
+            resolve_src_dialect(&session, &FrontendProtocol::TrinoHttp, &SqlDialect::DuckDb);
+        assert_eq!(resolved, SqlDialect::Sqlglot("snowflake".to_string()));
     }
 }

--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -190,7 +190,7 @@ impl FlightSqlService for QueryFluxFlightSql {
             .metadata()
             .get("authorization")
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
+            .and_then(crate::strip_bearer_prefix)
             .map(|t| t.to_string());
         let creds = Credentials {
             username: session.user().map(|s| s.to_string()),

--- a/crates/queryflux-frontend/src/lib.rs
+++ b/crates/queryflux-frontend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod abort;
 pub mod admin;
 pub mod dispatch;
 pub mod flight_sql;
+pub mod mcp;
 pub mod mysql_wire;
 pub mod postgres_wire;
 pub mod routing_resolve;

--- a/crates/queryflux-frontend/src/lib.rs
+++ b/crates/queryflux-frontend/src/lib.rs
@@ -24,6 +24,18 @@ pub type ShutdownRx = tokio::sync::watch::Receiver<bool>;
 /// multi‑MiB DoS buffers. Kept below MySQL's 24-bit packet max (16 MiB − 1).
 pub const MAX_FRONTEND_MESSAGE_BYTES: usize = 8 * 1024 * 1024;
 
+/// Extract the token from an `Authorization: Bearer <token>` header value. Matches the
+/// `Bearer` scheme name case-insensitively per RFC 6750 §2.1 (e.g. `bearer <token>` is a
+/// valid header), unlike a plain `str::strip_prefix("Bearer ")`.
+pub fn strip_bearer_prefix(value: &str) -> Option<&str> {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 7 && bytes[..7].eq_ignore_ascii_case(b"bearer ") {
+        Some(&value[7..])
+    } else {
+        None
+    }
+}
+
 /// Implemented by each frontend protocol server (Trino HTTP, PG wire, MySQL wire, etc.).
 ///
 /// Each listener binds to a port, accepts connections in its native protocol,
@@ -34,4 +46,40 @@ pub trait FrontendListenerTrait: Send + Sync {
     /// Start the listener. Returns when the shutdown signal fires and in-flight
     /// work has drained (or the server framework finishes its own drain).
     async fn listen(&self, shutdown: ShutdownRx) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_bearer_prefix_matches_canonical_case() {
+        assert_eq!(strip_bearer_prefix("Bearer abc123"), Some("abc123"));
+    }
+
+    #[test]
+    fn strip_bearer_prefix_matches_lowercase_scheme() {
+        assert_eq!(strip_bearer_prefix("bearer abc123"), Some("abc123"));
+    }
+
+    #[test]
+    fn strip_bearer_prefix_matches_mixed_case_scheme() {
+        assert_eq!(strip_bearer_prefix("BeArEr abc123"), Some("abc123"));
+    }
+
+    #[test]
+    fn strip_bearer_prefix_rejects_other_schemes() {
+        assert_eq!(strip_bearer_prefix("Basic abc123"), None);
+    }
+
+    #[test]
+    fn strip_bearer_prefix_rejects_short_input() {
+        assert_eq!(strip_bearer_prefix("Bear"), None);
+        assert_eq!(strip_bearer_prefix(""), None);
+    }
+
+    #[test]
+    fn strip_bearer_prefix_allows_empty_token() {
+        assert_eq!(strip_bearer_prefix("Bearer "), Some(""));
+    }
 }

--- a/crates/queryflux-frontend/src/mcp/mod.rs
+++ b/crates/queryflux-frontend/src/mcp/mod.rs
@@ -1,0 +1,81 @@
+//! MCP (Model Context Protocol) frontend — streamable HTTP tool calls for AI agents.
+//!
+//! Exposes `execute_query`, `list_schemas`, `describe_table`, `explain_query`,
+//! `get_query_status`, and `cancel_query` as MCP tools. Every tool authenticates via
+//! `Authorization: Bearer <token>` (same `AuthProvider` as every other HTTP frontend)
+//! and dispatches through the standard `execute_to_sink` pipeline, so routing,
+//! translation, guardrails, and query-history persistence are identical to every other
+//! frontend — nothing MCP-specific is layered on top.
+
+pub mod sink;
+pub mod tools;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use queryflux_core::error::{QueryFluxError, Result};
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, tower::StreamableHttpService, StreamableHttpServerConfig,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::state::AppState;
+use crate::{FrontendListenerTrait, ShutdownRx};
+use tools::QueryFluxMcpServer;
+
+pub struct McpFrontend {
+    state: Arc<AppState>,
+    port: u16,
+    max_connections: Option<usize>,
+}
+
+impl McpFrontend {
+    pub fn new(state: Arc<AppState>, port: u16, max_connections: Option<usize>) -> Self {
+        Self {
+            state,
+            port,
+            max_connections,
+        }
+    }
+}
+
+#[async_trait]
+impl FrontendListenerTrait for McpFrontend {
+    async fn listen(&self, mut shutdown: ShutdownRx) -> Result<()> {
+        let addr: std::net::SocketAddr = format!("0.0.0.0:{}", self.port)
+            .parse()
+            .map_err(|e: std::net::AddrParseError| QueryFluxError::Other(e.into()))?;
+
+        let ct = CancellationToken::new();
+        let config = StreamableHttpServerConfig::default().with_cancellation_token(ct.clone());
+
+        let server_state = self.state.clone();
+        let service: StreamableHttpService<QueryFluxMcpServer, LocalSessionManager> =
+            StreamableHttpService::new(
+                move || Ok(QueryFluxMcpServer::new(server_state.clone())),
+                Arc::new(LocalSessionManager::default()),
+                config,
+            );
+
+        let mut router = Router::new().nest_service("/mcp", service);
+        if let Some(limit) = self.max_connections.filter(|&l| l > 0) {
+            router = router.layer(tower::limit::ConcurrencyLimitLayer::new(limit));
+        }
+
+        info!("MCP frontend listening on {addr}");
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| QueryFluxError::Other(e.into()))?;
+
+        let result = axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown.changed().await;
+                ct.cancel();
+            })
+            .await
+            .map_err(|e| QueryFluxError::Other(e.into()));
+        result
+    }
+}

--- a/crates/queryflux-frontend/src/mcp/mod.rs
+++ b/crates/queryflux-frontend/src/mcp/mod.rs
@@ -64,18 +64,17 @@ impl FrontendListenerTrait for McpFrontend {
             router = router.layer(tower::limit::ConcurrencyLimitLayer::new(limit));
         }
 
-        info!("MCP frontend listening on {addr}");
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(|e| QueryFluxError::Other(e.into()))?;
+        info!("MCP frontend listening on {addr}");
 
-        let result = axum::serve(listener, router)
+        axum::serve(listener, router)
             .with_graceful_shutdown(async move {
                 let _ = shutdown.changed().await;
                 ct.cancel();
             })
             .await
-            .map_err(|e| QueryFluxError::Other(e.into()));
-        result
+            .map_err(|e| QueryFluxError::Other(e.into()))
     }
 }

--- a/crates/queryflux-frontend/src/mcp/sink.rs
+++ b/crates/queryflux-frontend/src/mcp/sink.rs
@@ -1,0 +1,222 @@
+use arrow::array::{
+    Array, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use queryflux_core::{error::Result, query::QueryStats};
+use serde_json::{json, Value};
+
+use crate::dispatch::ResultSink;
+
+/// Collects Arrow RecordBatches from `execute_to_sink` and serializes them as JSON rows
+/// keyed by column name. Used by every MCP tool that returns query results.
+///
+/// Truncates at `max_rows` — the caller-supplied tool parameter (e.g. `execute_query`'s
+/// `max_rows`, default 1000). This bounds the JSON response so it fits the agent's
+/// context window; it is not a safety mechanism. Row-count safety policy (if any) is
+/// the operator's responsibility via the normal `guardrails` config, same as every
+/// other frontend.
+pub struct JsonResultSink {
+    columns: Vec<String>,
+    rows: Vec<Value>,
+    max_rows: usize,
+    pub truncated: bool,
+    pub error: Option<String>,
+}
+
+impl JsonResultSink {
+    pub fn new(max_rows: usize) -> Self {
+        Self {
+            columns: Vec::new(),
+            rows: Vec::new(),
+            max_rows,
+            truncated: false,
+            error: None,
+        }
+    }
+
+    /// Build the final JSON result payload after `execute_to_sink` returns.
+    pub fn into_result(self, elapsed_ms: u64, engine: &str) -> Value {
+        let row_count = self.rows.len();
+        json!({
+            "columns": self.columns,
+            "rows": self.rows,
+            "row_count": row_count,
+            "truncated": self.truncated,
+            "elapsed_ms": elapsed_ms,
+            "engine": engine,
+        })
+    }
+}
+
+#[async_trait]
+impl ResultSink for JsonResultSink {
+    async fn on_schema(&mut self, schema: &Schema) -> Result<()> {
+        self.columns = schema.fields().iter().map(|f| f.name().clone()).collect();
+        Ok(())
+    }
+
+    async fn on_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        let remaining = self.max_rows.saturating_sub(self.rows.len());
+        if remaining == 0 {
+            self.truncated = true;
+            return Ok(());
+        }
+        let take = batch.num_rows().min(remaining);
+        if batch.num_rows() > remaining {
+            self.truncated = true;
+        }
+
+        for row_idx in 0..take {
+            let mut obj = serde_json::Map::new();
+            for (col_idx, field) in batch.schema().fields().iter().enumerate() {
+                let col = batch.column(col_idx);
+                let val = arrow_value(col.as_ref(), row_idx);
+                obj.insert(field.name().clone(), val);
+            }
+            self.rows.push(Value::Object(obj));
+        }
+        Ok(())
+    }
+
+    async fn on_complete(&mut self, _stats: &QueryStats) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_error(&mut self, message: &str) -> Result<()> {
+        self.error = Some(message.to_string());
+        Ok(())
+    }
+}
+
+/// Convert a single cell from an Arrow array into a `serde_json::Value`.
+/// Falls back to Arrow's display formatting for dates, decimals, and other complex
+/// types — preserves precision as a string rather than lossily coercing to `f64`.
+fn arrow_value(array: &dyn Array, idx: usize) -> Value {
+    if array.is_null(idx) {
+        return Value::Null;
+    }
+    match array.data_type() {
+        DataType::Boolean => {
+            let a = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+            Value::Bool(a.value(idx))
+        }
+        DataType::Int8 => {
+            let a = array.as_any().downcast_ref::<Int8Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::Int16 => {
+            let a = array.as_any().downcast_ref::<Int16Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::Int32 => {
+            let a = array.as_any().downcast_ref::<Int32Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::Int64 => {
+            let a = array.as_any().downcast_ref::<Int64Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::UInt8 => {
+            let a = array.as_any().downcast_ref::<UInt8Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::UInt16 => {
+            let a = array.as_any().downcast_ref::<UInt16Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::UInt32 => {
+            let a = array.as_any().downcast_ref::<UInt32Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::UInt64 => {
+            let a = array.as_any().downcast_ref::<UInt64Array>().unwrap();
+            json!(a.value(idx))
+        }
+        DataType::Float32 => {
+            let a = array.as_any().downcast_ref::<Float32Array>().unwrap();
+            let v = a.value(idx) as f64;
+            Value::Number(serde_json::Number::from_f64(v).unwrap_or(serde_json::Number::from(0)))
+        }
+        DataType::Float64 => {
+            let a = array.as_any().downcast_ref::<Float64Array>().unwrap();
+            let v = a.value(idx);
+            Value::Number(serde_json::Number::from_f64(v).unwrap_or(serde_json::Number::from(0)))
+        }
+        DataType::Utf8 | DataType::LargeUtf8 => {
+            let a = array.as_any().downcast_ref::<StringArray>().unwrap();
+            Value::String(a.value(idx).to_string())
+        }
+        _ => {
+            use arrow::util::display::array_value_to_string;
+            let s = array_value_to_string(array, idx).unwrap_or_else(|_| "<error>".to_string());
+            Value::String(s)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int32Array as I32, StringArray as Str};
+    use arrow::datatypes::{DataType as DT, Field};
+    use std::sync::Arc;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DT::Int32, false),
+            Field::new("name", DT::Utf8, true),
+        ]))
+    }
+
+    #[tokio::test]
+    async fn collects_rows_as_json_objects() {
+        let mut sink = JsonResultSink::new(100);
+        sink.on_schema(&schema()).await.unwrap();
+        let batch = RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(I32::from(vec![1, 2])),
+                Arc::new(Str::from(vec![Some("a"), None])),
+            ],
+        )
+        .unwrap();
+        sink.on_batch(&batch).await.unwrap();
+
+        let result = sink.into_result(5, "duckdb");
+        assert_eq!(result["row_count"], json!(2));
+        assert_eq!(result["truncated"], json!(false));
+        assert_eq!(result["rows"][0]["id"], json!(1));
+        assert_eq!(result["rows"][0]["name"], json!("a"));
+        assert_eq!(result["rows"][1]["name"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn truncates_at_max_rows() {
+        let mut sink = JsonResultSink::new(1);
+        sink.on_schema(&schema()).await.unwrap();
+        let batch = RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(I32::from(vec![1, 2, 3])),
+                Arc::new(Str::from(vec![Some("a"), Some("b"), Some("c")])),
+            ],
+        )
+        .unwrap();
+        sink.on_batch(&batch).await.unwrap();
+
+        assert!(sink.truncated);
+        let result = sink.into_result(5, "duckdb");
+        assert_eq!(result["row_count"], json!(1));
+        assert_eq!(result["truncated"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn on_error_records_message() {
+        let mut sink = JsonResultSink::new(10);
+        sink.on_error("boom").await.unwrap();
+        assert_eq!(sink.error.as_deref(), Some("boom"));
+    }
+}

--- a/crates/queryflux-frontend/src/mcp/sink.rs
+++ b/crates/queryflux-frontend/src/mcp/sink.rs
@@ -1,6 +1,6 @@
 use arrow::array::{
     Array, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-    StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
@@ -138,15 +138,23 @@ fn arrow_value(array: &dyn Array, idx: usize) -> Value {
         DataType::Float32 => {
             let a = array.as_any().downcast_ref::<Float32Array>().unwrap();
             let v = a.value(idx) as f64;
-            Value::Number(serde_json::Number::from_f64(v).unwrap_or(serde_json::Number::from(0)))
+            // NaN / +-infinity have no JSON representation; from_f64 returns None for
+            // them. Emit null rather than silently coercing to a misleading 0.
+            serde_json::Number::from_f64(v).map_or(Value::Null, Value::Number)
         }
         DataType::Float64 => {
             let a = array.as_any().downcast_ref::<Float64Array>().unwrap();
             let v = a.value(idx);
-            Value::Number(serde_json::Number::from_f64(v).unwrap_or(serde_json::Number::from(0)))
+            serde_json::Number::from_f64(v).map_or(Value::Null, Value::Number)
         }
-        DataType::Utf8 | DataType::LargeUtf8 => {
+        DataType::Utf8 => {
             let a = array.as_any().downcast_ref::<StringArray>().unwrap();
+            Value::String(a.value(idx).to_string())
+        }
+        DataType::LargeUtf8 => {
+            // Arrow backs LargeUtf8 with LargeStringArray, not StringArray — downcasting
+            // to StringArray here returns None and unwrap() panics on any LargeUtf8 column.
+            let a = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
             Value::String(a.value(idx).to_string())
         }
         _ => {
@@ -218,5 +226,45 @@ mod tests {
         let mut sink = JsonResultSink::new(10);
         sink.on_error("boom").await.unwrap();
         assert_eq!(sink.error.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn nan_and_infinity_become_null_not_zero() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DT::Float64, false)]));
+        let mut sink = JsonResultSink::new(10);
+        sink.on_schema(&schema).await.unwrap();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Float64Array::from(vec![
+                f64::NAN,
+                f64::INFINITY,
+                f64::NEG_INFINITY,
+                1.5,
+            ]))],
+        )
+        .unwrap();
+        sink.on_batch(&batch).await.unwrap();
+
+        let result = sink.into_result(5, "duckdb");
+        assert_eq!(result["rows"][0]["v"], Value::Null, "NaN should be null");
+        assert_eq!(result["rows"][1]["v"], Value::Null, "+inf should be null");
+        assert_eq!(result["rows"][2]["v"], Value::Null, "-inf should be null");
+        assert_eq!(result["rows"][3]["v"], json!(1.5));
+    }
+
+    #[tokio::test]
+    async fn large_utf8_column_does_not_panic() {
+        let schema = Arc::new(Schema::new(vec![Field::new("v", DT::LargeUtf8, false)]));
+        let mut sink = JsonResultSink::new(10);
+        sink.on_schema(&schema).await.unwrap();
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(LargeStringArray::from(vec!["hello"]))],
+        )
+        .unwrap();
+        sink.on_batch(&batch).await.unwrap();
+
+        let result = sink.into_result(5, "duckdb");
+        assert_eq!(result["rows"][0]["v"], json!("hello"));
     }
 }

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use queryflux_auth::{require_query_owner, AuthContext, Credentials};
 use queryflux_core::{
-    query::{ClusterGroupName, FrontendProtocol, ProxyQueryId},
+    query::{ClusterGroupName, FrontendProtocol, ProxyQueryId, SqlDialect},
     session::{AgentContext, SessionContext},
 };
 use queryflux_routing::ChainRouteResult;
@@ -64,6 +64,15 @@ struct ExecuteQueryParams {
     /// Maximum rows to return (default 1000). Bounds the JSON response size; not a
     /// safety mechanism — configure `row_limit` / `read_only` guards for that.
     max_rows: Option<usize>,
+    /// The SQL dialect `sql` is written in, if it differs from the target engine's own
+    /// dialect. MCP has no wire protocol to infer this from (unlike QueryFlux's other
+    /// frontends), so by default no translation is applied — the SQL is assumed to
+    /// already be in the target engine's dialect, the common case for an agent
+    /// iterating against that engine's own schema/errors. Set this only when the SQL
+    /// was written for a *different* engine and should be translated before routing.
+    /// One of: trino, athena, duckdb, starrocks, clickhouse, mysql, postgres, sqlite,
+    /// snowflake, bigquery, databricks, tsql, redshift, exasol, generic.
+    dialect: Option<String>,
     #[serde(flatten)]
     agent: AgentContextParams,
 }
@@ -96,6 +105,12 @@ struct ExplainQueryParams {
     sql: String,
     /// Preferred cluster group name. Falls back to normal routing when omitted.
     engine_hint: Option<String>,
+    /// The SQL dialect `sql` is written in, if it differs from the target engine's own
+    /// dialect. Defaults to no translation (SQL assumed already correct for the target
+    /// engine) — see `execute_query`'s `dialect` parameter for the full explanation.
+    /// One of: trino, athena, duckdb, starrocks, clickhouse, mysql, postgres, sqlite,
+    /// snowflake, bigquery, databricks, tsql, redshift, exasol, generic.
+    dialect: Option<String>,
     #[serde(flatten)]
     agent: AgentContextParams,
 }
@@ -150,6 +165,28 @@ async fn authenticate(
         .authenticate(&creds)
         .await
         .map_err(|e| McpError::invalid_request(e.to_string(), None))
+}
+
+/// Validate a caller-supplied `dialect` tool parameter against `SqlDialect::KNOWN_DIALECT_NAMES`
+/// and resolve it to the exact string `dispatch::resolve_src_dialect` will hand to sqlglot.
+/// Rejects unknown names outright (an `invalid_params` error listing the valid set) rather
+/// than passing them through as `SqlDialect::Sqlglot(name)` unvalidated — a typo should fail
+/// loudly, not silently be interpreted by sqlglot as some other dialect or fail deep inside
+/// translation with a less useful error.
+fn resolve_dialect_override(dialect: Option<&str>) -> Result<Option<String>, McpError> {
+    let Some(name) = dialect else {
+        return Ok(None);
+    };
+    match SqlDialect::from_known_name(name) {
+        Some(parsed) => Ok(Some(parsed.sqlglot_write_name())),
+        None => Err(McpError::invalid_params(
+            format!(
+                "Unknown dialect: {name:?}. Supported: {}",
+                SqlDialect::KNOWN_DIALECT_NAMES.join(", ")
+            ),
+            None,
+        )),
+    }
 }
 
 /// Merge explicit tool-parameter agent fields with any threaded HTTP headers into an
@@ -331,7 +368,7 @@ impl QueryFluxMcpServer {
 #[tool_router]
 impl QueryFluxMcpServer {
     #[tool(
-        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here."
+        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine."
     )]
     async fn execute_query(
         &self,
@@ -339,14 +376,19 @@ impl QueryFluxMcpServer {
             sql,
             engine_hint,
             max_rows,
+            dialect,
             agent,
         }): Parameters<ExecuteQueryParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        let dialect = resolve_dialect_override(dialect.as_deref())?;
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
-        let session = session_for(&auth, agent_context);
+        let mut session = session_for(&auth, agent_context);
+        if let Some(d) = dialect {
+            session.extra.insert("dialect".to_string(), d);
+        }
         let group =
             resolve_group(&self.state, &sql, &session, engine_hint.as_deref(), &auth).await?;
 
@@ -474,21 +516,26 @@ impl QueryFluxMcpServer {
     }
 
     #[tool(
-        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine."
+        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine."
     )]
     async fn explain_query(
         &self,
         Parameters(ExplainQueryParams {
             sql,
             engine_hint,
+            dialect,
             agent,
         }): Parameters<ExplainQueryParams>,
         ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        let dialect = resolve_dialect_override(dialect.as_deref())?;
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
-        let session = session_for(&auth, agent_context);
+        let mut session = session_for(&auth, agent_context);
+        if let Some(d) = dialect {
+            session.extra.insert("dialect".to_string(), d);
+        }
         let explain_sql = format!("EXPLAIN {sql}");
         let group = resolve_group(
             &self.state,
@@ -647,5 +694,52 @@ impl ServerHandler for QueryFluxMcpServer {
              Authorization: Bearer <token> and flows through QueryFlux's normal routing, \
              translation, and guardrail pipeline — no separate MCP-specific policy layer.",
         )
+    }
+}
+
+#[cfg(test)]
+mod resolve_dialect_override_tests {
+    use super::resolve_dialect_override;
+
+    #[test]
+    fn none_stays_none() {
+        assert_eq!(resolve_dialect_override(None).unwrap(), None);
+    }
+
+    #[test]
+    fn known_name_resolves_to_its_sqlglot_write_name() {
+        assert_eq!(
+            resolve_dialect_override(Some("postgres")).unwrap(),
+            Some("postgres".to_string())
+        );
+        assert_eq!(
+            resolve_dialect_override(Some("BigQuery")).unwrap(),
+            Some("bigquery".to_string())
+        );
+    }
+
+    #[test]
+    fn alias_resolves_to_the_canonical_sqlglot_write_name() {
+        // "postgresql" is an alias for Postgres, but sqlglot's own write name is "postgres".
+        assert_eq!(
+            resolve_dialect_override(Some("postgresql")).unwrap(),
+            Some("postgres".to_string())
+        );
+    }
+
+    #[test]
+    fn generic_resolves_to_empty_string_matching_sqlglots_base_dialect() {
+        assert_eq!(
+            resolve_dialect_override(Some("generic")).unwrap(),
+            Some(String::new())
+        );
+    }
+
+    #[test]
+    fn unknown_name_is_rejected_with_the_known_list_in_the_error() {
+        let err = resolve_dialect_override(Some("not-a-real-dialect")).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("not-a-real-dialect"));
+        assert!(msg.contains("trino"));
     }
 }

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -16,7 +16,7 @@ use rmcp::{
     tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
 };
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -291,6 +291,30 @@ async fn resolve_group(
     }
 }
 
+/// Insert the resolved `conversation_id` into a tool's JSON result, with a short note
+/// telling the caller to reuse it on later calls in this conversation.
+///
+/// MCP has no reliable transport-level way to correlate tool calls within one chat (see
+/// `resolve_agent_context`'s doc comment on why we default `conversation_id` at all), and
+/// asking the agent to *invent and remember* an id itself is unreliable — it can forget
+/// to generate one, or drift onto a different value on a later call. Echoing back
+/// whatever value QueryFlux actually resolved (explicit param, header, or the session/
+/// UUID default) gives the agent a concrete value already in its own context to copy
+/// forward, rather than something to recall from scratch — the same "mint a handle and
+/// have the model pass it back" pattern MCP itself recommends for cross-call state.
+fn attach_conversation_hint(result: &mut Value, conversation_id: &str) {
+    if let Value::Object(map) = result {
+        map.insert("conversation_id".to_string(), json!(conversation_id));
+        map.insert(
+            "_hint".to_string(),
+            json!(
+                "Pass this exact conversation_id on your next QueryFlux tool call in this \
+                 conversation to keep them grouped together."
+            ),
+        );
+    }
+}
+
 /// Run `sql` through the standard dispatch pipeline (routing, translation, guardrails,
 /// execution, persistence) and collect the result as JSON. Every tool goes through this
 /// single path so query history, agent-context, and guard enforcement are identical to
@@ -302,6 +326,7 @@ async fn run_query(
     group: ClusterGroupName,
     auth: &AuthContext,
     max_rows: usize,
+    conversation_id: &str,
 ) -> Result<CallToolResult, McpError> {
     let engine_name = group.0.clone();
     let capped = max_rows.min(ABSOLUTE_MAX_ROWS);
@@ -326,7 +351,8 @@ async fn run_query(
     }
 
     let elapsed = start.elapsed().as_millis() as u64;
-    let result = sink.into_result(elapsed, &engine_name);
+    let mut result = sink.into_result(elapsed, &engine_name);
+    attach_conversation_hint(&mut result, conversation_id);
     Ok(CallToolResult::success(vec![ContentBlock::text(
         serde_json::to_string_pretty(&result).unwrap_or_default(),
     )]))
@@ -368,7 +394,7 @@ impl QueryFluxMcpServer {
 #[tool_router]
 impl QueryFluxMcpServer {
     #[tool(
-        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine."
+        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine. The response includes `conversation_id` — copy that exact value into the `conversation_id` argument on your next QueryFlux tool call in this same conversation, so they're grouped together."
     )]
     async fn execute_query(
         &self,
@@ -385,6 +411,7 @@ impl QueryFluxMcpServer {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
+        let conversation_id = agent_context.conversation_id.clone();
         let mut session = session_for(&auth, agent_context);
         if let Some(d) = dialect {
             session.extra.insert("dialect".to_string(), d);
@@ -400,12 +427,13 @@ impl QueryFluxMcpServer {
             group,
             &auth,
             max_rows.unwrap_or(DEFAULT_MAX_ROWS),
+            &conversation_id,
         )
         .await
     }
 
     #[tool(
-        description = "List available schemas/databases on the routed engine. Queries information_schema.schemata through the normal QueryFlux pipeline — the SQL-standard view every supported engine implements, so this works whether or not dialect translation rewrites it further."
+        description = "List available schemas/databases on the routed engine. Queries information_schema.schemata through the normal QueryFlux pipeline — the SQL-standard view every supported engine implements, so this works whether or not dialect translation rewrites it further. The response includes `conversation_id` — reuse it on your next QueryFlux tool call in this conversation."
     )]
     async fn list_schemas(
         &self,
@@ -415,16 +443,26 @@ impl QueryFluxMcpServer {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
+        let conversation_id = agent_context.conversation_id.clone();
         let session = session_for(&auth, agent_context);
         let sql = "SELECT schema_name FROM information_schema.schemata".to_string();
         let group =
             resolve_group(&self.state, &sql, &session, engine_hint.as_deref(), &auth).await?;
 
-        run_query(&self.state, sql, session, group, &auth, DEFAULT_MAX_ROWS).await
+        run_query(
+            &self.state,
+            sql,
+            session,
+            group,
+            &auth,
+            DEFAULT_MAX_ROWS,
+            &conversation_id,
+        )
+        .await
     }
 
     #[tool(
-        description = "Describe a table's columns (name, type, nullable) and optionally include sample rows in the same call. Runs DESCRIBE <table>, plus a bounded SELECT * ... LIMIT <sample_rows> when sample_rows > 0."
+        description = "Describe a table's columns (name, type, nullable) and optionally include sample rows in the same call. Runs DESCRIBE <table>, plus a bounded SELECT * ... LIMIT <sample_rows> when sample_rows > 0. The response includes `conversation_id` — reuse it on your next QueryFlux tool call in this conversation."
     )]
     async fn describe_table(
         &self,
@@ -440,6 +478,7 @@ impl QueryFluxMcpServer {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
+        let conversation_id = agent_context.conversation_id.clone();
         let qualified = qualify_table(schema.as_deref(), &table);
 
         let describe_session = session_for(&auth, agent_context.clone());
@@ -505,18 +544,19 @@ impl QueryFluxMcpServer {
             None
         };
 
-        let result = json!({
+        let mut result = json!({
             "table": qualified,
             "columns": columns,
             "sample": sample,
         });
+        attach_conversation_hint(&mut result, &conversation_id);
         Ok(CallToolResult::success(vec![ContentBlock::text(
             serde_json::to_string_pretty(&result).unwrap_or_default(),
         )]))
     }
 
     #[tool(
-        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine."
+        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine. The response includes `conversation_id` — reuse it on your next QueryFlux tool call in this conversation."
     )]
     async fn explain_query(
         &self,
@@ -532,6 +572,7 @@ impl QueryFluxMcpServer {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
         let agent_context = resolve_agent_context(&headers, &agent, &auth);
+        let conversation_id = agent_context.conversation_id.clone();
         let mut session = session_for(&auth, agent_context);
         if let Some(d) = dialect {
             session.extra.insert("dialect".to_string(), d);
@@ -553,6 +594,7 @@ impl QueryFluxMcpServer {
             group,
             &auth,
             DEFAULT_MAX_ROWS,
+            &conversation_id,
         )
         .await
     }
@@ -692,7 +734,10 @@ impl ServerHandler for QueryFluxMcpServer {
             "QueryFlux MCP server. Tools: execute_query, list_schemas, describe_table, \
              explain_query, get_query_status, cancel_query. Every tool authenticates via \
              Authorization: Bearer <token> and flows through QueryFlux's normal routing, \
-             translation, and guardrail pipeline — no separate MCP-specific policy layer.",
+             translation, and guardrail pipeline — no separate MCP-specific policy layer. \
+             execute_query/list_schemas/describe_table/explain_query responses include a \
+             conversation_id field: copy that exact value into the conversation_id argument \
+             on every later call in this same conversation, so QueryFlux groups them together.",
         )
     }
 }

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -18,6 +18,7 @@ use rmcp::{
 use serde::Deserialize;
 use serde_json::json;
 use tracing::debug;
+use uuid::Uuid;
 
 use crate::{
     admin::{cancel_executing_query, delete_queued_if_exists, find_executing_query},
@@ -154,10 +155,22 @@ async fn authenticate(
 /// Merge explicit tool-parameter agent fields with any threaded HTTP headers into an
 /// `AgentContext`. Headers win on conflict — reuses `AgentContext::from_headers` exactly
 /// as every other frontend does, fed from a map with both sources' keys present.
+///
+/// MCP is inherently agent-facing traffic, but LLM callers inconsistently fill in the
+/// free-text `agent_id`/`conversation_id` tool params (or omit them), which would
+/// otherwise make the call invisible on the Agents page (it's keyed off
+/// `conversation_id`, and `AgentContext::from_headers` requires both fields or neither).
+/// So unlike every other frontend, MCP never leaves these unset: `agent_id` defaults to
+/// the authenticated identity (`auth.user`, never empty — see `AuthContext::user` docs),
+/// and `conversation_id` defaults to the transport's `Mcp-Session-Id` header when present
+/// (groups every call within one MCP session together), falling back to a fresh UUID per
+/// call when no session id is available (e.g. a stateless transport). Explicit
+/// params/headers still win over both defaults.
 fn resolve_agent_context(
     headers: &HashMap<String, String>,
     params: &AgentContextParams,
-) -> Option<AgentContext> {
+    auth: &AuthContext,
+) -> AgentContext {
     let mut merged = HashMap::new();
     if let Some(v) = &params.agent_id {
         merged.insert("agent_id".to_string(), v.clone());
@@ -177,18 +190,30 @@ fn resolve_agent_context(
     // Headers override same-named tool params (x-agent-id beats agent_id, etc.) because
     // AgentContext::from_headers checks the x-prefixed key first.
     merged.extend(headers.iter().map(|(k, v)| (k.clone(), v.clone())));
+
+    merged
+        .entry("agent_id".to_string())
+        .or_insert_with(|| auth.user.clone());
+    merged.entry("conversation_id".to_string()).or_insert_with(|| {
+        headers
+            .get("mcp-session-id")
+            .cloned()
+            .unwrap_or_else(|| format!("mcp-{}", Uuid::new_v4()))
+    });
+
     AgentContext::from_headers(&merged)
+        .expect("agent_id and conversation_id are populated by the defaults above")
 }
 
 /// `agent_context` must already be the fully-resolved value from `resolve_agent_context`
-/// (headers-vs-params precedence already applied) — setting it here makes
+/// (headers-vs-params precedence and defaults already applied) — setting it here makes
 /// `SessionContext::resolved_agent_context()` return it verbatim, since that method
 /// prefers an explicit `agent_context` over re-parsing `extra`. MCP never populates
 /// `extra`, so that fallback path is unused; do not rely on it for MCP.
-fn session_for(auth: &AuthContext, agent_context: Option<AgentContext>) -> SessionContext {
+fn session_for(auth: &AuthContext, agent_context: AgentContext) -> SessionContext {
     SessionContext {
         user: Some(auth.user.clone()),
-        agent_context,
+        agent_context: Some(agent_context),
         ..Default::default()
     }
 }
@@ -318,7 +343,7 @@ impl QueryFluxMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
-        let agent_context = resolve_agent_context(&headers, &agent);
+        let agent_context = resolve_agent_context(&headers, &agent, &auth);
         let session = session_for(&auth, agent_context);
         let group =
             resolve_group(&self.state, &sql, &session, engine_hint.as_deref(), &auth).await?;
@@ -345,7 +370,7 @@ impl QueryFluxMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
-        let agent_context = resolve_agent_context(&headers, &agent);
+        let agent_context = resolve_agent_context(&headers, &agent, &auth);
         let session = session_for(&auth, agent_context);
         let sql = "SELECT schema_name FROM information_schema.schemata".to_string();
         let group =
@@ -370,7 +395,7 @@ impl QueryFluxMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
-        let agent_context = resolve_agent_context(&headers, &agent);
+        let agent_context = resolve_agent_context(&headers, &agent, &auth);
         let qualified = qualify_table(schema.as_deref(), &table);
 
         let describe_session = session_for(&auth, agent_context.clone());
@@ -460,7 +485,7 @@ impl QueryFluxMcpServer {
     ) -> Result<CallToolResult, McpError> {
         let headers = extract_headers(&ctx);
         let auth = authenticate(&self.state, &headers).await?;
-        let agent_context = resolve_agent_context(&headers, &agent);
+        let agent_context = resolve_agent_context(&headers, &agent, &auth);
         let session = session_for(&auth, agent_context);
         let explain_sql = format!("EXPLAIN {sql}");
         let group = resolve_group(

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -1,0 +1,611 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use queryflux_auth::{require_query_owner, AuthContext, Credentials};
+use queryflux_core::{
+    query::{ClusterGroupName, FrontendProtocol, ProxyQueryId},
+    session::{AgentContext, SessionContext},
+};
+use queryflux_routing::ChainRouteResult;
+use rmcp::{
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
+    schemars,
+    service::RequestContext,
+    tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
+};
+use serde::Deserialize;
+use serde_json::json;
+use tracing::debug;
+
+use crate::{
+    admin::{cancel_executing_query, delete_queued_if_exists, find_executing_query},
+    dispatch::execute_to_sink,
+    mcp::sink::JsonResultSink,
+    state::AppState,
+};
+
+const DEFAULT_MAX_ROWS: usize = 1000;
+const ABSOLUTE_MAX_ROWS: usize = 100_000;
+
+// ---------------------------------------------------------------------------
+// Tool parameter schemas
+// ---------------------------------------------------------------------------
+
+/// Optional agent-identity fields shared by every tool. Explicit "handle as argument"
+/// path per MCP's own guidance for cross-call state (the newer stateless spec revision
+/// deprecates relying on transport session state for this) — works with any MCP client,
+/// including ones that don't support setting custom headers per call. When the caller
+/// *does* send `X-Agent-Id` / `X-Conversation-Id` / etc. headers, those take precedence
+/// over these fields (see `resolve_agent_context`).
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+struct AgentContextParams {
+    /// Stable identifier for the calling agent (e.g. "data-analyst-v2").
+    agent_id: Option<String>,
+    /// Groups queries from one agent session/reasoning chain together.
+    conversation_id: Option<String>,
+    /// Position of this query within the agent's reasoning chain.
+    step_index: Option<u32>,
+    /// The LLM framework's tool-call id that triggered this request.
+    tool_call_id: Option<String>,
+    /// Purpose hint: schema_exploration | aggregation | lookup | mutation | unknown.
+    /// Inferred from the SQL when omitted.
+    query_intent: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ExecuteQueryParams {
+    /// SQL to execute.
+    sql: String,
+    /// Preferred cluster group name. Falls back to normal routing when omitted.
+    engine_hint: Option<String>,
+    /// Maximum rows to return (default 1000). Bounds the JSON response size; not a
+    /// safety mechanism — configure `row_limit` / `read_only` guards for that.
+    max_rows: Option<usize>,
+    #[serde(flatten)]
+    agent: AgentContextParams,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListSchemasParams {
+    /// Preferred cluster group name. Falls back to normal routing when omitted.
+    engine_hint: Option<String>,
+    #[serde(flatten)]
+    agent: AgentContextParams,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct DescribeTableParams {
+    /// Schema/database name, if the engine requires qualification.
+    schema: Option<String>,
+    /// Table name (schema-qualified if `schema` is omitted and qualification is needed).
+    table: String,
+    /// Number of sample rows to include alongside the column metadata (default 0 = none).
+    sample_rows: Option<usize>,
+    /// Preferred cluster group name. Falls back to normal routing when omitted.
+    engine_hint: Option<String>,
+    #[serde(flatten)]
+    agent: AgentContextParams,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ExplainQueryParams {
+    /// SQL to explain (not executed).
+    sql: String,
+    /// Preferred cluster group name. Falls back to normal routing when omitted.
+    engine_hint: Option<String>,
+    #[serde(flatten)]
+    agent: AgentContextParams,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct QueryIdParams {
+    /// The query id returned in an `execute_query` result or `list_engines`-style lookup.
+    query_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Extract lowercased HTTP headers from the underlying request, when running over
+/// streamable HTTP. Empty for transports that don't carry an HTTP request (none in
+/// this build — MCP is HTTP-only here — but this stays defensive rather than panicking).
+fn extract_headers(ctx: &RequestContext<RoleServer>) -> HashMap<String, String> {
+    ctx.extensions
+        .get::<axum::http::request::Parts>()
+        .map(|parts| {
+            parts
+                .headers
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.as_str().to_ascii_lowercase(),
+                        v.to_str().unwrap_or_default().to_string(),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Authenticate the calling MCP client from `Authorization: Bearer <token>`.
+async fn authenticate(
+    state: &AppState,
+    headers: &HashMap<String, String>,
+) -> Result<AuthContext, McpError> {
+    let token = headers
+        .get("authorization")
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|t| t.to_string());
+    let creds = Credentials {
+        username: None,
+        password: None,
+        bearer_token: token,
+    };
+    let auth_provider = state.live.read().await.auth_provider.clone();
+    auth_provider
+        .authenticate(&creds)
+        .await
+        .map_err(|e| McpError::invalid_request(e.to_string(), None))
+}
+
+/// Merge explicit tool-parameter agent fields with any threaded HTTP headers into an
+/// `AgentContext`. Headers win on conflict — reuses `AgentContext::from_headers` exactly
+/// as every other frontend does, fed from a map with both sources' keys present.
+fn resolve_agent_context(
+    headers: &HashMap<String, String>,
+    params: &AgentContextParams,
+) -> Option<AgentContext> {
+    let mut merged = HashMap::new();
+    if let Some(v) = &params.agent_id {
+        merged.insert("agent_id".to_string(), v.clone());
+    }
+    if let Some(v) = &params.conversation_id {
+        merged.insert("conversation_id".to_string(), v.clone());
+    }
+    if let Some(v) = &params.step_index {
+        merged.insert("step_index".to_string(), v.to_string());
+    }
+    if let Some(v) = &params.tool_call_id {
+        merged.insert("tool_call_id".to_string(), v.clone());
+    }
+    if let Some(v) = &params.query_intent {
+        merged.insert("query_intent".to_string(), v.clone());
+    }
+    // Headers override same-named tool params (x-agent-id beats agent_id, etc.) because
+    // AgentContext::from_headers checks the x-prefixed key first.
+    merged.extend(headers.iter().map(|(k, v)| (k.clone(), v.clone())));
+    AgentContext::from_headers(&merged)
+}
+
+fn session_for(auth: &AuthContext, agent_context: Option<AgentContext>) -> SessionContext {
+    SessionContext {
+        user: Some(auth.user.clone()),
+        agent_context,
+        ..Default::default()
+    }
+}
+
+/// Resolve the target cluster group: use `engine_hint` if it names a real group,
+/// otherwise route normally through the configured `RouterChain`.
+async fn resolve_group(
+    state: &AppState,
+    sql: &str,
+    session: &SessionContext,
+    engine_hint: Option<&str>,
+    auth: &AuthContext,
+) -> Result<ClusterGroupName, McpError> {
+    if let Some(hint) = engine_hint {
+        let live = state.live.read().await;
+        if live.group_members.contains_key(hint) {
+            return Ok(ClusterGroupName(hint.to_string()));
+        }
+        return Err(McpError::invalid_params(
+            format!("Unknown engine group: {hint}"),
+            None,
+        ));
+    }
+
+    let decision = {
+        let live = state.live.read().await;
+        live.router_chain
+            .route(sql, session, &FrontendProtocol::Mcp, Some(auth))
+            .await
+    }
+    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    match decision {
+        ChainRouteResult::Routed(group) => Ok(group),
+        ChainRouteResult::Denied { message } => Err(McpError::invalid_request(message, None)),
+    }
+}
+
+/// Run `sql` through the standard dispatch pipeline (routing, translation, guardrails,
+/// execution, persistence) and collect the result as JSON. Every tool goes through this
+/// single path so query history, agent-context, and guard enforcement are identical to
+/// every other QueryFlux frontend.
+async fn run_query(
+    state: &Arc<AppState>,
+    sql: String,
+    session: SessionContext,
+    group: ClusterGroupName,
+    auth: &AuthContext,
+    max_rows: usize,
+) -> Result<CallToolResult, McpError> {
+    let engine_name = group.0.clone();
+    let capped = max_rows.min(ABSOLUTE_MAX_ROWS);
+    let mut sink = JsonResultSink::new(capped);
+    let start = Instant::now();
+
+    execute_to_sink(
+        state,
+        sql,
+        vec![],
+        session,
+        FrontendProtocol::Mcp,
+        group,
+        &mut sink,
+        auth,
+    )
+    .await
+    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+    if let Some(err) = &sink.error {
+        return Ok(CallToolResult::error(vec![ContentBlock::text(err.clone())]));
+    }
+
+    let elapsed = start.elapsed().as_millis() as u64;
+    let result = sink.into_result(elapsed, &engine_name);
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string_pretty(&result).unwrap_or_default(),
+    )]))
+}
+
+/// Best-effort identifier quoting shared by `describe_table` / `list_schemas`. QueryFlux's
+/// translation layer (sqlglot) normalizes the final SQL per target engine, so this only
+/// needs to produce something every dialect's parser accepts going in.
+fn qualify_table(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(s) if !s.is_empty() => format!("{s}.{table}"),
+        _ => table.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server — tool handlers
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct QueryFluxMcpServer {
+    state: Arc<AppState>,
+}
+
+impl QueryFluxMcpServer {
+    pub fn new(state: Arc<AppState>) -> Self {
+        Self { state }
+    }
+}
+
+#[tool_router]
+impl QueryFluxMcpServer {
+    #[tool(
+        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here."
+    )]
+    async fn execute_query(
+        &self,
+        Parameters(ExecuteQueryParams {
+            sql,
+            engine_hint,
+            max_rows,
+            agent,
+        }): Parameters<ExecuteQueryParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+        let agent_context = resolve_agent_context(&headers, &agent);
+        let session = session_for(&auth, agent_context);
+        let group =
+            resolve_group(&self.state, &sql, &session, engine_hint.as_deref(), &auth).await?;
+
+        debug!(sql = %sql, group = %group, "MCP execute_query");
+        run_query(
+            &self.state,
+            sql,
+            session,
+            group,
+            &auth,
+            max_rows.unwrap_or(DEFAULT_MAX_ROWS),
+        )
+        .await
+    }
+
+    #[tool(
+        description = "List available schemas/databases on the routed engine. Queries information_schema.schemata through the normal QueryFlux pipeline — the SQL-standard view every supported engine implements, so this works whether or not dialect translation rewrites it further."
+    )]
+    async fn list_schemas(
+        &self,
+        Parameters(ListSchemasParams { engine_hint, agent }): Parameters<ListSchemasParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+        let agent_context = resolve_agent_context(&headers, &agent);
+        let session = session_for(&auth, agent_context);
+        let sql = "SELECT schema_name FROM information_schema.schemata".to_string();
+        let group =
+            resolve_group(&self.state, &sql, &session, engine_hint.as_deref(), &auth).await?;
+
+        run_query(&self.state, sql, session, group, &auth, DEFAULT_MAX_ROWS).await
+    }
+
+    #[tool(
+        description = "Describe a table's columns (name, type, nullable) and optionally include sample rows in the same call. Runs DESCRIBE <table>, plus a bounded SELECT * ... LIMIT <sample_rows> when sample_rows > 0."
+    )]
+    async fn describe_table(
+        &self,
+        Parameters(DescribeTableParams {
+            schema,
+            table,
+            sample_rows,
+            engine_hint,
+            agent,
+        }): Parameters<DescribeTableParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+        let agent_context = resolve_agent_context(&headers, &agent);
+        let qualified = qualify_table(schema.as_deref(), &table);
+
+        let describe_session = session_for(&auth, agent_context.clone());
+        let describe_sql = format!("DESCRIBE {qualified}");
+        let group = resolve_group(
+            &self.state,
+            &describe_sql,
+            &describe_session,
+            engine_hint.as_deref(),
+            &auth,
+        )
+        .await?;
+
+        let engine_name = group.0.clone();
+        let mut describe_sink = JsonResultSink::new(1_000);
+        let describe_start = Instant::now();
+        execute_to_sink(
+            &self.state,
+            describe_sql,
+            vec![],
+            describe_session,
+            FrontendProtocol::Mcp,
+            group.clone(),
+            &mut describe_sink,
+            &auth,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+        if let Some(err) = &describe_sink.error {
+            return Ok(CallToolResult::error(vec![ContentBlock::text(err.clone())]));
+        }
+        let columns =
+            describe_sink.into_result(describe_start.elapsed().as_millis() as u64, &engine_name);
+
+        let sample_rows = sample_rows.unwrap_or(0);
+        let sample = if sample_rows > 0 {
+            let sample_session = session_for(&auth, agent_context);
+            let sample_sql = format!("SELECT * FROM {qualified} LIMIT {sample_rows}");
+            let mut sample_sink = JsonResultSink::new(sample_rows);
+            let sample_start = Instant::now();
+            execute_to_sink(
+                &self.state,
+                sample_sql,
+                vec![],
+                sample_session,
+                FrontendProtocol::Mcp,
+                group,
+                &mut sample_sink,
+                &auth,
+            )
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            if let Some(err) = &sample_sink.error {
+                Some(json!({ "error": err }))
+            } else {
+                Some(
+                    sample_sink
+                        .into_result(sample_start.elapsed().as_millis() as u64, &engine_name),
+                )
+            }
+        } else {
+            None
+        };
+
+        let result = json!({
+            "table": qualified,
+            "columns": columns,
+            "sample": sample,
+        });
+        Ok(CallToolResult::success(vec![ContentBlock::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[tool(
+        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine."
+    )]
+    async fn explain_query(
+        &self,
+        Parameters(ExplainQueryParams {
+            sql,
+            engine_hint,
+            agent,
+        }): Parameters<ExplainQueryParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+        let agent_context = resolve_agent_context(&headers, &agent);
+        let session = session_for(&auth, agent_context);
+        let explain_sql = format!("EXPLAIN {sql}");
+        let group = resolve_group(
+            &self.state,
+            &explain_sql,
+            &session,
+            engine_hint.as_deref(),
+            &auth,
+        )
+        .await?;
+
+        run_query(
+            &self.state,
+            explain_sql,
+            session,
+            group,
+            &auth,
+            DEFAULT_MAX_ROWS,
+        )
+        .await
+    }
+
+    #[tool(
+        description = "Check the status of a query submitted via execute_query. Only reports on queries still running or queued — QueryFlux does not currently retain a lookup-by-id history of completed queries, so a finished query reports as not_found_or_completed."
+    )]
+    async fn get_query_status(
+        &self,
+        Parameters(QueryIdParams { query_id }): Parameters<QueryIdParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+
+        if let Some(executing) = find_executing_query(self.state.persistence.as_ref(), &query_id)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        {
+            require_query_owner(&auth, &executing.submitted_by)
+                .map_err(|e| McpError::invalid_request(e.to_string(), None))?;
+            let result = json!({
+                "query_id": query_id,
+                "status": "running",
+                "cluster_group": executing.cluster_group.0,
+                "cluster": executing.cluster_name.0,
+                "sql_preview": executing.sql.chars().take(200).collect::<String>(),
+            });
+            return Ok(CallToolResult::success(vec![ContentBlock::text(
+                serde_json::to_string_pretty(&result).unwrap_or_default(),
+            )]));
+        }
+
+        if let Some(queued) = self
+            .state
+            .persistence
+            .get_queued(&ProxyQueryId(query_id.clone()))
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        {
+            require_query_owner(&auth, &queued.submitted_by)
+                .map_err(|e| McpError::invalid_request(e.to_string(), None))?;
+            let result = json!({
+                "query_id": query_id,
+                "status": "queued",
+                "cluster_group": queued.cluster_group.0,
+                "sql_preview": queued.sql.chars().take(200).collect::<String>(),
+            });
+            return Ok(CallToolResult::success(vec![ContentBlock::text(
+                serde_json::to_string_pretty(&result).unwrap_or_default(),
+            )]));
+        }
+
+        let result = json!({
+            "query_id": query_id,
+            "status": "not_found_or_completed",
+        });
+        Ok(CallToolResult::success(vec![ContentBlock::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[tool(
+        description = "Cancel a query submitted via execute_query, whether it is still queued or already running on a backend. Only the agent/user that submitted the query may cancel it."
+    )]
+    async fn cancel_query(
+        &self,
+        Parameters(QueryIdParams { query_id }): Parameters<QueryIdParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let headers = extract_headers(&ctx);
+        let auth = authenticate(&self.state, &headers).await?;
+
+        if let Some(executing) = find_executing_query(self.state.persistence.as_ref(), &query_id)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        {
+            require_query_owner(&auth, &executing.submitted_by)
+                .map_err(|e| McpError::invalid_request(e.to_string(), None))?;
+            cancel_executing_query(
+                &self.state,
+                FrontendProtocol::Mcp,
+                &executing,
+                "mcp cancelled",
+            )
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+            return Ok(CallToolResult::success(vec![ContentBlock::text(
+                json!({ "query_id": query_id, "status": "cancelled" }).to_string(),
+            )]));
+        }
+
+        if let Some(queued) = delete_queued_if_exists(self.state.persistence.as_ref(), &query_id)
+            .await
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?
+        {
+            require_query_owner(&auth, &queued.submitted_by)
+                .map_err(|e| McpError::invalid_request(e.to_string(), None))?;
+            self.state.record_queued_terminal(
+                &queued,
+                queryflux_core::query::QueryStatus::Cancelled,
+                "mcp cancelled",
+            );
+            // A worker may have claimed and started executing between the two lookups.
+            if let Some(executing) =
+                find_executing_query(self.state.persistence.as_ref(), &query_id)
+                    .await
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?
+            {
+                require_query_owner(&auth, &executing.submitted_by)
+                    .map_err(|e| McpError::invalid_request(e.to_string(), None))?;
+                cancel_executing_query(
+                    &self.state,
+                    FrontendProtocol::Mcp,
+                    &executing,
+                    "mcp cancelled",
+                )
+                .await
+                .map_err(|e| McpError::internal_error(e, None))?;
+            }
+            return Ok(CallToolResult::success(vec![ContentBlock::text(
+                json!({ "query_id": query_id, "status": "cancelled" }).to_string(),
+            )]));
+        }
+
+        Err(McpError::invalid_params(
+            format!("query not found: {query_id}"),
+            None,
+        ))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for QueryFluxMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "QueryFlux MCP server. Tools: execute_query, list_schemas, describe_table, \
+             explain_query, get_query_status, cancel_query. Every tool authenticates via \
+             Authorization: Bearer <token> and flows through QueryFlux's normal routing, \
+             translation, and guardrail pipeline — no separate MCP-specific policy layer.",
+        )
+    }
+}

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -194,12 +194,14 @@ fn resolve_agent_context(
     merged
         .entry("agent_id".to_string())
         .or_insert_with(|| auth.user.clone());
-    merged.entry("conversation_id".to_string()).or_insert_with(|| {
-        headers
-            .get("mcp-session-id")
-            .cloned()
-            .unwrap_or_else(|| format!("mcp-{}", Uuid::new_v4()))
-    });
+    merged
+        .entry("conversation_id".to_string())
+        .or_insert_with(|| {
+            headers
+                .get("mcp-session-id")
+                .cloned()
+                .unwrap_or_else(|| format!("mcp-{}", Uuid::new_v4()))
+        });
 
     AgentContext::from_headers(&merged)
         .expect("agent_id and conversation_id are populated by the defaults above")

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -137,7 +137,7 @@ async fn authenticate(
 ) -> Result<AuthContext, McpError> {
     let token = headers
         .get("authorization")
-        .and_then(|v| v.strip_prefix("Bearer "))
+        .and_then(|v| crate::strip_bearer_prefix(v))
         .map(|t| t.to_string());
     let creds = Credentials {
         username: None,

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -180,6 +180,11 @@ fn resolve_agent_context(
     AgentContext::from_headers(&merged)
 }
 
+/// `agent_context` must already be the fully-resolved value from `resolve_agent_context`
+/// (headers-vs-params precedence already applied) — setting it here makes
+/// `SessionContext::resolved_agent_context()` return it verbatim, since that method
+/// prefers an explicit `agent_context` over re-parsing `extra`. MCP never populates
+/// `extra`, so that fallback path is unused; do not rely on it for MCP.
 fn session_for(auth: &AuthContext, agent_context: Option<AgentContext>) -> SessionContext {
     SessionContext {
         user: Some(auth.user.clone()),
@@ -263,13 +268,21 @@ async fn run_query(
     )]))
 }
 
-/// Best-effort identifier quoting shared by `describe_table` / `list_schemas`. QueryFlux's
-/// translation layer (sqlglot) normalizes the final SQL per target engine, so this only
-/// needs to produce something every dialect's parser accepts going in.
+/// Quote a single identifier ANSI-style (double quotes, embedded `"` doubled). Used by
+/// `qualify_table` so a `table`/`schema` argument containing a space, reserved word, or
+/// `;` stays a single identifier rather than producing unintended SQL — the caller can
+/// already run arbitrary SQL via `execute_query`, so this isn't a privilege boundary,
+/// just correctness. QueryFlux's translation layer (sqlglot) re-quotes per target engine
+/// dialect (backticks for MySQL-family, etc.), so ANSI double-quoting on the way in is
+/// the right canonical form regardless of the final backend.
+fn quote_ident(ident: &str) -> String {
+    format!("\"{}\"", ident.replace('"', "\"\""))
+}
+
 fn qualify_table(schema: Option<&str>, table: &str) -> String {
     match schema {
-        Some(s) if !s.is_empty() => format!("{s}.{table}"),
-        _ => table.to_string(),
+        Some(s) if !s.is_empty() => format!("{}.{}", quote_ident(s), quote_ident(table)),
+        _ => quote_ident(table),
     }
 }
 

--- a/crates/queryflux-frontend/src/mcp/tools.rs
+++ b/crates/queryflux-frontend/src/mcp/tools.rs
@@ -66,12 +66,13 @@ struct ExecuteQueryParams {
     max_rows: Option<usize>,
     /// The SQL dialect `sql` is written in, if it differs from the target engine's own
     /// dialect. MCP has no wire protocol to infer this from (unlike QueryFlux's other
-    /// frontends), so by default no translation is applied — the SQL is assumed to
-    /// already be in the target engine's dialect, the common case for an agent
-    /// iterating against that engine's own schema/errors. Set this only when the SQL
-    /// was written for a *different* engine and should be translated before routing.
-    /// One of: trino, athena, duckdb, starrocks, clickhouse, mysql, postgres, sqlite,
-    /// snowflake, bigquery, databricks, tsql, redshift, exasol, generic.
+    /// frontends), so by default no translation is attempted at all — sqlglot is never
+    /// invoked, and the SQL is sent to the target engine exactly as written. This is a
+    /// deliberate no-op, not an assumption that the SQL already matches the target
+    /// engine. Set this when the SQL was written for a *different* engine and should be
+    /// translated before routing. One of: trino, athena, duckdb, starrocks, clickhouse,
+    /// mysql, postgres, sqlite, snowflake, bigquery, databricks, tsql, redshift, exasol,
+    /// generic.
     dialect: Option<String>,
     #[serde(flatten)]
     agent: AgentContextParams,
@@ -106,10 +107,10 @@ struct ExplainQueryParams {
     /// Preferred cluster group name. Falls back to normal routing when omitted.
     engine_hint: Option<String>,
     /// The SQL dialect `sql` is written in, if it differs from the target engine's own
-    /// dialect. Defaults to no translation (SQL assumed already correct for the target
-    /// engine) — see `execute_query`'s `dialect` parameter for the full explanation.
-    /// One of: trino, athena, duckdb, starrocks, clickhouse, mysql, postgres, sqlite,
-    /// snowflake, bigquery, databricks, tsql, redshift, exasol, generic.
+    /// dialect. Defaults to skipping translation entirely (sqlglot is never invoked) —
+    /// see `execute_query`'s `dialect` parameter for the full explanation. One of: trino,
+    /// athena, duckdb, starrocks, clickhouse, mysql, postgres, sqlite, snowflake,
+    /// bigquery, databricks, tsql, redshift, exasol, generic.
     dialect: Option<String>,
     #[serde(flatten)]
     agent: AgentContextParams,
@@ -394,7 +395,7 @@ impl QueryFluxMcpServer {
 #[tool_router]
 impl QueryFluxMcpServer {
     #[tool(
-        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine. The response includes `conversation_id` — copy that exact value into the `conversation_id` argument on your next QueryFlux tool call in this same conversation, so they're grouped together."
+        description = "Execute a SQL query against a QueryFlux-routed engine. Returns rows as JSON objects keyed by column name, truncated at max_rows (default 1000). Row-level safety policy (read-only, row limits, etc.) is whatever the operator has configured via QueryFlux guardrails — not enforced here. By default no dialect translation is attempted at all (sqlglot is never invoked); set `dialect` if the SQL was written for a different engine than the one it's routed to. The response includes `conversation_id` — copy that exact value into the `conversation_id` argument on your next QueryFlux tool call in this same conversation, so they're grouped together."
     )]
     async fn execute_query(
         &self,
@@ -556,7 +557,7 @@ impl QueryFluxMcpServer {
     }
 
     #[tool(
-        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine. By default the SQL is assumed to already be written for the target engine (no translation); set `dialect` if it was written for a different engine. The response includes `conversation_id` — reuse it on your next QueryFlux tool call in this conversation."
+        description = "Return the query plan for a SQL statement without executing it. Runs EXPLAIN <sql> on the routed engine. By default no dialect translation is attempted at all (sqlglot is never invoked); set `dialect` if the SQL was written for a different engine than the one it's routed to. The response includes `conversation_id` — reuse it on your next QueryFlux tool call in this conversation."
     )]
     async fn explain_query(
         &self,

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -406,7 +406,7 @@ async fn authenticate(
     let bearer = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "))
+        .and_then(crate::strip_bearer_prefix)
         .map(|s| s.to_string());
 
     let auth_provider = state.live.read().await.auth_provider.clone();

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -675,7 +675,7 @@ fn extract_credentials(headers: &HeaderMap) -> Credentials {
                 }
             }
         }
-        if let Some(token) = auth.strip_prefix("Bearer ") {
+        if let Some(token) = crate::strip_bearer_prefix(auth) {
             return Credentials {
                 username: None,
                 password: None,

--- a/crates/queryflux-persistence/src/routing_json.rs
+++ b/crates/queryflux-persistence/src/routing_json.rs
@@ -17,6 +17,7 @@ pub const PROTO_CAMEL_SNAKE: &[(&str, &str)] = &[
     ("flightSql", "flight_sql"),
     ("snowflakeHttp", "snowflake_http"),
     ("snowflakeSqlApi", "snowflake_sql_api"),
+    ("mcp", "mcp"),
 ];
 
 pub fn field<'a>(v: &'a Value, camel: &str, snake: &str) -> Option<&'a Value> {
@@ -509,6 +510,7 @@ mod tests {
             flight_sql: Some("g".into()),
             snowflake_http: Some("g".into()),
             snowflake_sql_api: Some("g".into()),
+            mcp: Some("g".into()),
         };
         let serialized = serde_json::to_value(&all_set).unwrap();
         let obj = serialized.as_object().unwrap();
@@ -542,6 +544,7 @@ mod tests {
             ("flightSql", "flight_sql"),
             ("snowflakeHttp", "snowflake_http"),
             ("snowflakeSqlApi", "snowflake_sql_api"),
+            ("mcp", "mcp"),
         ]
         .into_iter()
         .collect();

--- a/crates/queryflux-routing/src/implementations/protocol_based.rs
+++ b/crates/queryflux-routing/src/implementations/protocol_based.rs
@@ -18,6 +18,7 @@ pub struct ProtocolBasedRouter {
     pub flight_sql: Option<ClusterGroupName>,
     pub snowflake_http: Option<ClusterGroupName>,
     pub snowflake_sql_api: Option<ClusterGroupName>,
+    pub mcp: Option<ClusterGroupName>,
 }
 
 #[async_trait]
@@ -41,6 +42,7 @@ impl RouterTrait for ProtocolBasedRouter {
             FrontendProtocol::FlightSql => self.flight_sql.clone(),
             FrontendProtocol::SnowflakeHttp => self.snowflake_http.clone(),
             FrontendProtocol::SnowflakeSqlApi => self.snowflake_sql_api.clone(),
+            FrontendProtocol::Mcp => self.mcp.clone(),
         };
         Ok(group.into())
     }

--- a/crates/queryflux-routing/src/implementations/python_script.rs
+++ b/crates/queryflux-routing/src/implementations/python_script.rs
@@ -74,6 +74,7 @@ fn protocol_camel(p: FrontendProtocol) -> &'static str {
         FrontendProtocol::FlightSql => "flightSql",
         FrontendProtocol::SnowflakeHttp => "snowflakeHttp",
         FrontendProtocol::SnowflakeSqlApi => "snowflakeSqlApi",
+        FrontendProtocol::Mcp => "mcp",
     }
 }
 

--- a/crates/queryflux-routing/tests/router_tests.rs
+++ b/crates/queryflux-routing/tests/router_tests.rs
@@ -331,6 +331,30 @@ async fn protocol_router_snowflake_sql_api() {
     assert_eq!(result, RoutingDecision::Route(group("sf-rest")));
 }
 
+#[tokio::test]
+async fn protocol_router_mcp() {
+    let router = ProtocolBasedRouter {
+        trino_http: None,
+        postgres_wire: None,
+        mysql_wire: None,
+        clickhouse_http: None,
+        flight_sql: None,
+        snowflake_http: None,
+        snowflake_sql_api: None,
+        mcp: Some(group("agent-queries")),
+    };
+    let result = router
+        .route(
+            "SELECT 1",
+            &mysql_session(Some("u")),
+            &FrontendProtocol::Mcp,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result, RoutingDecision::Route(group("agent-queries")));
+}
+
 // ---------------------------------------------------------------------------
 // TagsRouter
 // ---------------------------------------------------------------------------

--- a/crates/queryflux-routing/tests/router_tests.rs
+++ b/crates/queryflux-routing/tests/router_tests.rs
@@ -152,6 +152,7 @@ async fn protocol_router_trino_http() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     let session = trino_session(&[]);
     let result = router
@@ -171,6 +172,7 @@ async fn protocol_router_postgres_wire() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     let result = router
         .route(
@@ -194,6 +196,7 @@ async fn protocol_router_unconfigured() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     let result = router
         .route(
@@ -217,6 +220,7 @@ async fn protocol_router_mysql_wire() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     let result = router
         .route(
@@ -240,6 +244,7 @@ async fn protocol_router_clickhouse_http() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     let result = router
         .route(
@@ -263,6 +268,7 @@ async fn protocol_router_flight_sql() {
         flight_sql: Some(group("sf-analytics")),
         snowflake_http: None,
         snowflake_sql_api: None,
+        mcp: None,
     };
     // `ProtocolBasedRouter` routes on frontend protocol only (session is ignored).
     let result = router
@@ -287,6 +293,7 @@ async fn protocol_router_snowflake_http() {
         flight_sql: None,
         snowflake_http: Some(group("sf-wire")),
         snowflake_sql_api: None,
+        mcp: None,
     };
     let result = router
         .route(
@@ -310,6 +317,7 @@ async fn protocol_router_snowflake_sql_api() {
         flight_sql: None,
         snowflake_http: None,
         snowflake_sql_api: Some(group("sf-rest")),
+        mcp: None,
     };
     let result = router
         .route(
@@ -1111,6 +1119,7 @@ async fn chain_protocol_based_then_header_fallback() {
                 flight_sql: None,
                 snowflake_http: None,
                 snowflake_sql_api: None,
+                mcp: None,
             }),
             Box::new(HeaderRouter::new(
                 "x-tenant".to_string(),

--- a/crates/queryflux-translation/tests/transform_scripts.rs
+++ b/crates/queryflux-translation/tests/transform_scripts.rs
@@ -182,3 +182,27 @@ def transform(ast, src, dst):
         "unexpected message: {msg}"
     );
 }
+
+/// Real cross-dialect proof for the MCP `dialect` parameter's whole reason to exist:
+/// MySQL quotes identifiers with backticks; DuckDB expects ANSI double quotes. This is
+/// the exact rewrite `dispatch::should_attempt_translation` gates on for MCP — this test
+/// exercises the actual sqlglot call directly (the e2e MCP suite can't: its test harness
+/// uses `TranslationService::disabled()`, same as every other e2e harness, so it never
+/// invokes real translation).
+#[tokio::test]
+async fn mysql_backtick_identifiers_translate_to_duckdb_double_quotes() {
+    require_sqlglot();
+    let t = SqlglotTranslator::new(SqlDialect::MySql, SqlDialect::DuckDb, vec![]);
+    let out = t
+        .translate("SELECT 1 AS `n`", &SchemaContext::default())
+        .await
+        .expect("translate");
+    assert!(
+        !out.contains('`'),
+        "expected backticks rewritten for DuckDB, got: {out}"
+    );
+    assert!(
+        out.contains("\"n\"") || out.contains(" n"),
+        "expected the alias to survive translation, got: {out}"
+    );
+}

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -17,6 +17,7 @@ use queryflux_frontend::{
         SecurityConfigDto as AdminSecurityConfigDto, TestClusterFn,
     },
     flight_sql::FlightSqlFrontend,
+    mcp::McpFrontend,
     mysql_wire::MysqlWireFrontend,
     postgres_wire::PostgresWireFrontend,
     snowflake::SnowflakeFrontend,
@@ -684,6 +685,7 @@ async fn main() -> Result<()> {
                 flight_sql,
                 snowflake_http,
                 snowflake_sql_api,
+                mcp,
             } => {
                 routers.push(Box::new(ProtocolBasedRouter {
                     trino_http: trino_http.as_ref().map(|s| ClusterGroupName(s.clone())),
@@ -697,6 +699,7 @@ async fn main() -> Result<()> {
                     snowflake_sql_api: snowflake_sql_api
                         .as_ref()
                         .map(|s| ClusterGroupName(s.clone())),
+                    mcp: mcp.as_ref().map(|s| ClusterGroupName(s.clone())),
                 }));
             }
             RouterConfig::Header {
@@ -1994,6 +1997,21 @@ async fn main() -> Result<()> {
             }
         }
     });
+    let mut mcp_handle = tokio::spawn({
+        let state = app_state.clone();
+        let rx = shutdown_rx.clone();
+        let cfg = config.queryflux.frontends.mcp.clone();
+        async move {
+            match cfg {
+                Some(c) if c.enabled => {
+                    McpFrontend::new(state, c.port, c.max_connections)
+                        .listen(rx)
+                        .await
+                }
+                _ => std::future::pending::<queryflux_core::error::Result<()>>().await,
+            }
+        }
+    });
 
     // Wait for either a shutdown signal or an unexpected frontend exit.
     let shutdown_signal = async {
@@ -2023,6 +2041,7 @@ async fn main() -> Result<()> {
         r = &mut postgres_handle => { if let Ok(Err(e)) = r { tracing::error!("Postgres wire exited unexpectedly: {e}"); } },
         r = &mut flight_sql_handle => { if let Ok(Err(e)) = r { tracing::error!("Flight SQL exited unexpectedly: {e}"); } },
         r = &mut snowflake_handle => { if let Ok(Err(e)) = r { tracing::error!("Snowflake exited unexpectedly: {e}"); } },
+        r = &mut mcp_handle => { if let Ok(Err(e)) = r { tracing::error!("MCP exited unexpectedly: {e}"); } },
     }
 
     // --- Phase 1: signal all frontends to stop accepting new connections ---
@@ -2045,6 +2064,7 @@ async fn main() -> Result<()> {
             postgres_handle,
             flight_sql_handle,
             snowflake_handle,
+            mcp_handle,
         );
 
         // Poll persistence until no executing or queued queries remain (or until
@@ -2278,8 +2298,9 @@ fn validate_live_config_refs(
                 flight_sql,
                 snowflake_http,
                 snowflake_sql_api,
+                mcp,
             } => {
-                let opts: [Option<&str>; 7] = [
+                let opts: [Option<&str>; 8] = [
                     trino_http.as_deref(),
                     postgres_wire.as_deref(),
                     mysql_wire.as_deref(),
@@ -2287,6 +2308,7 @@ fn validate_live_config_refs(
                     flight_sql.as_deref(),
                     snowflake_http.as_deref(),
                     snowflake_sql_api.as_deref(),
+                    mcp.as_deref(),
                 ];
                 refs.extend(opts.into_iter().flatten());
             }
@@ -2747,6 +2769,7 @@ async fn build_live_config(
                 flight_sql,
                 snowflake_http,
                 snowflake_sql_api,
+                mcp,
             } => {
                 routers.push(Box::new(
                     queryflux_routing::implementations::protocol_based::ProtocolBasedRouter {
@@ -2763,6 +2786,7 @@ async fn build_live_config(
                         snowflake_sql_api: snowflake_sql_api
                             .as_ref()
                             .map(|s| ClusterGroupName(s.clone())),
+                        mcp: mcp.as_ref().map(|s| ClusterGroupName(s.clone())),
                     },
                 ));
             }

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ Several stacks for **QueryFlux** + **Trino** (and optional add-ons). Run command
 |--------|----------|----------|
 | [`minimal/`](minimal-trino/) | Yes | Full Studio (query history, persisted clusters/groups/routing via API), production-like persistence |
 | [`minimal-inmemory/`](minimal-inmemory/) | No | Fastest local tryout; config only in `config.yaml`; no shared query history |
+| [`with-mcp/`](with-mcp/) | No | MCP frontend + embedded DuckDB — point an AI agent (Cursor, Claude Code, MCP Inspector, ...) at QueryFlux with zero external services |
 | [`with-prometheus-grafana/`](with-prometheus-grafana/) | Yes | Same workload as minimal + **Prometheus** + **Grafana** (repo [`grafana/`](../grafana/), local scrape config); **no Studio** |
 | [`full-stack/`](full-stack/) | Yes (host **5433**) | Trino + StarRocks + Iceberg/Lakekeeper + MinIO + TPCH loader |
 | [`full-stack-with-prometheus-grafana/`](full-stack-with-prometheus-grafana/) | Yes (host **5433**) | **`full-stack`** + **Prometheus** + **Grafana**; Grafana on **3001** |
@@ -48,6 +49,23 @@ docker compose up -d --wait
 |---------|-----|
 | SQL (Trino via QueryFlux) | http://localhost:8080 |
 | Trino (direct) | http://localhost:8081 |
+| Admin API | http://localhost:9000 |
+| Studio | http://localhost:3000 |
+
+---
+
+## With MCP (`with-mcp/`)
+
+**QueryFlux** with the **MCP frontend** enabled, backed by the **embedded DuckDB** engine — no Trino, no Postgres, nothing else to run. `persistence.type: inMemory` and `auth.provider: none`, same tradeoffs as `minimal-inmemory/`. Point an MCP client (Cursor, Claude Code, Claude Desktop, MCP Inspector) at the server and start running SQL through an agent immediately. Details: [`with-mcp/README.md`](with-mcp/README.md).
+
+```bash
+cd examples/with-mcp
+docker compose up -d --wait
+```
+
+| Service | URL |
+|---------|-----|
+| MCP endpoint (streamable HTTP) | http://localhost:8811/mcp |
 | Admin API | http://localhost:9000 |
 | Studio | http://localhost:3000 |
 

--- a/examples/with-mcp/README.md
+++ b/examples/with-mcp/README.md
@@ -1,0 +1,93 @@
+# QueryFlux + MCP
+
+The MCP (Model Context Protocol) frontend, backed by the embedded DuckDB engine — no
+Trino, Postgres, or any other external service. The fastest way to go from zero to
+"an AI agent is running SQL through QueryFlux."
+
+This example runs with `auth.provider: none` for simplicity. See
+**[Authentication](../../website/docs/authentication.md)** for real deployments
+(`oidc`, `static`, `ldap`), and
+**[`examples/with-keycloak-oidc`](../with-keycloak-oidc/)** for a runnable OIDC setup —
+the same pattern applies to the MCP frontend, just point an MCP client's `Authorization`
+header at a token from your IdP instead of `none`.
+
+## What's included
+
+| Service | URL |
+|---------|-----|
+| MCP endpoint (streamable HTTP) | `http://localhost:8811/mcp` |
+| Admin API | `http://localhost:9000` |
+| Studio | `http://localhost:3000` |
+
+There's no bearer token to configure — `auth.provider: none` accepts any (or no)
+`Authorization` header.
+
+## Start
+
+```bash
+docker compose up -d --wait
+```
+
+## Connect a client
+
+Full setup instructions (Cursor, Claude Code, Claude Desktop, MCP Inspector, generic
+`mcpServers` config) are in
+**[the MCP frontend docs](../../website/docs/architecture/frontends/mcp.md#connecting-a-client)**.
+Point any of them at `http://localhost:8811/mcp` — since this example has no auth, you
+can omit the `Authorization` header entirely, or set it to any placeholder value.
+
+Quickest check, with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector
+# Transport: Streamable HTTP
+# URL: http://localhost:8811/mcp
+```
+
+## Try it
+
+Once connected, ask your agent to run something like:
+
+> Create a table called `orders` with a few sample rows, describe its columns, then
+> show me everything in it.
+
+That exercises `execute_query` (CREATE + INSERT), `describe_table`, and `execute_query`
+again (SELECT) in sequence — a good first look at all six tools working together. Or run
+the same steps directly against `execute_query` yourself via the Inspector:
+
+```sql
+CREATE TABLE orders AS
+SELECT * FROM (VALUES (1, 'widget', 9.99), (2, 'gadget', 19.99)) AS t(id, name, price);
+```
+
+```sql
+SELECT * FROM orders;
+```
+
+DuckDB here is in-memory and process-local — data doesn't survive `docker compose down`,
+and (since `persistence.type: inMemory` too) query history and routing config live only
+in the running process, same as every `minimal-inmemory`-style example.
+
+## Explore query history in Studio
+
+Open **http://localhost:3000** — MCP-originated queries show up on the **Queries** page
+like any other frontend's traffic, and (once you set `agent_id`/`conversation_id`, either
+via tool parameters or letting them default) on the **Agents** and **Conversations**
+pages too. See
+**[Session replay and guardrails](../../website/docs/agentic/session-replay.md)**
+for what gets persisted.
+
+## Add guardrails
+
+Nothing here restricts what an agent can run — no read-only enforcement, no row caps.
+That's deliberate: guardrails are configured the same way for MCP as for every other
+frontend, not baked into the frontend itself. See
+**[Guardrails](../../website/docs/architecture/guardrails.md)** for `read_only`,
+`row_limit`, and other guard types, and add a `guardrails:` block to `config.yaml` to
+try one against this stack.
+
+## Stop
+
+```bash
+docker compose down
+```

--- a/examples/with-mcp/config.yaml
+++ b/examples/with-mcp/config.yaml
@@ -1,0 +1,40 @@
+# MCP frontend against the embedded DuckDB engine — no external database or
+# container needed. Good enough to point an MCP client (Cursor, Claude Code, MCP
+# Inspector, ...) at and start running SQL through an AI agent immediately.
+#
+# auth.provider: none / required: false is fine for this local demo only — see
+# https://queryflux.dev/docs/authentication for real deployments (oidc/static/ldap).
+
+queryflux:
+  externalAddress: http://localhost:8811
+  frontends:
+    trinoHttp:
+      enabled: false
+      port: 8080
+    mcp:
+      enabled: true
+      port: 8811
+  persistence:
+    type: inMemory
+  adminApi:
+    port: 9000
+  auth:
+    provider: none
+    required: false
+
+clusters:
+  duckdb-1:
+    engine: duckDb
+    enabled: true
+
+clusterGroups:
+  duckdb-local:
+    enabled: true
+    maxRunningQueries: 4
+    members: [duckdb-1]
+
+routers:
+  - type: protocolBased
+    mcp: duckdb-local
+
+routingFallback: duckdb-local

--- a/examples/with-mcp/docker-compose.yml
+++ b/examples/with-mcp/docker-compose.yml
@@ -1,0 +1,39 @@
+# QueryFlux with the MCP frontend enabled, backed by the embedded DuckDB engine.
+# No Trino/Postgres/etc. — this is the fastest path from zero to "point an MCP
+# client at QueryFlux."
+#
+# From this directory:
+#   docker compose up -d --wait
+#
+# MCP endpoint (streamable HTTP): http://localhost:8811/mcp
+# Admin API: http://localhost:9000 · Studio: http://localhost:3000
+
+name: queryflux-example-with-mcp
+
+services:
+  queryflux:
+    image: ghcr.io/lakeops-org/queryflux:latest
+    ports:
+      - "8811:8811"
+      - "9000:9000"
+    volumes:
+      - ./config.yaml:/etc/queryflux/config.yaml:ro
+    environment:
+      RUST_LOG: ${RUST_LOG:-queryflux=info,queryflux_frontend=info}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 15s
+    restart: unless-stopped
+
+  queryflux-studio:
+    image: 343959804465.dkr.ecr.us-east-1.amazonaws.com/queryflux-studio:latest
+    ports:
+      - "3000:3000"
+    environment:
+      ADMIN_API_URL: http://queryflux:9000
+    depends_on:
+      - queryflux
+    restart: unless-stopped

--- a/website/docs/agentic/agent-context.md
+++ b/website/docs/agentic/agent-context.md
@@ -17,7 +17,7 @@ All three approaches use the same underlying fields and produce identical record
 
 ## Setting context via HTTP headers
 
-HTTP frontends accept agentic context as request headers. Both `X-Agent-Id` and `X-Conversation-Id` must be present to activate agentic context — if either is missing the query is treated as a non-agentic request.
+HTTP frontends accept agentic context as request headers. Both `X-Agent-Id` and `X-Conversation-Id` must be present to activate agentic context — if either is missing the query is treated as a non-agentic request. **MCP is the one exception** — see [Agent context defaults on MCP](#agent-context-defaults-on-mcp) below.
 
 | Header | Required | Description |
 |--------|----------|-------------|
@@ -102,6 +102,19 @@ To cover that case, every MCP tool (`execute_query`, `list_schemas`, `describe_t
 When a value is supplied both ways — an `X-Agent-Id` header on the connection *and* an `agent_id` tool argument on the call — the **header wins**, matching the existing precedence between HTTP-header-style and SQL-session-param-style values used by every other frontend.
 
 This mirrors how the wider MCP ecosystem is moving away from relying on transport-level session state for anything that needs to persist across tool calls, in favor of explicit, model-visible arguments — the tool parameters are the reliable path for any MCP client, headers are a free bonus for integrators who control their own HTTP client.
+
+### Agent context defaults on MCP
+
+Every other frontend requires **both** `agent_id` and `conversation_id` to activate agentic context — if a client supplies neither, the query is just a normal, non-agentic query. MCP does not follow that rule: since MCP traffic is agent traffic by definition, a tool call that supplies neither field still gets agent context, so it isn't silently invisible on the **Agents** page.
+
+When `agent_id` / `conversation_id` aren't supplied via header or tool parameter, MCP fills them in:
+
+| Field | Default |
+|-------|---------|
+| `agent_id` | The authenticated identity (`auth.user` — e.g. `"anonymous"` under `auth.provider: none`). |
+| `conversation_id` | The transport's `Mcp-Session-Id`, so every tool call within one MCP session groups together. Falls back to a fresh UUID per call if no session id is available (e.g. a stateless client). |
+
+Explicit headers and tool parameters still override both defaults — this only fills gaps, it never replaces a value you actually sent. Because `conversation_id` defaults to the session id, a client that never sets it explicitly still gets meaningful session-level grouping on the **Conversations** page for free, for as long as its MCP session lives; a client that wants grouping across multiple MCP sessions (or a stable identity independent of transport reconnects) should still set `conversation_id` explicitly.
 
 ---
 

--- a/website/docs/agentic/agent-context.md
+++ b/website/docs/agentic/agent-context.md
@@ -1,17 +1,17 @@
 ---
-description: Agentic context — attaching agent identity and conversation state to queries via HTTP headers or SQL session params, with full session replay and audit from QueryFlux Studio.
+sidebar_label: Setting agent context
+description: How to attach agent identity and conversation state to queries — via HTTP headers, SQL session params, or MCP tool parameters, depending on the frontend.
 ---
 
-# Agentic context
+# Setting agent context
 
-When an AI agent queries through QueryFlux, it can identify itself and attach conversation state to every query. QueryFlux persists this context alongside every query record so you can replay an agent's full session, correlate queries across steps, and audit what the agent tried — including any guardrail decisions.
+Agentic context can be set in three ways depending on which frontend protocol the agent uses:
 
-Agentic context can be set in two ways depending on which frontend protocol the agent uses:
-
-- **HTTP headers** — for Trino HTTP, Snowflake HTTP, and ClickHouse HTTP frontends.
+- **HTTP headers** — for Trino HTTP, Snowflake HTTP, ClickHouse HTTP, and [MCP](../architecture/frontends/mcp) frontends.
 - **SQL session params** — for MySQL wire and PostgreSQL wire frontends, where HTTP headers are not available.
+- **MCP tool parameters** — the [MCP](../architecture/frontends/mcp) frontend additionally accepts these fields as explicit tool-call arguments, since not every MCP client lets you set custom headers per call.
 
-Both approaches use the same underlying fields and produce identical records in query history.
+All three approaches use the same underlying fields and produce identical records in query history — see [Session replay and guardrails](session-replay) for what gets persisted and how to reconstruct an agent's session afterward.
 
 ---
 
@@ -79,6 +79,32 @@ Parameters are extracted once at connection time.
 
 ---
 
+## Setting context via MCP tool parameters
+
+The MCP frontend accepts `X-Agent-Id` / `X-Conversation-Id` / etc. as HTTP headers on the streamable-HTTP request, exactly like the other HTTP frontends. But many MCP clients (Claude Desktop and similar consumer hosts) only let you configure headers once for the whole server connection, not per tool call — which makes headers alone a poor fit for per-query agent identity.
+
+To cover that case, every MCP tool (`execute_query`, `list_schemas`, `describe_table`, `explain_query`) also accepts the same fields as explicit, optional arguments:
+
+```json
+{
+  "name": "execute_query",
+  "arguments": {
+    "sql": "SELECT region, COUNT(*) FROM orders WHERE date > DATE '2026-01-01' GROUP BY 1",
+    "agent_id": "my-agent-v2",
+    "conversation_id": "conv-7f3a9b",
+    "step_index": 4,
+    "tool_call_id": "call_abc123",
+    "query_intent": "aggregation"
+  }
+}
+```
+
+When a value is supplied both ways — an `X-Agent-Id` header on the connection *and* an `agent_id` tool argument on the call — the **header wins**, matching the existing precedence between HTTP-header-style and SQL-session-param-style values used by every other frontend.
+
+This mirrors how the wider MCP ecosystem is moving away from relying on transport-level session state for anything that needs to persist across tool calls, in favor of explicit, model-visible arguments — the tool parameters are the reliable path for any MCP client, headers are a free bonus for integrators who control their own HTTP client.
+
+---
+
 ## Query intent
 
 `X-Query-Intent` (HTTP) or `query_intent` (SQL) classifies what the agent is trying to accomplish. When omitted, QueryFlux infers intent from the SQL using a lightweight heuristic.
@@ -93,62 +119,4 @@ Parameters are extracted once at connection time.
 
 Intent is stored on the query record and visible in Studio. It can also inform guardrail logic — a Python script guard can read `ctx["agent_context"]["query_intent"]` and apply stricter rules to `schema_exploration` queries on large tables.
 
----
-
-## What gets persisted
-
-Each query record in Postgres stores:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `agent_id` | `TEXT` | From `X-Agent-Id` or `SET agent_id`. |
-| `conversation_id` | `TEXT` | From `X-Conversation-Id` or `SET conversation_id`. |
-| `step_index` | `INTEGER` | From `X-Step-Index` or `SET step_index`. |
-| `tool_call_id` | `TEXT` | From `X-Tool-Call-Id` or `SET tool_call_id`. |
-| `query_intent` | `TEXT` | From `X-Query-Intent`, `SET query_intent`, or inferred. |
-| `guard_actions` | `JSONB` | Ordered list of guard verdicts for this query. |
-| `was_guard_blocked` | `BOOLEAN` | `true` if any guard denied the query. |
-
-`agent_id`, `conversation_id`, and `was_guard_blocked` are indexed for efficient lookup.
-
----
-
-## Replaying a session
-
-With conversation ID and step index you can reconstruct exactly what an agent did:
-
-```sql
--- Full session replay in order
-SELECT
-    step_index,
-    query_intent,
-    sql,
-    status,
-    was_guard_blocked,
-    guard_actions
-FROM query_records
-WHERE conversation_id = 'conv-7f3a9b'
-ORDER BY step_index;
-```
-
-```sql
--- All queries an agent was blocked on
-SELECT created_at, sql, guard_actions
-FROM query_records
-WHERE agent_id = 'my-agent-v2'
-  AND was_guard_blocked = TRUE
-ORDER BY created_at DESC;
-```
-
-QueryFlux Studio shows agentic context inline on the **Queries** page — conversation ID, step index, intent, and the full guard action trail are visible per query without writing SQL.
-
----
-
-## Using guardrails with agentic workloads
-
-Guardrails are a general-purpose SQL safety layer, but they integrate with agentic context in two ways:
-
-1. **Guard decisions are recorded per query** — every `allow`, `warn`, and `deny` is stored in `guard_actions`, so the agent session replay includes the full safety audit trail.
-2. **Python script guards can inspect agent context** — the `ctx` dict passed to a script guard includes `agent_context` with all fields above, so you can write rules that behave differently for agents vs. human clients.
-
-See [Guardrails](../architecture/guardrails) for the full guard configuration reference.
+Next: [Session replay and guardrails](session-replay) covers what gets persisted and how to reconstruct a full agent session from query history.

--- a/website/docs/agentic/overview.md
+++ b/website/docs/agentic/overview.md
@@ -1,0 +1,31 @@
+---
+title: Agentic AI
+sidebar_label: Overview
+description: How QueryFlux supports AI agent workloads — attaching agent identity to queries, replaying sessions, and applying guardrails to agent traffic.
+image: img/queryflux-hero-banner.png
+---
+# Agentic AI
+
+When an AI agent queries through QueryFlux, it can identify itself and attach conversation state to every query. QueryFlux persists this context alongside every query record so you can replay an agent's full session, correlate queries across steps, and audit what the agent tried — including any guardrail decisions.
+
+This section covers:
+
+- **[Setting agent context](agent-context)** — how to attach agent identity to a query, depending on which frontend the agent uses: HTTP headers, SQL session params, or [MCP](../architecture/frontends/mcp) tool parameters.
+- **[Session replay and guardrails](session-replay)** — what gets persisted, how to reconstruct an agent's full session from query history, and how guardrails integrate with agentic traffic.
+
+## The three propagation mechanisms
+
+Agentic context can be set in three ways depending on which frontend protocol the agent uses. All three use the same underlying fields and produce identical records in query history.
+
+| Mechanism | Used by |
+|-----------|---------|
+| **HTTP headers** | Trino HTTP, Snowflake HTTP, ClickHouse HTTP, and [MCP](../architecture/frontends/mcp) frontends. |
+| **SQL session params** | MySQL wire and PostgreSQL wire frontends, where HTTP headers are not available. |
+| **MCP tool parameters** | The [MCP](../architecture/frontends/mcp) frontend additionally accepts these fields as explicit tool-call arguments, since not every MCP client lets you set custom headers per call. |
+
+See [Setting agent context](agent-context) for the full reference on each.
+
+## Also relevant
+
+- **[MCP Frontend](../architecture/frontends/mcp)** — lets any MCP-compatible agent query QueryFlux directly, with agent context, routing, and guardrails all reused from the rest of QueryFlux.
+- **[Guardrails](../architecture/guardrails)** — the general-purpose SQL safety layer that applies to agent traffic exactly like any other client.

--- a/website/docs/agentic/session-replay.md
+++ b/website/docs/agentic/session-replay.md
@@ -1,0 +1,68 @@
+---
+sidebar_label: Session replay & guardrails
+description: What agentic context QueryFlux persists per query, how to replay an agent's full session from query history, and how guardrails integrate with agent traffic.
+---
+
+# Session replay and guardrails
+
+Once agent context is attached to queries — see [Setting agent context](agent-context) — QueryFlux persists it alongside every query record, giving you a full audit trail you can query directly or browse in Studio.
+
+---
+
+## What gets persisted
+
+Each query record in Postgres stores:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `agent_id` | `TEXT` | From `X-Agent-Id` or `SET agent_id`. |
+| `conversation_id` | `TEXT` | From `X-Conversation-Id` or `SET conversation_id`. |
+| `step_index` | `INTEGER` | From `X-Step-Index` or `SET step_index`. |
+| `tool_call_id` | `TEXT` | From `X-Tool-Call-Id` or `SET tool_call_id`. |
+| `query_intent` | `TEXT` | From `X-Query-Intent`, `SET query_intent`, or inferred. See [query intent values](agent-context#query-intent). |
+| `guard_actions` | `JSONB` | Ordered list of guard verdicts for this query. |
+| `was_guard_blocked` | `BOOLEAN` | `true` if any guard denied the query. |
+
+`agent_id`, `conversation_id`, and `was_guard_blocked` are indexed for efficient lookup.
+
+---
+
+## Replaying a session
+
+With conversation ID and step index you can reconstruct exactly what an agent did:
+
+```sql
+-- Full session replay in order
+SELECT
+    step_index,
+    query_intent,
+    sql,
+    status,
+    was_guard_blocked,
+    guard_actions
+FROM query_records
+WHERE conversation_id = 'conv-7f3a9b'
+ORDER BY step_index;
+```
+
+```sql
+-- All queries an agent was blocked on
+SELECT created_at, sql, guard_actions
+FROM query_records
+WHERE agent_id = 'my-agent-v2'
+  AND was_guard_blocked = TRUE
+ORDER BY created_at DESC;
+```
+
+QueryFlux Studio shows agentic context inline on the **Queries** page — conversation ID, step index, intent, and the full guard action trail are visible per query without writing SQL. The **Agents** and **Conversations** pages group query history by `agent_id` and `conversation_id` directly, without hand-written SQL.
+
+---
+
+## Using guardrails with agentic workloads
+
+Guardrails are a general-purpose SQL safety layer — they apply to every frontend identically, agent traffic included, with no agent-specific policy layer. They integrate with agentic context in two ways:
+
+1. **Guard decisions are recorded per query** — every `allow`, `warn`, and `deny` is stored in `guard_actions`, so the agent session replay above includes the full safety audit trail.
+2. **Python script guards can inspect agent context** — the `ctx` dict passed to a script guard includes `agent_context` with all the fields above, so you can write rules that behave differently for agents vs. human clients (e.g. stricter row limits for `schema_exploration` queries from an unrecognized `agent_id`).
+
+See [Guardrails](../architecture/guardrails) for the full guard configuration reference, and [MCP Frontend](../architecture/frontends/mcp) for how this applies to MCP-originated queries specifically — MCP has no guard policy of its own, it flows through the same `GuardChain` as everything else.

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -25,7 +25,25 @@ The MCP frontend speaks **streamable HTTP** only (`rmcp`'s `transport-streamable
 
 ## Authentication
 
-Requests carry `Authorization: Bearer <token>`, checked against the same `AuthProvider` every other HTTP frontend uses (`none`, `static`, `oidc`, `ldap` — see [Authentication](../../authentication)). There is no MCP-specific auth mechanism.
+Requests carry `Authorization: Bearer <token>`, checked against the same `AuthProvider` every other HTTP frontend uses (`none`, `static`, `oidc`, `ldap` — see [Authentication](../../authentication)). There is no MCP-specific auth mechanism — and specifically, QueryFlux does **not** implement the MCP spec's own OAuth 2.1 authorization flow (PKCE, `.well-known/oauth-authorization-server` discovery, dynamic client registration). A client expecting to auto-discover auth and interactively log a user in against QueryFlux directly won't find that here; every setup in [Connecting a client](#connecting-a-client) below relies on a token obtained some other way and pasted into config.
+
+### Authenticating with an OIDC provider (Keycloak, etc.)
+
+With `auth.provider: oidc`, QueryFlux only *validates* tokens (JWT signature + claims against your IdP's JWKS endpoint) — it never issues them. See [Authentication](../../authentication#frontend-authentication-auth) for the `oidc` config block, and **[`examples/with-keycloak-oidc`](https://github.com/lakeops-org/queryflux/tree/main/examples/with-keycloak-oidc)** for a runnable Keycloak + QueryFlux stack (that example fetches a token via the password grant).
+
+For a token that sits in a static MCP client config rather than a short-lived interactive session, a **client-credentials (service account)** token is usually the better fit — it's not tied to a human's login, and you control its lifetime independently:
+
+```bash
+TOKEN=$(curl -s https://keycloak.internal/realms/my-realm/protocol/openid-connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=queryflux-mcp \
+  -d client_secret="$QUERYFLUX_MCP_CLIENT_SECRET" | jq -r .access_token)
+```
+
+(Requires a Keycloak client with "Service Accounts" enabled.) Two things to plan for either way:
+
+- **The token will expire**, and nothing on QueryFlux's side refreshes it — validation enforces `exp` like any standard JWT check. A client config with a pasted-in token needs either a long-lived access-token setting on that Keycloak client, or periodic manual regeneration.
+- **One token = one identity** for every call made through it. A shared service-account token means all MCP traffic authenticated with it shows up under that one identity in query history — use the [agent-context fields](../../agentic/agent-context) (`agent_id`, `conversation_id`, etc.) to distinguish individual agents/conversations if that matters to you, rather than provisioning per-user OIDC tokens for something as ephemeral as an MCP client config.
 
 ## Tools
 
@@ -65,6 +83,8 @@ Every MCP query is recorded the same way as every other frontend's queries. Unli
 ## Connecting a client
 
 Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. Every example below uses `http://localhost:8811/mcp` for local development — QueryFlux does not terminate TLS itself (same as every other frontend), so a bearer token sent to a **remote** host must go through HTTPS or a TLS-terminating reverse proxy in front of QueryFlux; otherwise the token travels in cleartext. Don't hardcode the token in a committed config file — every client below supports pulling it from an environment variable instead.
+
+**[`examples/with-mcp`](https://github.com/lakeops-org/queryflux/tree/main/examples/with-mcp)** is a runnable Docker Compose stack — QueryFlux with the MCP frontend enabled against the embedded DuckDB engine, no other services required — if you'd rather have something running before working through the client configs below.
 
 ### MCP Inspector (quick sanity check)
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -31,16 +31,26 @@ Requests carry `Authorization: Bearer <token>`, checked against the same `AuthPr
 
 | Tool | Description |
 |------|-------------|
-| `execute_query(sql, engine_hint?, max_rows?, ...agent context)` | Execute SQL and return rows as JSON, keyed by column name. Truncates at `max_rows` (default 1000) — a result-size bound, not a safety mechanism. |
+| `execute_query(sql, engine_hint?, max_rows?, dialect?, ...agent context)` | Execute SQL and return rows as JSON, keyed by column name. Truncates at `max_rows` (default 1000) — a result-size bound, not a safety mechanism. |
 | `list_schemas(engine_hint?, ...agent context)` | List schemas by querying `information_schema.schemata` — the SQL-standard view every supported engine implements. |
 | `describe_table(schema?, table, sample_rows?, engine_hint?, ...agent context)` | Column metadata via `DESCRIBE`, plus a bounded sample (`SELECT * ... LIMIT sample_rows`) in the same call when `sample_rows > 0` — reduces agent round-trips. |
-| `explain_query(sql, engine_hint?, ...agent context)` | Query plan via `EXPLAIN`, without executing the query. |
+| `explain_query(sql, engine_hint?, dialect?, ...agent context)` | Query plan via `EXPLAIN`, without executing the query. |
 | `get_query_status(query_id)` | Status of a query submitted via `execute_query` — `running`, `queued`, or `not_found_or_completed`. QueryFlux does not currently retain a lookup-by-id history of completed queries, so this only covers in-flight queries. |
 | `cancel_query(query_id)` | Cancel a running or queued query. Only the agent/user that submitted it may cancel it (ownership-checked, same as every other owner-scoped operation in QueryFlux). |
 
 Every tool that accepts `engine_hint` uses it as an exact cluster-group name when it matches a configured group; otherwise the query is routed normally through the configured `RouterChain` — the same routing behavior as every other frontend, just with an optional override.
 
 Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. Both are optional: when neither is supplied, `agent_id`/`conversation_id` default rather than being left unset (see [Agent context defaults on MCP](../../agentic/agent-context#agent-context-defaults-on-mcp)). See [Agentic context](../../agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
+
+### The `dialect` parameter
+
+Every other frontend implies a SQL dialect from its wire protocol — a PostgreSQL wire client is assumed to write Postgres-flavored SQL, for example. MCP has no such signal: an LLM agent can write SQL in any dialect, or (more commonly) in whatever dialect the target engine itself uses. Guessing wrong is worse than not translating at all — a wrong dialect assumption can cause sqlglot to parse the SQL under the wrong syntax rules and silently rewrite it incorrectly.
+
+So `execute_query` and `explain_query` default to applying **no translation** — the SQL is assumed to already match the target engine's dialect, which is the common case. Set `dialect` only when the SQL was written for a *different* engine and should be translated before being routed. Accepted values (case-insensitive):
+
+`trino`, `athena`, `duckdb`, `starrocks`, `clickhouse`, `mysql`, `postgres` (or `postgresql`), `sqlite`, `snowflake`, `bigquery`, `databricks`, `tsql` (or `mssql`), `redshift`, `exasol`, `generic`.
+
+An unrecognized value is rejected with an `invalid_params` error listing the accepted set, rather than being passed through to sqlglot unvalidated.
 
 ## Guardrails
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -25,7 +25,7 @@ The MCP frontend speaks **streamable HTTP** only (`rmcp`'s `transport-streamable
 
 ## Authentication
 
-Requests carry `Authorization: Bearer <token>`, checked against the same `AuthProvider` every other HTTP frontend uses (`none`, `static`, `oidc`, `ldap` — see [Authentication](/docs/authentication)). There is no MCP-specific auth mechanism.
+Requests carry `Authorization: Bearer <token>`, checked against the same `AuthProvider` every other HTTP frontend uses (`none`, `static`, `oidc`, `ldap` — see [Authentication](../../authentication)). There is no MCP-specific auth mechanism.
 
 ## Tools
 
@@ -40,7 +40,7 @@ Requests carry `Authorization: Bearer <token>`, checked against the same `AuthPr
 
 Every tool that accepts `engine_hint` uses it as an exact cluster-group name when it matches a configured group; otherwise the query is routed normally through the configured `RouterChain` — the same routing behavior as every other frontend, just with an optional override.
 
-Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. See [Agentic context](/docs/agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
+Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. See [Agentic context](../../agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
 
 ## Guardrails
 
@@ -50,7 +50,7 @@ Column/PII masking is not currently available for any frontend, MCP included —
 
 ## Query history and session replay
 
-Every MCP query is recorded the same way as every other frontend's queries, with the agent-context fields populated when present. This means MCP-originated queries show up in QueryFlux Studio's **Queries**, **Agents**, and **Conversations** pages exactly like agent traffic through Trino HTTP or PostgreSQL wire — no separate MCP-specific tooling needed to audit or replay what an agent did. See [Session replay and guardrails](/docs/agentic/session-replay) for the full persistence and replay model.
+Every MCP query is recorded the same way as every other frontend's queries, with the agent-context fields populated when present. This means MCP-originated queries show up in QueryFlux Studio's **Queries**, **Agents**, and **Conversations** pages exactly like agent traffic through Trino HTTP or PostgreSQL wire — no separate MCP-specific tooling needed to audit or replay what an agent did. See [Session replay and guardrails](../../agentic/session-replay) for the full persistence and replay model.
 
 ## Connecting a client
 
@@ -79,6 +79,6 @@ npx @modelcontextprotocol/inspector
 ## Related
 
 - [Frontends overview](overview.md) — shared dispatch and session model
-- [Setting agent context](/docs/agentic/agent-context) — how MCP populates agent identity, via headers and tool parameters
-- [Session replay and guardrails](/docs/agentic/session-replay) — what gets persisted and how to reconstruct an agent's session
+- [Setting agent context](../../agentic/agent-context) — how MCP populates agent identity, via headers and tool parameters
+- [Session replay and guardrails](../../agentic/session-replay) — what gets persisted and how to reconstruct an agent's session
 - [Guardrails](../guardrails) — configuring `read_only`, `row_limit`, and other guards

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -40,7 +40,7 @@ Requests carry `Authorization: Bearer <token>`, checked against the same `AuthPr
 
 Every tool that accepts `engine_hint` uses it as an exact cluster-group name when it matches a configured group; otherwise the query is routed normally through the configured `RouterChain` — the same routing behavior as every other frontend, just with an optional override.
 
-Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. See [Agentic context](../../agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
+Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. Both are optional: when neither is supplied, `agent_id`/`conversation_id` default rather than being left unset (see [Agent context defaults on MCP](../../agentic/agent-context#agent-context-defaults-on-mcp)). See [Agentic context](../../agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
 
 ## Guardrails
 
@@ -50,7 +50,7 @@ Column/PII masking is not currently available for any frontend, MCP included —
 
 ## Query history and session replay
 
-Every MCP query is recorded the same way as every other frontend's queries, with the agent-context fields populated when present. This means MCP-originated queries show up in QueryFlux Studio's **Queries**, **Agents**, and **Conversations** pages exactly like agent traffic through Trino HTTP or PostgreSQL wire — no separate MCP-specific tooling needed to audit or replay what an agent did. See [Session replay and guardrails](../../agentic/session-replay) for the full persistence and replay model.
+Every MCP query is recorded the same way as every other frontend's queries. Unlike every other frontend, MCP always has agent context — even a tool call with no `agent_id`/`conversation_id` header or parameter still gets one, defaulted from the authenticated identity and the MCP session id (see [Agent context defaults on MCP](../../agentic/agent-context#agent-context-defaults-on-mcp)), so MCP traffic never goes missing from the **Agents** page the way an unlabeled query on another frontend would. MCP-originated queries show up in QueryFlux Studio's **Queries**, **Agents**, and **Conversations** pages exactly like agent traffic through Trino HTTP or PostgreSQL wire — no separate MCP-specific tooling needed to audit or replay what an agent did. See [Session replay and guardrails](../../agentic/session-replay) for the full persistence and replay model.
 
 ## Connecting a client
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -54,12 +54,14 @@ Every MCP query is recorded the same way as every other frontend's queries, with
 
 ## Connecting a client
 
-Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. For example, with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. The `http://localhost:8811/mcp` example below is for local development only — QueryFlux does not terminate TLS itself (same as every other frontend), so a bearer token sent to a **remote** host must go through HTTPS or a TLS-terminating reverse proxy in front of QueryFlux; otherwise the token travels in cleartext.
+
+For example, with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
 
 ```bash
 npx @modelcontextprotocol/inspector
 # Transport: Streamable HTTP
-# URL: http://localhost:8811/mcp
+# URL: http://localhost:8811/mcp   (local dev — use https:// through a TLS terminator remotely)
 # Header: Authorization: Bearer <token>
 ```
 
@@ -72,6 +74,7 @@ npx @modelcontextprotocol/inspector
 | Natural-language-to-SQL, semantic routing, result caching, query rewriting | Explicitly out of scope for this frontend — QueryFlux routes and executes the SQL it's given. |
 | Async submit/poll execution model | `execute_query` is synchronous — it blocks until the query completes. `get_query_status` / `cancel_query` are best-effort against the existing in-flight query registry (useful from a concurrent tool call), not a full async job API. |
 | Column/PII masking | Not implemented for any frontend yet. |
+| TLS | Not terminated by QueryFlux. Use an external TLS terminator in front of QueryFlux for any deployment where the bearer token crosses an untrusted network. |
 
 ## Related
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -64,16 +64,72 @@ Every MCP query is recorded the same way as every other frontend's queries. Unli
 
 ## Connecting a client
 
-Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. The `http://localhost:8811/mcp` example below is for local development only — QueryFlux does not terminate TLS itself (same as every other frontend), so a bearer token sent to a **remote** host must go through HTTPS or a TLS-terminating reverse proxy in front of QueryFlux; otherwise the token travels in cleartext.
+Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. Every example below uses `http://localhost:8811/mcp` for local development — QueryFlux does not terminate TLS itself (same as every other frontend), so a bearer token sent to a **remote** host must go through HTTPS or a TLS-terminating reverse proxy in front of QueryFlux; otherwise the token travels in cleartext. Don't hardcode the token in a committed config file — every client below supports pulling it from an environment variable instead.
 
-For example, with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+### MCP Inspector (quick sanity check)
 
 ```bash
 npx @modelcontextprotocol/inspector
 # Transport: Streamable HTTP
-# URL: http://localhost:8811/mcp   (local dev — use https:// through a TLS terminator remotely)
+# URL: http://localhost:8811/mcp
 # Header: Authorization: Bearer <token>
 ```
+
+### Cursor
+
+Cursor supports streamable HTTP natively — no bridge needed. Add to `.cursor/mcp.json` (project-scoped) or Cursor's global MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "queryflux": {
+      "url": "http://localhost:8811/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:QUERYFLUX_MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```bash
+claude mcp add --transport http queryflux http://localhost:8811/mcp \
+  --header "Authorization: Bearer $QUERYFLUX_MCP_TOKEN"
+```
+
+Add `--scope user` to make it available across every project instead of just the current one. Run `/mcp` inside Claude Code afterward to confirm it shows as connected — a bad token shows as failed with the HTTP status QueryFlux returned (e.g. 401).
+
+### Claude Desktop
+
+Claude Desktop's `claude_desktop_config.json` only validates stdio server entries — pasting a streamable-HTTP URL directly into it is silently ignored. Two options:
+
+- **Custom Connector (recommended)**: Settings → Connectors → Add custom connector, and enter the URL and bearer token there. No JSON file editing.
+- **[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge**, if you need it in the config file itself:
+
+```json
+{
+  "mcpServers": {
+    "queryflux": {
+      "command": "npx",
+      "args": [
+        "mcp-remote@latest",
+        "http://localhost:8811/mcp",
+        "--header",
+        "Authorization:${AUTH_HEADER}"
+      ],
+      "env": {
+        "AUTH_HEADER": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+### Other clients
+
+Most other MCP-capable tools (Windsurf, VS Code's MCP support, etc.) follow the same `mcpServers: { "<name>": { "url": ..., "headers": {...} } }` convention Cursor uses above — check that client's own docs for where the file lives, but the `url`/`headers` shape is usually a direct copy-paste.
 
 ## Not supported / Known limitations
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -46,7 +46,7 @@ Every tool except `get_query_status` / `cancel_query` also accepts the optional 
 
 Every other frontend implies a SQL dialect from its wire protocol — a PostgreSQL wire client is assumed to write Postgres-flavored SQL, for example. MCP has no such signal: an LLM agent can write SQL in any dialect, or (more commonly) in whatever dialect the target engine itself uses. Guessing wrong is worse than not translating at all — a wrong dialect assumption can cause sqlglot to parse the SQL under the wrong syntax rules and silently rewrite it incorrectly.
 
-So `execute_query` and `explain_query` default to applying **no translation** — the SQL is assumed to already match the target engine's dialect, which is the common case. Set `dialect` only when the SQL was written for a *different* engine and should be translated before being routed. Accepted values (case-insensitive):
+So `execute_query` and `explain_query` don't guess at all: with no `dialect` given, translation is skipped entirely — sqlglot is never invoked, and the SQL is sent to the target engine exactly as written (this also means any configured translation fixup scripts don't run for that call, since those need a real dialect to parse under too). This is a deliberate no-op, not an assumption — QueryFlux doesn't claim to know what dialect the SQL is in unless you tell it. Set `dialect` when the SQL was written for a *different* engine and should actually be translated before being routed. Accepted values (case-insensitive):
 
 `trino`, `athena`, `duckdb`, `starrocks`, `clickhouse`, `mysql`, `postgres` (or `postgresql`), `sqlite`, `snowflake`, `bigquery`, `databricks`, `tsql` (or `mssql`), `redshift`, `exasol`, `generic`.
 

--- a/website/docs/architecture/frontends/mcp.md
+++ b/website/docs/architecture/frontends/mcp.md
@@ -1,0 +1,81 @@
+---
+title: MCP Frontend
+description: Model Context Protocol tool-call frontend — streamable HTTP, six tools for AI agents, and how it reuses QueryFlux's existing routing, auth, guardrails, and agent-context features.
+image: img/queryflux-hero-banner.png
+---
+# MCP Frontend
+
+The MCP frontend lets any [Model Context Protocol](https://modelcontextprotocol.io/) client — Claude, GPT-based agents, LangChain, or a custom framework — query QueryFlux without writing custom integration code. It is implemented as a submodule of `queryflux-frontend`, the same crate every other frontend (Trino HTTP, PostgreSQL wire, MySQL wire, Flight SQL, Snowflake) lives in, and it dispatches every tool call through the exact same `execute_to_sink` pipeline: routing, SQL translation, guardrails, and query-history persistence are identical to every other frontend. There is no separate MCP-specific execution path and no MCP-specific safety policy layered on top — what you already have configured applies here too.
+
+## Configuration
+
+```yaml
+queryflux:
+  frontends:
+    mcp:
+      enabled: true
+      port: 8811
+```
+
+Config key: `mcp`. Protocol identifier: `FrontendProtocol::Mcp`. Default dialect: `SqlDialect::Generic`. There is no default port — set one explicitly, same as every other optional frontend.
+
+## Transport
+
+The MCP frontend speaks **streamable HTTP** only (`rmcp`'s `transport-streamable-http-server`), served at `http://<host>:<port>/mcp`. This matches every other QueryFlux frontend being a network service — stdio transport (common for embedding an MCP server as a local subprocess) doesn't fit QueryFlux's server deployment model and isn't offered.
+
+## Authentication
+
+Requests carry `Authorization: Bearer <token>`, checked against the same `AuthProvider` every other HTTP frontend uses (`none`, `static`, `oidc`, `ldap` — see [Authentication](/docs/authentication)). There is no MCP-specific auth mechanism.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `execute_query(sql, engine_hint?, max_rows?, ...agent context)` | Execute SQL and return rows as JSON, keyed by column name. Truncates at `max_rows` (default 1000) — a result-size bound, not a safety mechanism. |
+| `list_schemas(engine_hint?, ...agent context)` | List schemas by querying `information_schema.schemata` — the SQL-standard view every supported engine implements. |
+| `describe_table(schema?, table, sample_rows?, engine_hint?, ...agent context)` | Column metadata via `DESCRIBE`, plus a bounded sample (`SELECT * ... LIMIT sample_rows`) in the same call when `sample_rows > 0` — reduces agent round-trips. |
+| `explain_query(sql, engine_hint?, ...agent context)` | Query plan via `EXPLAIN`, without executing the query. |
+| `get_query_status(query_id)` | Status of a query submitted via `execute_query` — `running`, `queued`, or `not_found_or_completed`. QueryFlux does not currently retain a lookup-by-id history of completed queries, so this only covers in-flight queries. |
+| `cancel_query(query_id)` | Cancel a running or queued query. Only the agent/user that submitted it may cancel it (ownership-checked, same as every other owner-scoped operation in QueryFlux). |
+
+Every tool that accepts `engine_hint` uses it as an exact cluster-group name when it matches a configured group; otherwise the query is routed normally through the configured `RouterChain` — the same routing behavior as every other frontend, just with an optional override.
+
+Every tool except `get_query_status` / `cancel_query` also accepts the optional agent-context fields — `agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent` — directly as tool parameters, in addition to the `X-Agent-Id` / `X-Conversation-Id` / etc. headers every other HTTP frontend already supports. See [Agentic context](/docs/agentic/agent-context#setting-context-via-mcp-tool-parameters) for why MCP gets both paths and which one wins when both are supplied.
+
+## Guardrails
+
+MCP queries flow through the exact same configurable `GuardChain` as every other frontend — `read_only`, `row_limit`, `require_predicate`, Python-script guards, and HTTP webhook guards all apply automatically to any group that serves MCP traffic, with no MCP-specific guard code involved. There is no default guard policy baked into the MCP frontend itself; if you want agent-facing queries restricted (e.g. read-only, row-capped), configure that the same way you would for any other frontend — see [Guardrails](../guardrails) for the full guard configuration reference.
+
+Column/PII masking is not currently available for any frontend, MCP included — it's tracked as a separate, unimplemented design (row filtering and column masking via an external policy engine).
+
+## Query history and session replay
+
+Every MCP query is recorded the same way as every other frontend's queries, with the agent-context fields populated when present. This means MCP-originated queries show up in QueryFlux Studio's **Queries**, **Agents**, and **Conversations** pages exactly like agent traffic through Trino HTTP or PostgreSQL wire — no separate MCP-specific tooling needed to audit or replay what an agent did. See [Session replay and guardrails](/docs/agentic/session-replay) for the full persistence and replay model.
+
+## Connecting a client
+
+Point any streamable-HTTP MCP client at `http://<host>:<port>/mcp` with a bearer token. For example, with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+npx @modelcontextprotocol/inspector
+# Transport: Streamable HTTP
+# URL: http://localhost:8811/mcp
+# Header: Authorization: Bearer <token>
+```
+
+## Not supported / Known limitations
+
+| Feature | Status |
+|---------|--------|
+| stdio transport | Not offered — streamable HTTP only. |
+| MCP Resources (e.g. `schema:///{table}` subscriptions) | Not implemented. |
+| Natural-language-to-SQL, semantic routing, result caching, query rewriting | Explicitly out of scope for this frontend — QueryFlux routes and executes the SQL it's given. |
+| Async submit/poll execution model | `execute_query` is synchronous — it blocks until the query completes. `get_query_status` / `cancel_query` are best-effort against the existing in-flight query registry (useful from a concurrent tool call), not a full async job API. |
+| Column/PII masking | Not implemented for any frontend yet. |
+
+## Related
+
+- [Frontends overview](overview.md) — shared dispatch and session model
+- [Setting agent context](/docs/agentic/agent-context) — how MCP populates agent identity, via headers and tool parameters
+- [Session replay and guardrails](/docs/agentic/session-replay) — what gets persisted and how to reconstruct an agent's session
+- [Guardrails](../guardrails) — configuring `read_only`, `row_limit`, and other guards

--- a/website/docs/architecture/frontends/overview.md
+++ b/website/docs/architecture/frontends/overview.md
@@ -17,6 +17,7 @@ A **frontend** is the entry point for client traffic into QueryFlux. Each fronte
 | [MySQL wire](mysql-wire.md) | `mysqlWire` | 3306 | MySQL wire | MySQL | **Done** |
 | [Arrow Flight SQL](flight-sql.md) | `flightSql` | 50051 | gRPC (Arrow Flight) | Generic | **Done** |
 | [Snowflake](snowflake.md) | `snowflakeHttp` | 8443* | Snowflake HTTP wire + SQL API v2 | Snowflake | **Done** |
+| [MCP](mcp.md) | `mcp` | — | Streamable HTTP (MCP tool calls) | Generic | **Done** |
 | ClickHouse HTTP | `clickhouseHttp` | 8123 | HTTP | ClickHouse | Planned |
 
 \*Snowflake is optional: you must set `snowflakeHttp.port` in YAML (no implicit default). `8443` is typical; some repo examples use `8445`. Wire and SQL API v2 share this listener; routing uses `snowflakeHttp` vs `snowflakeSqlApi` — see [Snowflake](snowflake.md).
@@ -103,6 +104,7 @@ routers:
     flightSql: flight-analytics
     snowflakeHttp: trino-default
     snowflakeSqlApi: trino-default
+    mcp: agent-queries
 ```
 
 ### SQL dialect and translation
@@ -132,8 +134,11 @@ queryflux:
       enabled: true
       port: 8443
       sessionAffinityAcknowledged: false
+    mcp:
+      enabled: true
+      port: 8811
 ```
 
-Omitting `postgresWire`, `mysqlWire`, `flightSql`, or `snowflakeHttp` disables that listener. For any frontend block, `enabled: false` turns the listener off while keeping other settings. When `trinoHttp` is omitted from YAML, serde defaults apply (`enabled: true`, port `8080`).
+Omitting `postgresWire`, `mysqlWire`, `flightSql`, `snowflakeHttp`, or `mcp` disables that listener. For any frontend block, `enabled: false` turns the listener off while keeping other settings. When `trinoHttp` is omitted from YAML, serde defaults apply (`enabled: true`, port `8080`).
 
 See **[Snowflake](snowflake.md)** for session affinity, TTL fields, and SQL API v2 behavior.

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -21,6 +21,7 @@ Everything below is implemented and available on the `main` branch.
 | | MySQL wire protocol (port 3306) |
 | | Arrow Flight SQL (gRPC) |
 | | Snowflake HTTP wire + SQL API v2 (configurable port) |
+| | MCP (Model Context Protocol) — streamable HTTP, six tools for AI agents, see **[MCP Frontend](./architecture/frontends/mcp)** |
 | | Admin REST API + OpenAPI / Swagger UI (port 9000) |
 | **Backends** | Trino — async HTTP polling, transparent `nextUri` proxying |
 | | DuckDB — embedded, in-process, Arrow result sets |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -33,7 +33,9 @@ const sidebars: SidebarsConfig = {
       label: 'Agentic AI',
       collapsed: false,
       items: [
+        'agentic/overview',
         'agentic/agent-context',
+        'agentic/session-replay',
       ],
     },
     {
@@ -67,6 +69,7 @@ const sidebars: SidebarsConfig = {
         'architecture/frontends/mysql-wire',
         'architecture/frontends/flight-sql',
         'architecture/frontends/snowflake',
+        'architecture/frontends/mcp',
       ],
     },
     {


### PR DESCRIPTION
## Summary

- Adds an MCP streamable-HTTP frontend (closes #188) so AI agents (Claude, GPT-based agents, LangChain, custom frameworks) can query QueryFlux without custom integration code.
- Implemented as a submodule of `queryflux-frontend` (`src/mcp/`), matching how every other frontend (Trino HTTP, PostgreSQL wire, MySQL wire, Flight SQL, Snowflake) is structured — not a separate crate.
- Every tool call dispatches through the existing `execute_to_sink` pipeline, so routing, SQL translation, guardrails, and query-history persistence are identical to every other frontend. **No MCP-specific safety policy is added** — guardrail enforcement (read-only, row limits, etc.) is entirely delegated to the existing, user-configurable `guardrails` system, same as any other frontend. Column/PII masking is intentionally out of scope, pending [discussion #71](https://github.com/lakeops-org/queryflux/discussions/71).
- Six tools: `execute_query`, `list_schemas`, `describe_table`, `explain_query`, `get_query_status`, `cancel_query`.
- Agent context (`agent_id`, `conversation_id`, `step_index`, `tool_call_id`, `query_intent`) is accepted **both** via HTTP headers (matching every other frontend's convention) **and** as explicit tool parameters — since not every MCP client lets you set custom headers per call, and the MCP spec itself is moving away from relying on transport session state for this kind of thing. Headers win on conflict.
- MCP-originated queries automatically get Prometheus metrics (`queries_total{protocol="Mcp"}`, etc.) and show up in QueryFlux Studio's Queries/Agents/Conversations pages — no new instrumentation needed, since it flows through the same `record_query` path as every other frontend.

## Docs

- New `architecture/frontends/mcp.md`, added to the Frontends comparison table and `protocolBased` router example.
- Split the "Agentic AI" sidebar section from one growing page into three: `overview`, `agent-context` (how to set it — headers, SQL session params, MCP tool params), and `session-replay` (what's persisted, replay, guardrail integration).
- `roadmap.md` updated.

## Test plan

- [x] `cargo build --workspace` — clean.
- [x] `cargo test --tests --workspace --exclude queryflux-e2e-tests --exclude queryflux-bench` — all passing, no regressions.
- [x] `cargo clippy --all-targets -- -D warnings` on all touched crates — clean.
- [x] New unit tests in `mcp/sink.rs` (Arrow→JSON conversion, row truncation, error capture).
- [x] New e2e suite `mcp_tests.rs` (10 tests) using a **real `rmcp` client** against an in-process `McpFrontend` — tool happy paths, `max_rows` truncation, guardrail denial (`read_only` blocking a `DELETE` while allowing `SELECT`), and agent-context propagation via both headers and tool params (including header-wins-on-conflict).
- [x] `cargo test -p queryflux-e2e-tests --test wire_protocol_tests --test query_params_tests` — confirms the shared `ProtocolWireHarness` changes didn't regress existing MySQL/Postgres/Flight SQL e2e coverage.
- [x] Manual smoke test: ran the compiled `queryflux` binary against a real DuckDB-backed config and drove a full MCP session by hand (`initialize` → `execute_query`) — `SELECT 21 * 2 AS answer` → `{"answer": 42}`.
- [ ] `pnpm build` in `website/` to confirm the new/edited docs pages build without broken links — **not run**, `pnpm`/`node` weren't available in the environment this was built in. Worth a check before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional MCP (Model Context Protocol) streamable-HTTP frontend.
  * Added tools for SQL execution, schema discovery, table descriptions, query explanations, status checks, and cancellation.
  * Added Bearer authentication, agent context propagation, guardrails, result truncation, query history integration, and configurable routing.
* **Documentation**
  * Added MCP, agentic AI, session replay, guardrail, configuration, and routing documentation.
* **Tests**
  * Added end-to-end coverage for MCP tools, authentication context, guardrails, truncation, and query management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->