### PR TITLE
feat: native catalog integration foundation (schema-aware SQL translation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,6 +4007,7 @@ dependencies = [
  "opentelemetry_sdk",
  "queryflux-auth",
  "queryflux-cache",
+ "queryflux-catalog",
  "queryflux-cli",
  "queryflux-cluster-manager",
  "queryflux-config",
@@ -4077,6 +4078,16 @@ dependencies = [
  "tokio",
  "tracing",
  "xxhash-rust",
+]
+
+[[package]]
+name = "queryflux-catalog"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "queryflux-core",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/queryflux-engine-adapters",
     "crates/queryflux-frontend",
     "crates/queryflux-cluster-manager",
+    "crates/queryflux-catalog",
     "crates/queryflux-config",
     "crates/queryflux-metrics",
     "crates/queryflux-fingerprint",
@@ -72,6 +73,7 @@ dashmap = "6.1.0"
 
 # Internal crates
 queryflux-core = { path = "crates/queryflux-core" }
+queryflux-catalog = { path = "crates/queryflux-catalog" }
 queryflux-auth = { path = "crates/queryflux-auth" }
 queryflux-persistence = { path = "crates/queryflux-persistence" }
 queryflux-routing = { path = "crates/queryflux-routing" }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -80,6 +80,44 @@ translation:
   #         if dst == "athena":
   #             for table in ast.find_all(exp.Table):
   #                 table.set("catalog", None)
+  # Max time to spend on catalog lookup (see `catalogProvider` below) before
+  # falling back to dialect-only translation. Default 1500ms.
+  # schemaResolutionTimeoutMs: 1500
+
+# Native catalog integration — discovers table/column metadata so schema-aware SQL
+# translation (sqlglot's optimizer) can qualify columns/types, not just transpile
+# syntax. Defaults to `type: null` (no metadata, dialect-only translation only).
+catalogProvider:
+  type: null
+  # --- Other provider examples ---
+  # A literal, hand-declared schema — zero external dependencies, useful for
+  # testing or a small fixed set of tables.
+  # type: static
+  # schemas:
+  #   - catalog: hive
+  #     database: analytics
+  #     table: orders
+  #     columns:
+  #       - { name: order_id, dataType: BIGINT, nullable: false }
+  #       - { name: total, dataType: "DECIMAL(10,2)", nullable: true }
+  #
+  # Wrap any provider with a TTL cache:
+  # type: caching
+  # ttlSeconds: 300
+  # maxEntries: 10000
+  # delegate:
+  #   type: static
+  #   schemas: []
+  #
+  # Try a primary provider, fall back to a secondary on error (or a missing
+  # table, for get_table_schema specifically). Note: "null" must be quoted here —
+  # a bare YAML `null` parses as YAML's null type, not the string tag `type` expects.
+  # type: fallback
+  # primary:
+  #   type: static
+  #   schemas: []
+  # secondary:
+  #   type: "null"
 
 routers:
   - type: protocolBased

--- a/crates/queryflux-catalog/Cargo.toml
+++ b/crates/queryflux-catalog/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "queryflux-catalog"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+queryflux-core = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/queryflux-catalog/src/caching.rs
+++ b/crates/queryflux-catalog/src/caching.rs
@@ -1,0 +1,245 @@
+//! TTL + capacity-bounded cache wrapping any `CatalogProvider`.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use queryflux_core::catalog::{CatalogProvider, TableSchema};
+use queryflux_core::error::Result;
+use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+enum CacheKey {
+    ListCatalogs,
+    ListDatabases(String),
+    ListTables(String, String),
+    GetTableSchema(String, String, String),
+}
+
+#[derive(Debug, Clone)]
+enum CacheValue {
+    Catalogs(Vec<String>),
+    Databases(Vec<String>),
+    Tables(Vec<String>),
+    Schema(Option<TableSchema>),
+}
+
+struct Entry {
+    value: CacheValue,
+    inserted_at: Instant,
+}
+
+struct Inner {
+    entries: HashMap<CacheKey, Entry>,
+    /// Insertion order, for FIFO eviction once `max_entries` is exceeded. A full
+    /// LRU (touch-on-read reordering) isn't worth the extra bookkeeping here —
+    /// catalog lookups are cheap/infrequent relative to query traffic.
+    order: VecDeque<CacheKey>,
+}
+
+/// Wraps a `CatalogProvider`, caching each method's results independently by its
+/// arguments, matching the `catalogProvider: { type: caching, ttlSeconds,
+/// maxEntries, delegate: {...} }` config shape. Only `Ok` results are cached — an
+/// error is never pinned for `ttl_seconds`, so a transient catalog outage
+/// self-heals on the very next call instead of being cached as a failure.
+pub struct CachingCatalogProvider {
+    delegate: Arc<dyn CatalogProvider>,
+    ttl: Duration,
+    max_entries: usize,
+    inner: Mutex<Inner>,
+}
+
+impl CachingCatalogProvider {
+    pub fn new(delegate: Arc<dyn CatalogProvider>, ttl_seconds: u64, max_entries: usize) -> Self {
+        Self {
+            delegate,
+            ttl: Duration::from_secs(ttl_seconds),
+            max_entries,
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                order: VecDeque::new(),
+            }),
+        }
+    }
+
+    async fn get_cached(&self, key: &CacheKey) -> Option<CacheValue> {
+        let inner = self.inner.lock().await;
+        let entry = inner.entries.get(key)?;
+        if entry.inserted_at.elapsed() > self.ttl {
+            return None;
+        }
+        Some(entry.value.clone())
+    }
+
+    async fn insert(&self, key: CacheKey, value: CacheValue) {
+        let mut inner = self.inner.lock().await;
+        if !inner.entries.contains_key(&key) {
+            inner.order.push_back(key.clone());
+        }
+        inner.entries.insert(
+            key,
+            Entry {
+                value,
+                inserted_at: Instant::now(),
+            },
+        );
+        while inner.entries.len() > self.max_entries {
+            match inner.order.pop_front() {
+                Some(oldest) => {
+                    inner.entries.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl CatalogProvider for CachingCatalogProvider {
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        let key = CacheKey::ListCatalogs;
+        if let Some(CacheValue::Catalogs(v)) = self.get_cached(&key).await {
+            return Ok(v);
+        }
+        let v = self.delegate.list_catalogs().await?;
+        self.insert(key, CacheValue::Catalogs(v.clone())).await;
+        Ok(v)
+    }
+
+    async fn list_databases(&self, catalog: &str) -> Result<Vec<String>> {
+        let key = CacheKey::ListDatabases(catalog.to_string());
+        if let Some(CacheValue::Databases(v)) = self.get_cached(&key).await {
+            return Ok(v);
+        }
+        let v = self.delegate.list_databases(catalog).await?;
+        self.insert(key, CacheValue::Databases(v.clone())).await;
+        Ok(v)
+    }
+
+    async fn list_tables(&self, catalog: &str, database: &str) -> Result<Vec<String>> {
+        let key = CacheKey::ListTables(catalog.to_string(), database.to_string());
+        if let Some(CacheValue::Tables(v)) = self.get_cached(&key).await {
+            return Ok(v);
+        }
+        let v = self.delegate.list_tables(catalog, database).await?;
+        self.insert(key, CacheValue::Tables(v.clone())).await;
+        Ok(v)
+    }
+
+    async fn get_table_schema(
+        &self,
+        catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        let key =
+            CacheKey::GetTableSchema(catalog.to_string(), database.to_string(), table.to_string());
+        if let Some(CacheValue::Schema(v)) = self.get_cached(&key).await {
+            return Ok(v);
+        }
+        let v = self
+            .delegate
+            .get_table_schema(catalog, database, table)
+            .await?;
+        self.insert(key, CacheValue::Schema(v.clone())).await;
+        Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::error::QueryFluxError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Counts calls and lets a test script errors/results per call.
+    struct CountingProvider {
+        calls: AtomicUsize,
+        fail_next: std::sync::atomic::AtomicBool,
+    }
+
+    impl CountingProvider {
+        fn new() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                fail_next: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CatalogProvider for CountingProvider {
+        async fn list_catalogs(&self) -> Result<Vec<String>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail_next.swap(false, Ordering::SeqCst) {
+                return Err(QueryFluxError::Catalog("boom".to_string()));
+            }
+            Ok(vec!["hive".to_string()])
+        }
+        async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn get_table_schema(
+            &self,
+            _catalog: &str,
+            _database: &str,
+            _table: &str,
+        ) -> Result<Option<TableSchema>> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn hits_are_served_from_cache() {
+        let inner = Arc::new(CountingProvider::new());
+        let cache = CachingCatalogProvider::new(inner.clone(), 300, 10);
+
+        assert_eq!(cache.list_catalogs().await.unwrap(), vec!["hive"]);
+        assert_eq!(cache.list_catalogs().await.unwrap(), vec!["hive"]);
+        assert_eq!(
+            inner.calls.load(Ordering::SeqCst),
+            1,
+            "second call should hit cache"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn entries_expire_after_ttl() {
+        let inner = Arc::new(CountingProvider::new());
+        let cache = CachingCatalogProvider::new(inner.clone(), 60, 10);
+
+        cache.list_catalogs().await.unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        cache.list_catalogs().await.unwrap();
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1, "still within TTL");
+
+        tokio::time::advance(Duration::from_secs(31)).await;
+        cache.list_catalogs().await.unwrap();
+        assert_eq!(
+            inner.calls.load(Ordering::SeqCst),
+            2,
+            "TTL expired, should refetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn errors_are_never_cached() {
+        let inner = Arc::new(CountingProvider::new());
+        inner.fail_next.store(true, Ordering::SeqCst);
+        let cache = CachingCatalogProvider::new(inner.clone(), 300, 10);
+
+        assert!(cache.list_catalogs().await.is_err());
+        assert_eq!(cache.list_catalogs().await.unwrap(), vec!["hive"]);
+        assert_eq!(
+            inner.calls.load(Ordering::SeqCst),
+            2,
+            "error must not be cached"
+        );
+    }
+}

--- a/crates/queryflux-catalog/src/fallback.rs
+++ b/crates/queryflux-catalog/src/fallback.rs
@@ -1,0 +1,194 @@
+//! Primary/secondary catalog provider composition.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use queryflux_core::catalog::{CatalogProvider, TableSchema};
+use queryflux_core::error::Result;
+
+/// Tries `primary` first, matching the `catalogProvider: { type: fallback, primary,
+/// secondary }` config shape. Falls through to `secondary` on:
+/// - any `Err` from `primary`, for every method;
+/// - `get_table_schema` specifically returning `Ok(None)` — "not found in primary"
+///   is exactly the fallback use case (e.g. an engine-delegate primary plus a
+///   static secondary for tables the engine doesn't know about yet).
+///
+/// `list_tables`/`list_databases`/`list_catalogs` do **not** fall through on an
+/// empty `Ok` result — an empty catalog/database is a legitimate answer there,
+/// not a "try harder" signal, unlike a missing single table.
+pub struct FallbackCatalogProvider {
+    primary: Arc<dyn CatalogProvider>,
+    secondary: Arc<dyn CatalogProvider>,
+}
+
+impl FallbackCatalogProvider {
+    pub fn new(primary: Arc<dyn CatalogProvider>, secondary: Arc<dyn CatalogProvider>) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+#[async_trait]
+impl CatalogProvider for FallbackCatalogProvider {
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        match self.primary.list_catalogs().await {
+            Ok(v) => Ok(v),
+            Err(_) => self.secondary.list_catalogs().await,
+        }
+    }
+
+    async fn list_databases(&self, catalog: &str) -> Result<Vec<String>> {
+        match self.primary.list_databases(catalog).await {
+            Ok(v) => Ok(v),
+            Err(_) => self.secondary.list_databases(catalog).await,
+        }
+    }
+
+    async fn list_tables(&self, catalog: &str, database: &str) -> Result<Vec<String>> {
+        match self.primary.list_tables(catalog, database).await {
+            Ok(v) => Ok(v),
+            Err(_) => self.secondary.list_tables(catalog, database).await,
+        }
+    }
+
+    async fn get_table_schema(
+        &self,
+        catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        match self
+            .primary
+            .get_table_schema(catalog, database, table)
+            .await
+        {
+            Ok(Some(v)) => Ok(Some(v)),
+            Ok(None) => {
+                self.secondary
+                    .get_table_schema(catalog, database, table)
+                    .await
+            }
+            Err(_) => {
+                self.secondary
+                    .get_table_schema(catalog, database, table)
+                    .await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::catalog::ColumnDef;
+    use queryflux_core::error::QueryFluxError;
+
+    struct AlwaysErrors;
+    #[async_trait]
+    impl CatalogProvider for AlwaysErrors {
+        async fn list_catalogs(&self) -> Result<Vec<String>> {
+            Err(QueryFluxError::Catalog("down".into()))
+        }
+        async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+            Err(QueryFluxError::Catalog("down".into()))
+        }
+        async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+            Err(QueryFluxError::Catalog("down".into()))
+        }
+        async fn get_table_schema(
+            &self,
+            _catalog: &str,
+            _database: &str,
+            _table: &str,
+        ) -> Result<Option<TableSchema>> {
+            Err(QueryFluxError::Catalog("down".into()))
+        }
+    }
+
+    struct AlwaysEmpty;
+    #[async_trait]
+    impl CatalogProvider for AlwaysEmpty {
+        async fn list_catalogs(&self) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn get_table_schema(
+            &self,
+            _catalog: &str,
+            _database: &str,
+            _table: &str,
+        ) -> Result<Option<TableSchema>> {
+            Ok(None)
+        }
+    }
+
+    fn sample_schema() -> TableSchema {
+        TableSchema {
+            catalog: "hive".into(),
+            database: "analytics".into(),
+            table: "orders".into(),
+            columns: vec![ColumnDef {
+                name: "order_id".into(),
+                data_type: "BIGINT".into(),
+                nullable: false,
+            }],
+        }
+    }
+
+    struct HasOrders;
+    #[async_trait]
+    impl CatalogProvider for HasOrders {
+        async fn list_catalogs(&self) -> Result<Vec<String>> {
+            Ok(vec!["hive".into()])
+        }
+        async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+            Ok(vec!["analytics".into()])
+        }
+        async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+            Ok(vec!["orders".into()])
+        }
+        async fn get_table_schema(
+            &self,
+            _catalog: &str,
+            _database: &str,
+            table: &str,
+        ) -> Result<Option<TableSchema>> {
+            if table == "orders" {
+                Ok(Some(sample_schema()))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn falls_through_on_primary_error() {
+        let fb = FallbackCatalogProvider::new(Arc::new(AlwaysErrors), Arc::new(HasOrders));
+        assert_eq!(fb.list_catalogs().await.unwrap(), vec!["hive"]);
+    }
+
+    #[tokio::test]
+    async fn falls_through_on_missing_table_schema() {
+        let fb = FallbackCatalogProvider::new(Arc::new(AlwaysEmpty), Arc::new(HasOrders));
+        let schema = fb
+            .get_table_schema("hive", "analytics", "orders")
+            .await
+            .unwrap();
+        assert!(schema.is_some());
+    }
+
+    #[tokio::test]
+    async fn does_not_fall_through_on_empty_list_tables() {
+        let fb = FallbackCatalogProvider::new(Arc::new(AlwaysEmpty), Arc::new(HasOrders));
+        // AlwaysEmpty legitimately has no tables — must not be overridden by secondary.
+        assert!(fb
+            .list_tables("hive", "analytics")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/queryflux-catalog/src/lib.rs
+++ b/crates/queryflux-catalog/src/lib.rs
@@ -1,0 +1,133 @@
+//! Catalog discovery for QueryFlux — pluggable, format-agnostic integrations
+//! (Glue, Iceberg REST, Snowflake, ...) behind one `CatalogProvider` trait
+//! (`queryflux_core::catalog`), feeding schema-aware SQL translation.
+//!
+//! **Foundation phase** (this crate today): `Static`/`Caching`/`Fallback`, plus the
+//! `build_catalog_provider` factory that turns YAML config into a live provider.
+//! Real external integrations (Glue, Iceberg REST, Snowflake, engine-delegated
+//! discovery) land in a follow-up phase — see `plans/` for the full design. Until
+//! then, every config variant beyond `Null`/`Static`/`Caching`/`Fallback` degrades
+//! to a no-op `NullCatalogProvider` with a startup warning, exactly like an
+//! unreachable external catalog would at runtime — never a hard failure.
+
+pub mod caching;
+pub mod fallback;
+pub mod static_provider;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use queryflux_core::catalog::{CatalogProvider, NullCatalogProvider};
+use queryflux_core::config::CatalogProviderConfig;
+
+pub use caching::CachingCatalogProvider;
+pub use fallback::FallbackCatalogProvider;
+pub use static_provider::StaticCatalogProvider;
+
+/// Builds a live `CatalogProvider` tree from config. Recursive (`Caching`/`Fallback`
+/// wrap other configs), hence the boxed-future return type rather than plain `async
+/// fn` — Rust can't size a directly-recursive `async fn`'s state.
+///
+/// Never fails: an unimplemented or misconfigured integration logs a warning and
+/// substitutes `NullCatalogProvider` for that leaf, mirroring how the rest of
+/// QueryFlux's startup degrades rather than refuses to boot on a bad integration
+/// (see `TranslationService::new_sqlglot`'s fallback in `crates/queryflux/src/main.rs`).
+pub fn build_catalog_provider(
+    cfg: &CatalogProviderConfig,
+) -> Pin<Box<dyn Future<Output = Arc<dyn CatalogProvider>> + Send + '_>> {
+    Box::pin(async move {
+        match cfg {
+            CatalogProviderConfig::Null => {
+                Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::Static { schemas } => {
+                Arc::new(StaticCatalogProvider::new(schemas.clone())) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::EngineDelegate { cluster_group } => {
+                tracing::warn!(
+                    cluster_group = %cluster_group,
+                    "catalogProvider: type 'engineDelegate' is not implemented yet — \
+                     using a no-op catalog provider (schema-aware translation will \
+                     fall back to dialect-only)"
+                );
+                Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::Glue { .. } => {
+                tracing::warn!(
+                    "catalogProvider: type 'glue' is not implemented yet — using a \
+                     no-op catalog provider (schema-aware translation will fall back \
+                     to dialect-only)"
+                );
+                Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::HiveMetastore { .. } => {
+                tracing::warn!(
+                    "catalogProvider: type 'hiveMetastore' is not implemented yet — \
+                     using a no-op catalog provider (schema-aware translation will \
+                     fall back to dialect-only)"
+                );
+                Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::Caching {
+                ttl_seconds,
+                max_entries,
+                delegate,
+            } => {
+                let inner = build_catalog_provider(delegate).await;
+                Arc::new(CachingCatalogProvider::new(
+                    inner,
+                    *ttl_seconds,
+                    *max_entries,
+                )) as Arc<dyn CatalogProvider>
+            }
+
+            CatalogProviderConfig::Fallback { primary, secondary } => {
+                let primary = build_catalog_provider(primary).await;
+                let secondary = build_catalog_provider(secondary).await;
+                Arc::new(FallbackCatalogProvider::new(primary, secondary))
+                    as Arc<dyn CatalogProvider>
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn null_config_yields_null_provider() {
+        let provider = build_catalog_provider(&CatalogProviderConfig::Null).await;
+        assert!(provider.is_null());
+    }
+
+    #[tokio::test]
+    async fn unimplemented_variants_degrade_to_null_rather_than_panic() {
+        let provider = build_catalog_provider(&CatalogProviderConfig::EngineDelegate {
+            cluster_group: "trino-default".to_string(),
+        })
+        .await;
+        assert!(provider.list_catalogs().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn caching_and_fallback_compose_recursively() {
+        let cfg = CatalogProviderConfig::Caching {
+            ttl_seconds: 60,
+            max_entries: 100,
+            delegate: Box::new(CatalogProviderConfig::Fallback {
+                primary: Box::new(CatalogProviderConfig::Static { schemas: vec![] }),
+                secondary: Box::new(CatalogProviderConfig::Null),
+            }),
+        };
+        let provider = build_catalog_provider(&cfg).await;
+        // Just proving the tree builds and is callable end to end.
+        assert!(provider.list_catalogs().await.unwrap().is_empty());
+    }
+}

--- a/crates/queryflux-catalog/src/static_provider.rs
+++ b/crates/queryflux-catalog/src/static_provider.rs
@@ -1,0 +1,163 @@
+//! Zero-I/O catalog provider backed by a literal, config-declared schema.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use queryflux_core::catalog::{CatalogProvider, ColumnDef, TableSchema};
+use queryflux_core::config::StaticTableSchema;
+use queryflux_core::error::Result;
+
+/// Serves table/column metadata from a fixed list declared in config
+/// (`catalogProvider: { type: static, schemas: [...] }`). No network calls, no
+/// errors beyond lookup misses — the simplest possible `CatalogProvider`, and the
+/// vehicle for testing schema-aware translation end to end without any external
+/// dependency to stand up.
+pub struct StaticCatalogProvider {
+    schemas: HashMap<(String, String, String), TableSchema>,
+}
+
+impl StaticCatalogProvider {
+    pub fn new(schemas: Vec<StaticTableSchema>) -> Self {
+        let schemas = schemas
+            .into_iter()
+            .map(|s| {
+                let key = (s.catalog.clone(), s.database.clone(), s.table.clone());
+                let columns = s
+                    .columns
+                    .into_iter()
+                    .map(|c| ColumnDef {
+                        name: c.name,
+                        data_type: c.data_type,
+                        nullable: c.nullable,
+                    })
+                    .collect();
+                let value = TableSchema {
+                    catalog: s.catalog,
+                    database: s.database,
+                    table: s.table,
+                    columns,
+                };
+                (key, value)
+            })
+            .collect();
+        Self { schemas }
+    }
+}
+
+#[async_trait]
+impl CatalogProvider for StaticCatalogProvider {
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        let mut catalogs: Vec<String> = self.schemas.keys().map(|(c, _, _)| c.clone()).collect();
+        catalogs.sort();
+        catalogs.dedup();
+        Ok(catalogs)
+    }
+
+    async fn list_databases(&self, catalog: &str) -> Result<Vec<String>> {
+        let mut databases: Vec<String> = self
+            .schemas
+            .keys()
+            .filter(|(c, _, _)| c == catalog)
+            .map(|(_, d, _)| d.clone())
+            .collect();
+        databases.sort();
+        databases.dedup();
+        Ok(databases)
+    }
+
+    async fn list_tables(&self, catalog: &str, database: &str) -> Result<Vec<String>> {
+        let mut tables: Vec<String> = self
+            .schemas
+            .keys()
+            .filter(|(c, d, _)| c == catalog && d == database)
+            .map(|(_, _, t)| t.clone())
+            .collect();
+        tables.sort();
+        Ok(tables)
+    }
+
+    async fn get_table_schema(
+        &self,
+        catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        let key = (catalog.to_string(), database.to_string(), table.to_string());
+        Ok(self.schemas.get(&key).cloned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queryflux_core::config::StaticColumnDef;
+
+    fn sample() -> Vec<StaticTableSchema> {
+        vec![
+            StaticTableSchema {
+                catalog: "hive".into(),
+                database: "analytics".into(),
+                table: "orders".into(),
+                columns: vec![
+                    StaticColumnDef {
+                        name: "order_id".into(),
+                        data_type: "BIGINT".into(),
+                        nullable: false,
+                    },
+                    StaticColumnDef {
+                        name: "total".into(),
+                        data_type: "DECIMAL(10,2)".into(),
+                        nullable: true,
+                    },
+                ],
+            },
+            StaticTableSchema {
+                catalog: "hive".into(),
+                database: "analytics".into(),
+                table: "customers".into(),
+                columns: vec![StaticColumnDef {
+                    name: "customer_id".into(),
+                    data_type: "BIGINT".into(),
+                    nullable: false,
+                }],
+            },
+        ]
+    }
+
+    #[tokio::test]
+    async fn round_trips_configured_schemas() {
+        let provider = StaticCatalogProvider::new(sample());
+
+        assert_eq!(provider.list_catalogs().await.unwrap(), vec!["hive"]);
+        assert_eq!(
+            provider.list_databases("hive").await.unwrap(),
+            vec!["analytics"]
+        );
+        let mut tables = provider.list_tables("hive", "analytics").await.unwrap();
+        tables.sort();
+        assert_eq!(tables, vec!["customers", "orders"]);
+
+        let schema = provider
+            .get_table_schema("hive", "analytics", "orders")
+            .await
+            .unwrap()
+            .expect("orders should be found");
+        assert_eq!(schema.columns.len(), 2);
+        assert_eq!(schema.columns[0].name, "order_id");
+    }
+
+    #[tokio::test]
+    async fn unknown_lookup_returns_none_not_error() {
+        let provider = StaticCatalogProvider::new(sample());
+        assert!(provider
+            .get_table_schema("hive", "analytics", "does_not_exist")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .list_tables("hive", "does_not_exist")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/queryflux-core/src/catalog.rs
+++ b/crates/queryflux-core/src/catalog.rs
@@ -75,6 +75,18 @@ pub trait CatalogProvider: Send + Sync {
         }
         Ok(schemas)
     }
+
+    /// True for a provider that is known to always return empty results (i.e.
+    /// `NullCatalogProvider`). Lets callers on a hot path (schema-aware translation)
+    /// skip catalog lookup — and any SQL parsing needed just to build the lookup
+    /// request — entirely when no real catalog is configured, rather than paying
+    /// that cost only to get an empty answer back. Composite providers (caching,
+    /// fallback) are not required to propagate this from their delegate(s): it's a
+    /// fast-path hint, not a correctness requirement — worst case, a query pays for
+    /// a lookup that returns nothing, exactly as it would without this method.
+    fn is_null(&self) -> bool {
+        false
+    }
 }
 
 /// No-op catalog provider — returns empty results, sqlglot does best-effort translation.
@@ -98,5 +110,8 @@ impl CatalogProvider for NullCatalogProvider {
         _table: &str,
     ) -> Result<Option<TableSchema>> {
         Ok(None)
+    }
+    fn is_null(&self) -> bool {
+        true
     }
 }

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1866,10 +1866,25 @@ pub struct TranslationConfig {
     /// Scripts mutate `ast` in-place; `src`/`dst` carry the dialect names.
     #[serde(default)]
     pub python_scripts: Vec<String>,
+    /// Max time to spend on catalog lookup for schema-aware translation before
+    /// falling back to dialect-only translation. Default 1500ms.
+    #[serde(default = "default_schema_resolution_timeout_ms")]
+    pub schema_resolution_timeout_ms: u64,
+}
+
+fn default_schema_resolution_timeout_ms() -> u64 {
+    1500
 }
 
 // --- Catalog provider ---
 
+// NOTE: `rename_all = "camelCase"` on this container does NOT reliably reach
+// multi-word field names *inside* struct-like variants of an internally-tagged
+// (`tag = "type"`) enum with this serde/serde_yaml version combination — confirmed
+// empirically (deserialization silently reports the snake_case name as "missing"
+// even when the container attribute claims camelCase). Every multi-word variant
+// field below has an explicit `#[serde(rename = "...")]` because of this; don't
+// rely on the container-level rename_all for new fields added here.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum CatalogProviderConfig {
@@ -1878,8 +1893,14 @@ pub enum CatalogProviderConfig {
     Static {
         schemas: Vec<StaticTableSchema>,
     },
-    Trino {
+    /// Delegates catalog discovery to a cluster group's own adapter (Trino, DuckDB,
+    /// StarRocks, Athena, or ClickHouse — whichever engine the group runs). Opt-in
+    /// convenience/fallback, not a recommended default: its accuracy and availability
+    /// are tied to that cluster group's health. Not yet implemented — see
+    /// `plans/` catalog integration plan for phasing.
+    EngineDelegate {
         /// Name of the cluster group to use for metadata queries.
+        #[serde(rename = "clusterGroup")]
         cluster_group: String,
     },
     HiveMetastore {
@@ -1889,9 +1910,14 @@ pub enum CatalogProviderConfig {
         region: Option<String>,
     },
     Caching {
+        #[serde(rename = "ttlSeconds")]
         ttl_seconds: u64,
+        #[serde(rename = "maxEntries")]
         max_entries: usize,
-        #[serde(flatten)]
+        /// The wrapped provider, e.g. `delegate: { type: static, schemas: [] }`.
+        /// Deliberately *not* `#[serde(flatten)]`: `CatalogProviderConfig` is itself
+        /// an internally-tagged enum (`tag = "type"`), so flattening it here would
+        /// require two `type` keys in the same YAML mapping — nest it instead.
         delegate: Box<CatalogProviderConfig>,
     },
     Fallback {
@@ -3257,5 +3283,127 @@ auth:
             }),
         };
         assert!(authz.validate().is_err());
+    }
+}
+
+/// Regression coverage for `CatalogProviderConfig` YAML round-tripping.
+///
+/// This enum's variants went untested against real YAML for a long time (it was
+/// declared but never wired to a live provider), and that let two real bugs slip
+/// in unnoticed: `#[serde(flatten)]` on a nested internally-tagged enum requiring
+/// two `type` keys in one mapping, and `rename_all = "camelCase"` on the
+/// container not reaching multi-word field names inside this enum's variants
+/// (confirmed empirically against this serde/serde_yaml version combination —
+/// every such field now has an explicit `#[serde(rename = "...")]` instead).
+/// These tests exist so both classes of bug can't silently reappear.
+#[cfg(test)]
+mod catalog_provider_config_tests {
+    use super::CatalogProviderConfig;
+
+    #[test]
+    fn null_is_the_default_and_parses_from_yaml() {
+        assert!(matches!(
+            CatalogProviderConfig::default(),
+            CatalogProviderConfig::Null
+        ));
+        let cfg: CatalogProviderConfig = serde_yaml::from_str("type: null\n").unwrap();
+        assert!(matches!(cfg, CatalogProviderConfig::Null));
+    }
+
+    #[test]
+    fn static_schemas_round_trip_camel_case() {
+        let yaml = r#"
+type: static
+schemas:
+  - catalog: hive
+    database: analytics
+    table: orders
+    columns:
+      - { name: order_id, dataType: BIGINT, nullable: false }
+"#;
+        let cfg: CatalogProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        match cfg {
+            CatalogProviderConfig::Static { schemas } => {
+                assert_eq!(schemas.len(), 1);
+                assert_eq!(schemas[0].table, "orders");
+                assert_eq!(schemas[0].columns[0].data_type, "BIGINT");
+            }
+            other => panic!("expected Static, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn engine_delegate_cluster_group_uses_camel_case_key() {
+        let cfg: CatalogProviderConfig =
+            serde_yaml::from_str("type: engineDelegate\nclusterGroup: trino-default\n").unwrap();
+        match cfg {
+            CatalogProviderConfig::EngineDelegate { cluster_group } => {
+                assert_eq!(cluster_group, "trino-default");
+            }
+            other => panic!("expected EngineDelegate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn caching_wraps_a_nested_delegate_not_flattened() {
+        let yaml = r#"
+type: caching
+ttlSeconds: 300
+maxEntries: 10000
+delegate:
+  type: static
+  schemas: []
+"#;
+        let cfg: CatalogProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        match cfg {
+            CatalogProviderConfig::Caching {
+                ttl_seconds,
+                max_entries,
+                delegate,
+            } => {
+                assert_eq!(ttl_seconds, 300);
+                assert_eq!(max_entries, 10000);
+                assert!(matches!(*delegate, CatalogProviderConfig::Static { .. }));
+            }
+            other => panic!("expected Caching, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fallback_primary_and_secondary_nest_independently() {
+        // "null" must be quoted here — a bare YAML `null` parses as YAML's null
+        // type, not the string the `type` tag needs to match the Null variant.
+        let yaml = r#"
+type: fallback
+primary:
+  type: static
+  schemas: []
+secondary:
+  type: "null"
+"#;
+        let cfg: CatalogProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        match cfg {
+            CatalogProviderConfig::Fallback { primary, secondary } => {
+                assert!(matches!(*primary, CatalogProviderConfig::Static { .. }));
+                assert!(matches!(*secondary, CatalogProviderConfig::Null));
+            }
+            other => panic!("expected Fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn glue_and_hive_metastore_parse() {
+        let glue: CatalogProviderConfig =
+            serde_yaml::from_str("type: glue\nregion: us-east-1\n").unwrap();
+        assert!(matches!(
+            glue,
+            CatalogProviderConfig::Glue {
+                region: Some(ref r)
+            } if r == "us-east-1"
+        ));
+
+        let hms: CatalogProviderConfig =
+            serde_yaml::from_str("type: hiveMetastore\nuri: thrift://localhost:9083\n").unwrap();
+        assert!(matches!(hms, CatalogProviderConfig::HiveMetastore { .. }));
     }
 }

--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -364,6 +364,7 @@ impl TestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(CapturingMetrics {
                 records: records.clone(),
             }),
@@ -613,6 +614,7 @@ impl WireTestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NullMetrics),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
@@ -756,6 +758,7 @@ impl WireTestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NullMetrics),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
@@ -927,6 +930,7 @@ impl ProtocolWireHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(CapturingMetrics {
                 records: records.clone(),
             }),

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -27,7 +27,6 @@ use queryflux_engine_adapters::{
 };
 use queryflux_guardrails::{GuardChain, GuardContext, GuardLayer};
 use queryflux_metrics::MetricsStore;
-use queryflux_translation::SchemaContext;
 
 use tracing::{debug, info, warn};
 
@@ -354,13 +353,17 @@ pub async fn dispatch_query(
     let engine_type = adapter_kind.engine_type();
     let original_sql = sql.clone();
     let sql = if should_attempt_translation(&session, &protocol) {
+        let schema_context = state
+            .translation
+            .resolve_schema_context(&sql, &src_dialect, &state.catalog, None, session.database())
+            .await;
         match state
             .translation
             .maybe_translate(
                 &sql,
                 &src_dialect,
                 &tgt_dialect,
-                &SchemaContext::default(),
+                &schema_context,
                 &group_fixups,
             )
             .await
@@ -1405,13 +1408,17 @@ async fn setup_sync_query(
     // (sqlglot never invoked) when should_attempt_translation is false — see its doc
     // comment for why MCP without a declared dialect takes this path.
     let translated = if should_attempt_translation(&session, &protocol) {
+        let schema_context = state
+            .translation
+            .resolve_schema_context(&sql, &src_dialect, &state.catalog, None, session.database())
+            .await;
         match state
             .translation
             .maybe_translate(
                 &sql,
                 &src_dialect,
                 &tgt_dialect,
-                &SchemaContext::default(),
+                &schema_context,
                 &group_fixups,
             )
             .await

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use queryflux_auth::{AuthProvider, AuthorizationChecker, BackendIdentityResolver};
 use queryflux_cluster_manager::{cluster_state::ClusterState, ClusterGroupManager};
 use queryflux_core::{
+    catalog::CatalogProvider,
     config::ClusterConfig,
     params::QueryParams,
     query::{
@@ -83,6 +84,11 @@ pub struct AppState {
     // Static (never reloaded):
     pub persistence: Arc<dyn Persistence>,
     pub translation: Arc<TranslationService>,
+    /// Discovers table/column metadata for schema-aware translation
+    /// (`TranslationService::resolve_schema_context`). `NullCatalogProvider` when no
+    /// `catalogProvider` is configured — every call site treats that identically to
+    /// "catalog lookup found nothing," never as an error.
+    pub catalog: Arc<dyn CatalogProvider>,
     pub metrics: Arc<dyn MetricsStore>,
     /// Resolves per-user `QueryCredentials` from `AuthContext` + cluster `queryAuth` config.
     pub identity_resolver: Arc<BackendIdentityResolver>,
@@ -680,6 +686,7 @@ pub mod test_fixtures {
             live: Arc::new(RwLock::new(live)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation: Arc::new(TranslationService::disabled()),
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics,
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1641,6 +1641,7 @@ mod cancel_executing_statement_tests {
             live: Arc::new(RwLock::new(live)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation: Arc::new(TranslationService::disabled()),
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NoopMetricsStore),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,

--- a/crates/queryflux-translation/src/lib.rs
+++ b/crates/queryflux-translation/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod sqlglot;
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
-use queryflux_core::{error::Result, query::SqlDialect};
-pub use sqlglot::SqlglotTranslator;
+use queryflux_core::{catalog::CatalogProvider, error::Result, query::SqlDialect};
+pub use sqlglot::{extract_table_refs_async, SqlglotTranslator, TableRef};
 
 /// Schema context passed to the translator so sqlglot can produce accurate output.
 /// Maps table name → { column name → SQL type string }.
@@ -71,9 +73,15 @@ impl TranslatorTrait for PassthroughTranslator {
 /// must define `def transform(ast, src: str, dst: str) -> None:`. Top-level
 /// imports and helper functions are fully supported. Scripts mutate `ast`
 /// in-place.
+/// Default catalog-lookup timeout for `resolve_schema_context` when the caller
+/// doesn't override it via `with_schema_resolution_timeout` — matches
+/// `TranslationConfig`'s own default.
+const DEFAULT_SCHEMA_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(1500);
+
 pub struct TranslationService {
     enabled: bool,
     python_scripts: Vec<String>,
+    schema_resolution_timeout: Duration,
 }
 
 impl TranslationService {
@@ -84,6 +92,7 @@ impl TranslationService {
         Ok(Self {
             enabled: true,
             python_scripts,
+            schema_resolution_timeout: DEFAULT_SCHEMA_RESOLUTION_TIMEOUT,
         })
     }
 
@@ -92,7 +101,15 @@ impl TranslationService {
         Self {
             enabled: false,
             python_scripts: Vec::new(),
+            schema_resolution_timeout: DEFAULT_SCHEMA_RESOLUTION_TIMEOUT,
         }
+    }
+
+    /// Overrides the default catalog-lookup timeout `resolve_schema_context` uses
+    /// (config: `translation.schemaResolutionTimeoutMs`).
+    pub fn with_schema_resolution_timeout(mut self, timeout: Duration) -> Self {
+        self.schema_resolution_timeout = timeout;
+        self
     }
 
     /// Translate `sql` from `src` to `tgt` if they differ.
@@ -118,5 +135,89 @@ impl TranslationService {
         }
         let translator = SqlglotTranslator::new(src.clone(), tgt.clone(), combined);
         translator.translate(sql, schema).await
+    }
+
+    /// Best-effort schema resolution: extract the tables `sql` references, look them
+    /// up via `catalog`, and flatten the result into a `SchemaContext` for
+    /// `maybe_translate`. **Never fails** — a parse error, catalog error, or timeout
+    /// all degrade to `SchemaContext::default()` (today's behavior without any
+    /// catalog configured), so calling this can only ever improve translation
+    /// accuracy, never block or break a query. Skips SQL parsing entirely when
+    /// `catalog.is_null()`, so a query pays nothing extra when no catalog is configured.
+    /// Uses `self`'s configured timeout (default 1500ms, see
+    /// `with_schema_resolution_timeout`) for both the extraction step and the
+    /// catalog-lookup step, budgeted separately.
+    pub async fn resolve_schema_context(
+        &self,
+        sql: &str,
+        src_dialect: &SqlDialect,
+        catalog: &Arc<dyn CatalogProvider>,
+        default_catalog: Option<&str>,
+        default_database: Option<&str>,
+    ) -> SchemaContext {
+        if catalog.is_null() {
+            return SchemaContext::default();
+        }
+        let timeout = self.schema_resolution_timeout;
+
+        let dialect = src_dialect.sqlglot_write_name().to_string();
+        let refs =
+            match tokio::time::timeout(timeout, extract_table_refs_async(sql.to_string(), dialect))
+                .await
+            {
+                Ok(Ok(refs)) if !refs.is_empty() => refs,
+                Ok(Ok(_)) => return SchemaContext::default(),
+                Ok(Err(e)) => {
+                    tracing::debug!("resolve_schema_context: table-ref extraction failed: {e}");
+                    return SchemaContext::default();
+                }
+                Err(_) => {
+                    tracing::debug!("resolve_schema_context: table-ref extraction timed out");
+                    return SchemaContext::default();
+                }
+            };
+
+        let tables: Vec<&str> = refs.iter().map(|r| r.table.as_str()).collect();
+        let resolved_catalog = refs
+            .first()
+            .and_then(|r| r.catalog.as_deref())
+            .or(default_catalog);
+        let resolved_database = refs
+            .first()
+            .and_then(|r| r.database.as_deref())
+            .or(default_database);
+
+        let schemas = match tokio::time::timeout(
+            timeout,
+            catalog.get_schemas_for_query(resolved_catalog, resolved_database, &tables),
+        )
+        .await
+        {
+            Ok(Ok(schemas)) => schemas,
+            Ok(Err(e)) => {
+                tracing::debug!("resolve_schema_context: catalog lookup failed: {e}");
+                return SchemaContext::default();
+            }
+            Err(_) => {
+                tracing::debug!("resolve_schema_context: catalog lookup timed out");
+                return SchemaContext::default();
+            }
+        };
+
+        let mut tables_map = HashMap::new();
+        for schema in schemas {
+            let cols = schema
+                .columns
+                .iter()
+                .map(|c| (c.name.clone(), c.data_type.clone()))
+                .collect();
+            tables_map.insert(schema.table.clone(), cols);
+        }
+
+        SchemaContext {
+            catalog: resolved_catalog.map(String::from),
+            database: resolved_database.map(String::from),
+            tables: tables_map,
+        }
     }
 }

--- a/crates/queryflux-translation/src/sqlglot.rs
+++ b/crates/queryflux-translation/src/sqlglot.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -8,6 +10,124 @@ use queryflux_core::{
 use tracing::debug;
 
 use crate::{SchemaContext, TranslatorTrait};
+
+/// A table reference as written in the SQL, before catalog/database defaulting.
+/// Distinct from (and unrelated to) the `TableRef` used elsewhere in this org for
+/// query-history intelligence — this one is fed straight into catalog lookup for
+/// schema-aware translation and never persisted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableRef {
+    pub catalog: Option<String>,
+    pub database: Option<String>,
+    pub table: String,
+}
+
+/// Parse `sql` under `dialect` and return every distinct table it references (via
+/// sqlglot's `exp.Table` nodes), excluding names that resolve to a CTE defined in
+/// the same query rather than a real table. Best-effort: a parse failure yields
+/// `Ok(vec![])`, not an error — callers should treat that identically to "no
+/// schema info available" and fall back to dialect-only translation.
+pub fn extract_table_refs(sql: &str, dialect: &str) -> Result<Vec<TableRef>> {
+    Python::attach(|py| extract_table_refs_with_gil(py, sql, dialect))
+}
+
+/// Async wrapper around `extract_table_refs`, off the async executor (same
+/// `spawn_blocking` pattern `SqlglotTranslator::translate` already uses for GIL work).
+pub async fn extract_table_refs_async(sql: String, dialect: String) -> Result<Vec<TableRef>> {
+    tokio::task::spawn_blocking(move || extract_table_refs(&sql, &dialect))
+        .await
+        .map_err(|e| QueryFluxError::Translation(format!("spawn_blocking error: {e}")))?
+}
+
+fn extract_table_refs_with_gil(py: Python<'_>, sql: &str, dialect: &str) -> Result<Vec<TableRef>> {
+    let sqlglot = PyModule::import(py, "sqlglot")
+        .map_err(|e| QueryFluxError::Translation(format!("Failed to import sqlglot: {e}")))?;
+    let exp = PyModule::import(py, "sqlglot.expressions").map_err(|e| {
+        QueryFluxError::Translation(format!("Failed to import sqlglot.expressions: {e}"))
+    })?;
+
+    let parse_kwargs = PyDict::new(py);
+    parse_kwargs.set_item("dialect", dialect).ok();
+    let tree = match sqlglot.call_method("parse_one", (sql,), Some(&parse_kwargs)) {
+        Ok(t) => t,
+        Err(e) => {
+            debug!("extract_table_refs: parse_one failed, treating as no refs: {e}");
+            return Ok(vec![]);
+        }
+    };
+
+    // CTE aliases shadow same-named real tables within this query — an unqualified
+    // reference to one is never a catalog lookup target.
+    let cte_cls = exp
+        .getattr("CTE")
+        .map_err(|e| QueryFluxError::Translation(format!("no sqlglot.expressions.CTE: {e}")))?;
+    let ctes = tree
+        .call_method1("find_all", (cte_cls,))
+        .map_err(|e| QueryFluxError::Translation(format!("find_all(CTE) failed: {e}")))?;
+    let mut cte_aliases: HashSet<String> = HashSet::new();
+    for cte in ctes
+        .try_iter()
+        .map_err(|e| QueryFluxError::Translation(format!("iterate CTEs failed: {e}")))?
+    {
+        let cte = cte.map_err(|e| QueryFluxError::Translation(format!("CTE item failed: {e}")))?;
+        // `alias_or_name` is a sqlglot property, not a method — plain attribute access.
+        if let Ok(alias) = cte
+            .getattr("alias_or_name")
+            .and_then(|v| v.extract::<String>())
+        {
+            if !alias.is_empty() {
+                cte_aliases.insert(alias);
+            }
+        }
+    }
+
+    let table_cls = exp
+        .getattr("Table")
+        .map_err(|e| QueryFluxError::Translation(format!("no sqlglot.expressions.Table: {e}")))?;
+    let tables = tree
+        .call_method1("find_all", (table_cls,))
+        .map_err(|e| QueryFluxError::Translation(format!("find_all(Table) failed: {e}")))?;
+
+    let mut refs = Vec::new();
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
+    for table in tables
+        .try_iter()
+        .map_err(|e| QueryFluxError::Translation(format!("iterate tables failed: {e}")))?
+    {
+        let table =
+            table.map_err(|e| QueryFluxError::Translation(format!("table item failed: {e}")))?;
+        let name: String = table
+            .getattr("name")
+            .and_then(|v| v.extract())
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue; // e.g. a derived/subquery table with no literal name
+        }
+        let catalog: String = table
+            .getattr("catalog")
+            .and_then(|v| v.extract())
+            .unwrap_or_default();
+        let database: String = table
+            .getattr("db")
+            .and_then(|v| v.extract())
+            .unwrap_or_default();
+
+        if catalog.is_empty() && database.is_empty() && cte_aliases.contains(&name) {
+            continue;
+        }
+
+        let key = (catalog.clone(), database.clone(), name.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        refs.push(TableRef {
+            catalog: (!catalog.is_empty()).then_some(catalog),
+            database: (!database.is_empty()).then_some(database),
+            table: name,
+        });
+    }
+    Ok(refs)
+}
 
 /// SQL translator backed by the sqlglot Python library (via PyO3).
 pub struct SqlglotTranslator {
@@ -254,4 +374,62 @@ fn run_fixup_scripts(
         .map_err(|e| QueryFluxError::Translation(format!("transform: extract failed: {e}")))?;
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod extract_table_refs_tests {
+    use super::*;
+
+    #[test]
+    fn extracts_qualified_and_unqualified_tables() {
+        let refs = extract_table_refs("SELECT * FROM hive.analytics.orders", "trino").unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].catalog.as_deref(), Some("hive"));
+        assert_eq!(refs[0].database.as_deref(), Some("analytics"));
+        assert_eq!(refs[0].table, "orders");
+
+        let refs = extract_table_refs("SELECT x FROM t", "trino").unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].catalog, None);
+        assert_eq!(refs[0].database, None);
+        assert_eq!(refs[0].table, "t");
+    }
+
+    #[test]
+    fn extracts_all_tables_in_a_join_without_duplicates() {
+        let refs = extract_table_refs(
+            "SELECT * FROM orders o JOIN orders x ON o.id = x.id JOIN customers c ON o.customer_id = c.id",
+            "trino",
+        )
+        .unwrap();
+        let names: std::collections::HashSet<_> = refs.iter().map(|r| r.table.as_str()).collect();
+        // `orders` is joined against itself under two aliases — must appear once.
+        assert_eq!(names, ["orders", "customers"].into_iter().collect());
+    }
+
+    #[test]
+    fn cte_aliases_are_excluded_but_real_tables_survive() {
+        let refs = extract_table_refs(
+            "WITH recent AS (SELECT a FROM real_table) SELECT * FROM recent",
+            "trino",
+        )
+        .unwrap();
+        let names: Vec<&str> = refs.iter().map(|r| r.table.as_str()).collect();
+        assert_eq!(names, vec!["real_table"]);
+    }
+
+    #[test]
+    fn malformed_sql_yields_empty_not_error() {
+        let refs = extract_table_refs("SELECT FROM WHERE", "trino").unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn async_wrapper_matches_sync_result() {
+        let refs = extract_table_refs_async("SELECT * FROM t".to_string(), "trino".to_string())
+            .await
+            .unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].table, "t");
+    }
 }

--- a/crates/queryflux-translation/tests/schema_aware_translation.rs
+++ b/crates/queryflux-translation/tests/schema_aware_translation.rs
@@ -1,0 +1,145 @@
+//! Proves `SchemaContext` actually engages sqlglot's schema-aware optimizer branch
+//! (not just the dialect-only transpile path), and exercises
+//! `TranslationService::resolve_schema_context` end to end against a fake
+//! `CatalogProvider` — without depending on `queryflux-catalog` (translation only
+//! needs the `CatalogProvider` trait, not any concrete implementation).
+//!
+//! Requires a working PyO3 interpreter with `sqlglot` on `PYTHONPATH` (same as CI:
+//! venv + `pip install -r requirements.txt`). Run: `cargo test -p queryflux-translation`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use queryflux_core::catalog::{CatalogProvider, ColumnDef, TableSchema};
+use queryflux_core::error::Result;
+use queryflux_core::query::SqlDialect;
+use queryflux_translation::{
+    SchemaContext, SqlglotTranslator, TranslationService, TranslatorTrait,
+};
+
+fn require_sqlglot() {
+    SqlglotTranslator::check_available().expect(
+        "sqlglot not importable — set PYO3_PYTHON to a venv with `pip install -r requirements.txt`",
+    );
+}
+
+/// Serves exactly one table, `t(x INT)` — enough to prove schema-aware behavior
+/// without pulling in `queryflux-catalog`.
+struct OneTableCatalog;
+
+#[async_trait]
+impl CatalogProvider for OneTableCatalog {
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+    async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+    async fn list_tables(&self, _catalog: &str, _database: &str) -> Result<Vec<String>> {
+        Ok(vec!["t".to_string()])
+    }
+    async fn get_table_schema(
+        &self,
+        _catalog: &str,
+        _database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        if table != "t" {
+            return Ok(None);
+        }
+        Ok(Some(TableSchema {
+            catalog: String::new(),
+            database: String::new(),
+            table: "t".to_string(),
+            columns: vec![ColumnDef {
+                name: "x".to_string(),
+                data_type: "INT".to_string(),
+                nullable: false,
+            }],
+        }))
+    }
+}
+
+#[tokio::test]
+async fn schema_aware_translation_qualifies_columns_dialect_only_does_not() {
+    require_sqlglot();
+    // Trino -> DuckDb (not Trino -> Trino): `translate_with_gil` treats matching
+    // src/tgt as an unconditional no-op regardless of schema_context, so same-dialect
+    // would never reach either branch and couldn't prove anything here.
+    let translator = SqlglotTranslator::new(SqlDialect::Trino, SqlDialect::DuckDb, vec![]);
+
+    let mut tables = HashMap::new();
+    tables.insert(
+        "t".to_string(),
+        HashMap::from([("x".to_string(), "INT".to_string())]),
+    );
+    let schema = SchemaContext {
+        catalog: None,
+        database: None,
+        tables,
+    };
+    let with_schema = translator
+        .translate("SELECT x FROM t", &schema)
+        .await
+        .unwrap();
+    assert!(
+        with_schema.contains("\"t\".\"x\""),
+        "schema-aware optimizer should qualify the unqualified column: {with_schema}"
+    );
+
+    let dialect_only = translator
+        .translate("SELECT x FROM t", &SchemaContext::default())
+        .await
+        .unwrap();
+    assert!(
+        !dialect_only.contains("\"t\".\"x\""),
+        "dialect-only translation must not qualify columns: {dialect_only}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_schema_context_feeds_maybe_translate_end_to_end() {
+    require_sqlglot();
+    let service = TranslationService::new_sqlglot(vec![]).unwrap();
+    let catalog: Arc<dyn CatalogProvider> = Arc::new(OneTableCatalog);
+
+    let schema_context = service
+        .resolve_schema_context("SELECT x FROM t", &SqlDialect::Trino, &catalog, None, None)
+        .await;
+    assert!(!schema_context.is_empty());
+    assert_eq!(
+        schema_context.tables.get("t").and_then(|c| c.get("x")),
+        Some(&"INT".to_string())
+    );
+
+    // Trino -> DuckDb is not dialect-compatible, so maybe_translate can't take its
+    // same-dialect fast path (lib.rs:116) — it must actually invoke sqlglot, and the
+    // resolved schema_context should make that invocation the schema-aware branch.
+    let translated = service
+        .maybe_translate(
+            "SELECT x FROM t",
+            &SqlDialect::Trino,
+            &SqlDialect::DuckDb,
+            &schema_context,
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(
+        translated.contains("\"t\".\"x\""),
+        "resolve_schema_context's output should have driven the schema-aware branch: {translated}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_schema_context_is_empty_when_catalog_is_null() {
+    require_sqlglot();
+    let service = TranslationService::new_sqlglot(vec![]).unwrap();
+    let catalog: Arc<dyn CatalogProvider> = Arc::new(queryflux_core::catalog::NullCatalogProvider);
+
+    let schema_context = service
+        .resolve_schema_context("SELECT x FROM t", &SqlDialect::Trino, &catalog, None, None)
+        .await;
+    assert!(schema_context.is_empty());
+}

--- a/crates/queryflux/Cargo.toml
+++ b/crates/queryflux/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 queryflux-core = { workspace = true }
+queryflux-catalog = { workspace = true }
 queryflux-auth = { workspace = true }
 queryflux-config = { workspace = true }
 queryflux-persistence = { workspace = true }

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -662,13 +662,23 @@ async fn main() -> Result<()> {
 
     // --- Build translation service ---
     let translation = Arc::new(
-        TranslationService::new_sqlglot(config.translation.python_scripts.clone()).unwrap_or_else(
-            |e| {
+        TranslationService::new_sqlglot(config.translation.python_scripts.clone())
+            .unwrap_or_else(|e| {
                 tracing::warn!("sqlglot unavailable ({e}), translation disabled");
                 TranslationService::disabled()
-            },
-        ),
+            })
+            .with_schema_resolution_timeout(std::time::Duration::from_millis(
+                config.translation.schema_resolution_timeout_ms,
+            )),
     );
+
+    // --- Build catalog provider ---
+    // Feeds `translation.resolve_schema_context` so sqlglot's optimizer can qualify
+    // columns/types instead of falling back to dialect-only translation. Never fails
+    // startup: an unimplemented or misconfigured integration degrades to a no-op
+    // (see `queryflux_catalog::build_catalog_provider`), same philosophy as `translation` above.
+    let catalog: Arc<dyn queryflux_core::catalog::CatalogProvider> =
+        queryflux_catalog::build_catalog_provider(&config.catalog_provider).await;
 
     // --- Build router chain ---
     let fallback = ClusterGroupName(config.routing_fallback.clone());
@@ -1121,6 +1131,7 @@ async fn main() -> Result<()> {
         live: live.clone(),
         persistence,
         translation,
+        catalog,
         metrics,
         identity_resolver,
         capacity_store,


### PR DESCRIPTION
## Summary

Foundation phase of native catalog integration — closes the gap where schema-aware SQL translation was dead code: both call sites in `dispatch.rs` always passed an empty `SchemaContext`, so `sqlglot`'s optimizer branch (`MappingSchema` / column qualification) never ran in production.

Design doc: local plan, happy to share/port to a Discussion if useful (references [#196](https://github.com/lakeops-org/queryflux/discussions/196)).

## What's in this PR (Phase 1 — Foundation)

- **New `queryflux-catalog` crate**: `StaticCatalogProvider` (literal config-declared schema), `CachingCatalogProvider` (TTL + FIFO eviction), `FallbackCatalogProvider` (primary/secondary — falls through on error always, and on a missing single table specifically, but *not* on a legitimately empty `list_tables`/`list_databases`), and `build_catalog_provider()` recursively building a live provider tree from `CatalogProviderConfig`. Depends only on `queryflux-core` — no query engine required.
- **`queryflux-translation`**: `extract_table_refs`/`extract_table_refs_async` (PyO3, reuses the existing sqlglot binding — no new dependency) parse the tables a query references, excluding CTE aliases. `TranslationService::resolve_schema_context` ties extraction → catalog lookup → flattening together: best-effort, timeout-guarded, **never fails** — any parse error, catalog error, or timeout degrades to `SchemaContext::default()`, identical to today's behavior. This is strictly additive.
- **`queryflux-frontend`**: new `AppState.catalog` field (defaults to `NullCatalogProvider`); both `dispatch.rs` call sites build a real `SchemaContext` via `resolve_schema_context` instead of hardcoding `SchemaContext::default()`.
- **`queryflux-core`**: renamed the unshipped `CatalogProviderConfig::Trino { cluster_group }` → `EngineDelegate { cluster_group }` (generalized — every adapter except generic ADBC already has real catalog introspection, not just Trino); added `CatalogProvider::is_null()` so a query pays zero extra cost (no PyO3 table extraction) when no catalog is configured; added `TranslationConfig.schemaResolutionTimeoutMs` (default 1500ms).

Unimplemented config variants (`Glue`, `HiveMetastore`, `EngineDelegate`) degrade to a no-op provider with a startup warning rather than failing to boot — same philosophy as the existing `TranslationService::new_sqlglot` fallback.

### Bonus: two latent bugs fixed in `CatalogProviderConfig`

This enum existed in config but was never exercised against real YAML before this PR. Wiring it up surfaced two real bugs, both now covered by regression tests (`crates/queryflux-core/src/config.rs`, `catalog_provider_config_tests`):

1. `#[serde(flatten)]` on `Caching`'s nested `delegate: Box<CatalogProviderConfig>` — invalid, since flattening an internally-tagged enum (`tag = "type"`) into a parent that also tags on `type` requires two `type` keys in one mapping. Removed; `delegate` is now a normal nested field.
2. `rename_all = "camelCase"` on the enum container silently didn't reach multi-word field names *inside* variants for this serde/serde_yaml version combo (e.g. `ttl_seconds` stayed snake_case on the wire, `clusterGroup` was rejected). Fixed with explicit `#[serde(rename = "...")]` per field.

## Explicitly out of scope (follow-up PRs)

- Real external integrations: `GlueCatalogProvider`, `IcebergRestCatalogProvider` (built on the upstream `iceberg`/`iceberg-catalog-rest` crates), `SnowflakeCatalogProvider`, `EngineDelegateCatalogProvider`.
- Read-only admin API surface for browsing discovered catalogs (`/admin/catalogs/...`) and `catalogProvider` config CRUD.
- `HiveMetastore` real implementation.

## Testing

- `cargo test --workspace --exclude queryflux-e2e-tests` — all green (167 tests, including 20 new: 11 in `queryflux-catalog`, 6 new `CatalogProviderConfig` regression tests, 8 in `queryflux-translation` covering `extract_table_refs` + a behavioral before/after proof that `resolve_schema_context`'s output actually drives sqlglot's schema-aware optimizer branch, not just the dialect-only path).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` — clean, matching CI.
- Manually verified every `catalogProvider` YAML shape (`null`/`static`/`caching`/`fallback`/`engineDelegate`/`glue`/`hiveMetastore`) round-trips through the real `serde_yaml::from_str::<ProxyConfig>` path `queryflux-config`'s loader actually uses.
- `config.example.yaml` gets a new `catalogProvider:` block (defaults to `type: null`, i.e. today's behavior unchanged) with commented `static`/`caching`/`fallback` examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema-aware SQL translation using catalog metadata.
  * Added configurable catalog providers, including static, caching, fallback, and no-op options.
  * Added configurable schema-resolution timeouts, defaulting to 1.5 seconds.
  * Added SQL table-reference discovery for improved metadata resolution.
* **Documentation**
  * Expanded the example configuration with catalog provider and caching options.
* **Bug Fixes**
  * Catalog lookup failures, timeouts, and unsupported providers now safely fall back without blocking translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->