### PR TITLE
docs: show GHCR download count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lakeops-org/queryflux/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/lakeops-org/queryflux/ci.yml?branch=main&amp;label=build&amp;style=for-the-badge&amp;logo=github&amp;logoColor=white" alt="CI status on main" /></a>
-  <a href="https://github.com/lakeops-org/queryflux/releases"><img src="https://img.shields.io/github/downloads/lakeops-org/queryflux/total?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;label=downloads" alt="GitHub release downloads" /></a>
+  <a href="https://github.com/lakeops-org/queryflux/pkgs/container/queryflux"><img src="https://ghcr-badge.elias.eu.org/shield/lakeops-org/queryflux/queryflux" alt="GHCR downloads" /></a>
   <a href="https://github.com/lakeops-org/queryflux/releases/latest"><img src="https://img.shields.io/github/v/release/lakeops-org/queryflux?sort=semver&amp;style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;label=release" alt="Latest release" /></a>
   <a href="https://github.com/lakeops-org/queryflux/commits/main/"><img src="https://img.shields.io/github/last-commit/lakeops-org/queryflux?style=for-the-badge&amp;logo=git&amp;logoColor=white&amp;label=last%20commit" alt="Last commit" /></a>
 </p>


### PR DESCRIPTION
## Summary
- replace the GitHub Release asset-download badge with the GHCR pull-count badge
- link the badge to the QueryFlux container package instead of Releases

Fixes #192.

## Validation
- git diff --check`n- verified the GHCR badge endpoint returns HTTP 200

## Release impact
- documentation-only; no release impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project README badge to display container download statistics from the GitHub Container Registry.
  * The badge now links directly to the QueryFlux container package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->