### PR TITLE
feat: admin API + Studio UI for catalog provider config, plus docs

### DIFF
--- a/crates/queryflux-e2e-tests/src/harness.rs
+++ b/crates/queryflux-e2e-tests/src/harness.rs
@@ -357,6 +357,7 @@ impl TestHarness {
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
         let records = Arc::new(Mutex::new(Vec::<QueryRecord>::new()));
         let state = Arc::new(AppState {
@@ -364,7 +365,6 @@ impl TestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(CapturingMetrics {
                 records: records.clone(),
             }),
@@ -607,6 +607,7 @@ impl WireTestHarness {
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
 
         let state = Arc::new(AppState {
@@ -614,7 +615,6 @@ impl WireTestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NullMetrics),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
@@ -751,6 +751,7 @@ impl WireTestHarness {
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
 
         let state = Arc::new(AppState {
@@ -758,7 +759,6 @@ impl WireTestHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NullMetrics),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,
@@ -922,6 +922,7 @@ impl ProtocolWireHarness {
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
 
         let records: Arc<Mutex<Vec<QueryRecord>>> = Arc::new(Mutex::new(Vec::new()));
@@ -930,7 +931,6 @@ impl ProtocolWireHarness {
             live: Arc::new(tokio::sync::RwLock::new(live_config)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation,
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(CapturingMetrics {
                 records: records.clone(),
             }),

--- a/crates/queryflux-frontend/src/admin.rs
+++ b/crates/queryflux-frontend/src/admin.rs
@@ -56,6 +56,19 @@ pub type TestClusterFn = Arc<
         + Sync,
 >;
 
+/// Callback type for testing a `catalogProvider` config without persisting it.
+/// Receives the raw config JSON → returns `Ok(true)` if the provider was built and
+/// responded to a smoke-test call, `Ok(false)` if it degraded to a no-op (e.g. an
+/// unimplemented provider type) or the smoke-test call itself returned an error,
+/// `Err(msg)` if the config didn't even parse into a `CatalogProviderConfig`.
+pub type TestCatalogProviderFn = Arc<
+    dyn Fn(
+            serde_json::Value,
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<(bool, String)>> + Send>>
+        + Send
+        + Sync,
+>;
+
 // ---------------------------------------------------------------------------
 // OpenAPI spec
 // ---------------------------------------------------------------------------
@@ -123,6 +136,9 @@ pub struct ClusterStateDto {
         put_routing_config_handler,
         get_guardrails_config_handler,
         put_guardrails_config_handler,
+        get_catalog_config_handler,
+        put_catalog_config_handler,
+        test_catalog_config_handler,
         // Agents & conversations
         list_agents_handler,
         list_conversations_handler,
@@ -147,6 +163,8 @@ pub struct ClusterStateDto {
         queryflux_persistence::cluster_config::RenameConfigRequest,
         queryflux_persistence::query_history::AgentSummary,
         queryflux_persistence::query_history::ConversationSummary,
+        TestCatalogProviderRequest,
+        TestCatalogProviderResponse,
     )),
     tags(
         (name = "admin", description = "Cluster and query management"),
@@ -536,6 +554,9 @@ struct AdminState {
     admin_store: Option<Arc<dyn AdminStore>>,
     security_config: Arc<SecurityConfigDto>,
     routing_config: Arc<RoutingConfigDto>,
+    /// Startup (YAML) `catalogProvider` config — GET's fallback when nothing has
+    /// been persisted via the admin API yet.
+    catalog_provider_config: Arc<queryflux_core::config::CatalogProviderConfig>,
     engine_registry: Arc<EngineRegistry>,
     /// Wake the config reload task immediately after mutating persisted config.
     /// Uses `ConfigRevisionStore::bump_revision()` for distributed notification
@@ -547,6 +568,8 @@ struct AdminState {
     admin_creds: Arc<AdminCredentialsManager>,
     /// Test a cluster config (build adapter + health_check) without persisting it.
     test_cluster_fn: TestClusterFn,
+    /// Test a catalogProvider config (build it + smoke-test) without persisting it.
+    test_catalog_provider_fn: TestCatalogProviderFn,
     /// Query result cache for invalidation endpoints.
     result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
     /// Shared proxy state — in-flight queries, adapters, slot release.
@@ -564,11 +587,13 @@ pub struct AdminFrontend {
     port: u16,
     security_config: Arc<SecurityConfigDto>,
     routing_config: Arc<RoutingConfigDto>,
+    catalog_provider_config: Arc<queryflux_core::config::CatalogProviderConfig>,
     engine_registry: Arc<EngineRegistry>,
     config_reload_notify: Arc<tokio::sync::Notify>,
     frontends_status: FrontendsStatusDto,
     admin_creds: Arc<AdminCredentialsManager>,
     test_cluster_fn: TestClusterFn,
+    test_catalog_provider_fn: TestCatalogProviderFn,
     cors_allowed_origins: Vec<String>,
     result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
     app: Arc<AppState>,
@@ -583,11 +608,13 @@ impl AdminFrontend {
         port: u16,
         security_config: Arc<SecurityConfigDto>,
         routing_config: Arc<RoutingConfigDto>,
+        catalog_provider_config: Arc<queryflux_core::config::CatalogProviderConfig>,
         engine_registry: Arc<EngineRegistry>,
         config_reload_notify: Arc<tokio::sync::Notify>,
         frontends_status: FrontendsStatusDto,
         admin_creds: Arc<AdminCredentialsManager>,
         test_cluster_fn: TestClusterFn,
+        test_catalog_provider_fn: TestCatalogProviderFn,
         cors_allowed_origins: Vec<String>,
         result_cache: Arc<dyn queryflux_cache::QueryResultCache>,
         app: Arc<AppState>,
@@ -599,11 +626,13 @@ impl AdminFrontend {
             port,
             security_config,
             routing_config,
+            catalog_provider_config,
             engine_registry,
             config_reload_notify,
             frontends_status,
             admin_creds,
             test_cluster_fn,
+            test_catalog_provider_fn,
             cors_allowed_origins,
             result_cache,
             app,
@@ -617,11 +646,13 @@ impl AdminFrontend {
             admin_store: self.admin_store.clone(),
             security_config: self.security_config.clone(),
             routing_config: self.routing_config.clone(),
+            catalog_provider_config: self.catalog_provider_config.clone(),
             engine_registry: self.engine_registry.clone(),
             config_reload_notify: self.config_reload_notify.clone(),
             frontends_status: self.frontends_status.clone(),
             admin_creds: self.admin_creds.clone(),
             test_cluster_fn: self.test_cluster_fn.clone(),
+            test_catalog_provider_fn: self.test_catalog_provider_fn.clone(),
             result_cache: self.result_cache.clone(),
             app: self.app.clone(),
         });
@@ -712,6 +743,14 @@ impl AdminFrontend {
             .route(
                 "/admin/config/guardrails",
                 get(get_guardrails_config_handler).put(put_guardrails_config_handler),
+            )
+            .route(
+                "/admin/config/catalog",
+                get(get_catalog_config_handler).put(put_catalog_config_handler),
+            )
+            .route(
+                "/admin/config/catalog/test",
+                post(test_catalog_config_handler),
             )
             // Cache invalidation endpoints
             .route("/admin/cache", delete(invalidate_all_cache_handler))
@@ -2683,6 +2722,112 @@ async fn put_guardrails_config_handler(
             StatusCode::NO_CONTENT.into_response()
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog provider config (schema-aware translation source)
+// ---------------------------------------------------------------------------
+
+/// Get the current `catalogProvider` configuration. Falls back to the
+/// startup (YAML) value when nothing has been persisted via this API yet.
+#[utoipa::path(
+    get,
+    path = "/admin/config/catalog",
+    tag = "config",
+    responses(
+        (status = 200, description = "CatalogProviderConfig JSON (tagged by `type`)", body = serde_json::Value),
+    )
+)]
+async fn get_catalog_config_handler(State(state): State<Arc<AdminState>>) -> impl IntoResponse {
+    if let Some(store) = &state.admin_store {
+        if let Ok(Some(v)) = store.get_proxy_setting("catalog_config").await {
+            return Json(v).into_response();
+        }
+    }
+    Json(state.catalog_provider_config.as_ref()).into_response()
+}
+
+/// Replace the `catalogProvider` configuration. Structurally validated against
+/// `CatalogProviderConfig` before persisting (same tagged-enum shape as YAML's
+/// `catalogProvider:` block) — an unimplemented provider type (e.g. `glue` in the
+/// current release) is accepted, since it degrades to a no-op provider at build
+/// time rather than being rejected here; use `/admin/config/catalog/test` to check
+/// whether a config actually does anything useful before saving it.
+#[utoipa::path(
+    put,
+    path = "/admin/config/catalog",
+    tag = "config",
+    request_body = serde_json::Value,
+    responses(
+        (status = 204, description = "Saved"),
+        (status = 400, description = "Invalid catalogProvider config", body = str),
+        (status = 503, description = "Persistence not configured", body = str),
+        (status = 500, description = "Internal error", body = str),
+    )
+)]
+async fn put_catalog_config_handler(
+    State(state): State<Arc<AdminState>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let Some(store) = &state.admin_store else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Persistence not configured",
+        )
+            .into_response();
+    };
+    if let Err(e) =
+        serde_json::from_value::<queryflux_core::config::CatalogProviderConfig>(body.clone())
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid catalogProvider config: {e}"),
+        )
+            .into_response();
+    }
+    match store.set_proxy_setting("catalog_config", body).await {
+        Ok(()) => {
+            notify_live_config_reload(&state);
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+struct TestCatalogProviderRequest {
+    config: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+struct TestCatalogProviderResponse {
+    ok: bool,
+    message: String,
+}
+
+/// Build a `catalogProvider` config and smoke-test it, without persisting it.
+#[utoipa::path(
+    post,
+    path = "/admin/config/catalog/test",
+    tag = "config",
+    request_body = TestCatalogProviderRequest,
+    responses(
+        (status = 200, description = "Test result", body = TestCatalogProviderResponse),
+        (status = 500, description = "Internal error", body = str),
+    )
+)]
+async fn test_catalog_config_handler(
+    State(state): State<Arc<AdminState>>,
+    Json(body): Json<TestCatalogProviderRequest>,
+) -> impl IntoResponse {
+    match (state.test_catalog_provider_fn)(body.config).await {
+        Ok((ok, message)) => Json(TestCatalogProviderResponse { ok, message }).into_response(),
+        Err(e) => Json(TestCatalogProviderResponse {
+            ok: false,
+            message: e.to_string(),
+        })
+        .into_response(),
     }
 }
 

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -182,6 +182,7 @@ pub async fn dispatch_query(
         cluster_cfg,
         adapters,
         max_queued_queries,
+        catalog,
     ) = {
         let live = state.live.read().await;
         (
@@ -211,6 +212,7 @@ pub async fn dispatch_query(
                 .get(&group.0)
                 .copied()
                 .flatten(),
+            live.catalog.clone(),
         )
     };
 
@@ -355,7 +357,7 @@ pub async fn dispatch_query(
     let sql = if should_attempt_translation(&session, &protocol) {
         let schema_context = state
             .translation
-            .resolve_schema_context(&sql, &src_dialect, &state.catalog, None, session.database())
+            .resolve_schema_context(&sql, &src_dialect, &catalog, None, session.database())
             .await;
         match state
             .translation
@@ -1290,7 +1292,7 @@ async fn setup_sync_query(
 ) -> Result<SyncQuerySetup> {
     let query_id = ProxyQueryId::new();
 
-    let (cluster_manager, group_fixups, group_default_tags, wait_timeout_secs) = {
+    let (cluster_manager, group_fixups, group_default_tags, wait_timeout_secs, catalog) = {
         let live = state.live.read().await;
         let wait_timeout_secs = live
             .group_capacity_wait_timeout_secs
@@ -1308,6 +1310,7 @@ async fn setup_sync_query(
                 .cloned()
                 .unwrap_or_default(),
             wait_timeout_secs,
+            live.catalog.clone(),
         )
     };
     let effective_tags: QueryTags = merge_tags(&group_default_tags, &session.tags().clone());
@@ -1410,7 +1413,7 @@ async fn setup_sync_query(
     let translated = if should_attempt_translation(&session, &protocol) {
         let schema_context = state
             .translation
-            .resolve_schema_context(&sql, &src_dialect, &state.catalog, None, session.database())
+            .resolve_schema_context(&sql, &src_dialect, &catalog, None, session.database())
             .await;
         match state
             .translation

--- a/crates/queryflux-frontend/src/routing_resolve.rs
+++ b/crates/queryflux-frontend/src/routing_resolve.rs
@@ -115,6 +115,7 @@ mod tests {
             auth_provider: Arc::new(queryflux_auth::NoneAuthProvider::new(false)),
             authorization: Arc::new(SimpleAuthorizationPolicy::new(policies))
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         }
     }
 

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -72,6 +72,12 @@ pub struct LiveConfig {
     /// Checks whether an authenticated user may access a cluster group — hot-reloaded
     /// when security config changes via admin API.
     pub authorization: Arc<dyn AuthorizationChecker>,
+    /// Discovers table/column metadata for schema-aware translation
+    /// (`TranslationService::resolve_schema_context`) — hot-reloaded when catalog
+    /// config changes via the admin API. `NullCatalogProvider` when no
+    /// `catalogProvider` is configured; every call site treats that identically to
+    /// "catalog lookup found nothing," never as an error.
+    pub catalog: Arc<dyn CatalogProvider>,
 }
 
 /// Shared application state — passed to every handler via `axum::extract::State`.
@@ -84,11 +90,6 @@ pub struct AppState {
     // Static (never reloaded):
     pub persistence: Arc<dyn Persistence>,
     pub translation: Arc<TranslationService>,
-    /// Discovers table/column metadata for schema-aware translation
-    /// (`TranslationService::resolve_schema_context`). `NullCatalogProvider` when no
-    /// `catalogProvider` is configured — every call site treats that identically to
-    /// "catalog lookup found nothing," never as an error.
-    pub catalog: Arc<dyn CatalogProvider>,
     pub metrics: Arc<dyn MetricsStore>,
     /// Resolves per-user `QueryCredentials` from `AuthContext` + cluster `queryAuth` config.
     pub identity_resolver: Arc<BackendIdentityResolver>,
@@ -680,13 +681,13 @@ pub mod test_fixtures {
             auth_provider: Arc::new(NoneAuthProvider::new(auth_required)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
         Arc::new(AppState {
             external_address: "http://127.0.0.1:8080".into(),
             live: Arc::new(RwLock::new(live)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation: Arc::new(TranslationService::disabled()),
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics,
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -1635,13 +1635,13 @@ mod cancel_executing_statement_tests {
             auth_provider: Arc::new(NoneAuthProvider::new(false)) as Arc<dyn AuthProvider>,
             authorization: Arc::new(AllowAllAuthorization::default())
                 as Arc<dyn AuthorizationChecker>,
+            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
         };
         Arc::new(AppState {
             external_address: "http://127.0.0.1:8080".into(),
             live: Arc::new(RwLock::new(live)),
             persistence: Arc::new(InMemoryPersistence::new()),
             translation: Arc::new(TranslationService::disabled()),
-            catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
             metrics: Arc::new(NoopMetricsStore),
             identity_resolver: Arc::new(BackendIdentityResolver::new()),
             capacity_store: None,

--- a/crates/queryflux/src/main.rs
+++ b/crates/queryflux/src/main.rs
@@ -14,7 +14,7 @@ use queryflux_core::query::{ClusterGroupName, ClusterName, EngineType};
 use queryflux_frontend::{
     admin::{
         build_frontends_status, AdminFrontend, RoutingConfigDto as AdminRoutingConfigDto,
-        SecurityConfigDto as AdminSecurityConfigDto, TestClusterFn,
+        SecurityConfigDto as AdminSecurityConfigDto, TestCatalogProviderFn, TestClusterFn,
     },
     flight_sql::FlightSqlFrontend,
     mcp::McpFrontend,
@@ -970,6 +970,7 @@ async fn main() -> Result<()> {
         group_cache_settings,
         auth_provider,
         authorization,
+        catalog,
     };
     // Seed the reload cache. When Postgres is active, fingerprint `engine_key` + JSONB config
     // (same format as `build_live_config` on reload) so an engine change rebuilds adapters even
@@ -1131,7 +1132,6 @@ async fn main() -> Result<()> {
         live: live.clone(),
         persistence,
         translation,
-        catalog,
         metrics,
         identity_resolver,
         capacity_store,
@@ -1159,6 +1159,7 @@ async fn main() -> Result<()> {
         &config.routing_fallback,
         &config.routers,
     ));
+    let catalog_provider_config = Arc::new(config.catalog_provider.clone());
     let config_reload_notify = Arc::new(tokio::sync::Notify::new());
 
     let frontends_status = build_frontends_status(
@@ -1201,6 +1202,35 @@ async fn main() -> Result<()> {
         })
     });
 
+    let test_catalog_provider_fn: TestCatalogProviderFn = Arc::new(|config_json| {
+        Box::pin(async move {
+            let cfg = serde_json::from_value::<queryflux_core::config::CatalogProviderConfig>(
+                config_json,
+            )?;
+            let requested_null = matches!(cfg, queryflux_core::config::CatalogProviderConfig::Null);
+            let provider = queryflux_catalog::build_catalog_provider(&cfg).await;
+            if provider.is_null() && !requested_null {
+                return Ok((
+                    false,
+                    "This catalogProvider type is not implemented yet — it built \
+                         successfully but degrades to a no-op (schema-aware translation \
+                         will fall back to dialect-only)."
+                        .to_string(),
+                ));
+            }
+            match provider.list_catalogs().await {
+                Ok(catalogs) => Ok((
+                    true,
+                    format!("Connected — {} catalog(s) visible", catalogs.len()),
+                )),
+                Err(e) => Ok((
+                    false,
+                    format!("Built provider, but a test call failed: {e}"),
+                )),
+            }
+        })
+    });
+
     let admin_store_for_reload = admin_store.clone();
     let cors_origins = config.queryflux.admin_api.cors_allowed_origins.clone();
     if cors_origins.is_empty() {
@@ -1216,11 +1246,13 @@ async fn main() -> Result<()> {
         admin_port,
         security_config,
         routing_config,
+        catalog_provider_config,
         engine_registry,
         config_reload_notify.clone(),
         frontends_status,
         admin_creds,
         test_cluster_fn,
+        test_catalog_provider_fn,
         cors_origins,
         app_state.result_cache.clone(),
         app_state.clone(),
@@ -1656,6 +1688,7 @@ async fn main() -> Result<()> {
                         authorization: l.authorization.clone(),
                         guard_chain: l.guard_chain.clone(),
                         group_guard_chains: l.group_guard_chains.clone(),
+                        catalog: l.catalog.clone(),
                     }
                 };
                 match reload_live_config(backend, &mut cache_guard, &prev, metrics).await {
@@ -1694,6 +1727,35 @@ async fn main() -> Result<()> {
                         Err(e) => {
                             metrics.on_config_reload_failure("guard_reload");
                             tracing::warn!("Guard chain reload failed: {e}");
+                        }
+                    }
+                    // Catalog provider: same admin-store-only reload contract as guard
+                    // chains above — a `Null` provider is always a safe fallback (schema-aware
+                    // translation just degrades to dialect-only), unlike auth/authz.
+                    match store.get_proxy_setting("catalog_config").await {
+                        Ok(Some(v)) => {
+                            match serde_json::from_value::<
+                                queryflux_core::config::CatalogProviderConfig,
+                            >(v)
+                            {
+                                Ok(cfg) => {
+                                    let provider =
+                                        queryflux_catalog::build_catalog_provider(&cfg).await;
+                                    live.write().await.catalog = provider;
+                                }
+                                Err(e) => {
+                                    metrics.on_config_reload_failure("catalog_reload");
+                                    tracing::warn!("Catalog config parse failed: {e}");
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            live.write().await.catalog =
+                                Arc::new(queryflux_core::catalog::NullCatalogProvider);
+                        }
+                        Err(e) => {
+                            metrics.on_config_reload_failure("catalog_reload");
+                            tracing::warn!("Catalog config reload failed: {e}");
                         }
                     }
                 }
@@ -2953,6 +3015,10 @@ async fn build_live_config(
         group_cache_settings,
         auth_provider: Arc::new(NoneAuthProvider::new(false)),
         authorization: Arc::new(AllowAllAuthorization::default()),
+        // Placeholder — `reload_live_config` immediately overwrites this with the
+        // carried-forward previous value (and possibly a fresh one from
+        // `catalog_config`), same as `auth_provider`/`authorization` above.
+        catalog: Arc::new(queryflux_core::catalog::NullCatalogProvider),
     })
 }
 
@@ -2969,6 +3035,7 @@ struct PreservedLive {
     authorization: Arc<dyn queryflux_auth::AuthorizationChecker>,
     guard_chain: Option<Arc<GuardChain>>,
     group_guard_chains: HashMap<String, Arc<GuardChain>>,
+    catalog: Arc<dyn queryflux_core::catalog::CatalogProvider>,
 }
 
 async fn reload_live_config(
@@ -3058,6 +3125,7 @@ async fn reload_live_config(
     live.authorization = prev.authorization.clone();
     live.guard_chain = prev.guard_chain.clone();
     live.group_guard_chains = prev.group_guard_chains.clone();
+    live.catalog = prev.catalog.clone();
 
     // Guardrails from DB (UI-managed) override carried-over chains. An admin
     // "clear" still writes an empty `global` row, so Ok(None) can only mean
@@ -3129,6 +3197,30 @@ async fn reload_live_config(
         Err(e) => {
             metrics.on_config_reload_failure("auth_rebuild");
             tracing::warn!("Reload: security_config read failed; keeping previous auth: {e}")
+        }
+    }
+
+    // Rebuild the catalog provider from persisted config. A missing row means
+    // "never configured via admin" (keep the carried-over, e.g. startup-YAML,
+    // provider); a parse failure keeps the previous provider too — a reload must
+    // never silently fall back to `NullCatalogProvider` and quietly stop
+    // discovering schema for already-working translation.
+    match pg.get_proxy_setting("catalog_config").await {
+        Ok(Some(v)) => {
+            match serde_json::from_value::<queryflux_core::config::CatalogProviderConfig>(v) {
+                Ok(cfg) => live.catalog = queryflux_catalog::build_catalog_provider(&cfg).await,
+                Err(e) => {
+                    metrics.on_config_reload_failure("catalog_reload");
+                    tracing::warn!(
+                        "Reload: catalog_config parse failed; keeping previous catalog: {e}"
+                    )
+                }
+            }
+        }
+        Ok(None) => {}
+        Err(e) => {
+            metrics.on_config_reload_failure("catalog_reload");
+            tracing::warn!("Reload: catalog_config read failed; keeping previous catalog: {e}")
         }
     }
 

--- a/queryflux-studio/app/catalog/catalog-editor.tsx
+++ b/queryflux-studio/app/catalog/catalog-editor.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import React, { useState } from "react";
+import { putCatalogProviderConfig, testCatalogProviderConfig } from "@/lib/api";
+import type { CatalogProviderConfig, StaticColumnDefDto, StaticTableSchemaDto } from "@/lib/api-types";
+import { Field, SectionHeader, TextInput, SaveBar } from "@/components/studio-settings";
+import { Database, Plus, Trash2 } from "lucide-react";
+
+interface Props {
+  initialConfig: CatalogProviderConfig | null;
+}
+
+type ProviderType = CatalogProviderConfig["type"];
+
+const DEFAULTS: Record<ProviderType, CatalogProviderConfig> = {
+  null: { type: "null" },
+  static: { type: "static", schemas: [] },
+  engineDelegate: { type: "engineDelegate", clusterGroup: "" },
+  hiveMetastore: { type: "hiveMetastore", uri: "" },
+  glue: { type: "glue", region: null },
+  caching: {
+    type: "caching",
+    ttlSeconds: 300,
+    maxEntries: 10000,
+    delegate: { type: "null" },
+  },
+  fallback: {
+    type: "fallback",
+    primary: { type: "null" },
+    secondary: { type: "null" },
+  },
+};
+
+const TYPE_LABELS: Record<ProviderType, string> = {
+  null: "None",
+  static: "Static (literal schema)",
+  engineDelegate: "Engine delegate",
+  hiveMetastore: "Hive Metastore",
+  glue: "AWS Glue",
+  caching: "Caching (wraps another provider)",
+  fallback: "Fallback (primary → secondary)",
+};
+
+// Declared in config, but the backend doesn't have a real implementation for
+// these yet — they build successfully and degrade to a no-op provider rather
+// than failing, per queryflux_catalog::build_catalog_provider.
+const UNIMPLEMENTED = new Set<ProviderType>(["engineDelegate", "hiveMetastore", "glue"]);
+
+// ---------------------------------------------------------------------------
+// Static schema editor — one row per table, columns as a "name:TYPE" shorthand
+// (comma-separated; nullable always defaults to true through this UI — edit
+// the persisted JSON directly via the admin API if you need nullable: false).
+// ---------------------------------------------------------------------------
+
+function parseColumns(text: string): StaticColumnDefDto[] {
+  return text
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((pair) => {
+      const [name, dataType] = pair.split(":").map((s) => s.trim());
+      return { name: name || pair, dataType: dataType || "VARCHAR", nullable: true };
+    });
+}
+
+function columnsToText(columns: StaticColumnDefDto[]): string {
+  return columns.map((c) => `${c.name}:${c.dataType}`).join(", ");
+}
+
+function StaticSchemasEditor({
+  schemas,
+  onChange,
+}: {
+  schemas: StaticTableSchemaDto[];
+  onChange: (v: StaticTableSchemaDto[]) => void;
+}) {
+  const update = (idx: number, patch: Partial<StaticTableSchemaDto>) => {
+    const next = schemas.slice();
+    next[idx] = { ...next[idx], ...patch };
+    onChange(next);
+  };
+  const remove = (idx: number) => onChange(schemas.filter((_, i) => i !== idx));
+  const add = () =>
+    onChange([...schemas, { catalog: "", database: "", table: "", columns: [] }]);
+
+  return (
+    <div className="space-y-3">
+      {schemas.length === 0 && <p className="text-xs text-slate-400">No tables declared yet.</p>}
+      {schemas.map((schema, idx) => (
+        <div key={idx} className="border border-slate-200 rounded-lg p-3 space-y-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="grid grid-cols-3 gap-2 flex-1">
+              <TextInput
+                label="Catalog"
+                value={schema.catalog}
+                onChange={(v) => update(idx, { catalog: v })}
+              />
+              <TextInput
+                label="Database"
+                value={schema.database}
+                onChange={(v) => update(idx, { database: v })}
+              />
+              <TextInput
+                label="Table"
+                value={schema.table}
+                onChange={(v) => update(idx, { table: v })}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => remove(idx)}
+              className="mt-5 text-slate-400 hover:text-red-600"
+              title="Remove table"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+          <TextInput
+            label="Columns (name:TYPE, comma-separated)"
+            value={columnsToText(schema.columns)}
+            onChange={(v) => update(idx, { columns: parseColumns(v) })}
+            placeholder="order_id:BIGINT, total:DECIMAL(10,2)"
+          />
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="flex items-center gap-1.5 text-xs font-semibold text-indigo-600 hover:text-indigo-700"
+      >
+        <Plus size={13} /> Add table
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recursive CatalogProviderConfig editor — one dispatcher, indented on nesting
+// (only `caching`/`fallback` recurse, wrapping another CatalogProviderConfig).
+// ---------------------------------------------------------------------------
+
+function CatalogProviderConfigEditor({
+  value,
+  onChange,
+  depth = 0,
+}: {
+  value: CatalogProviderConfig;
+  onChange: (v: CatalogProviderConfig) => void;
+  depth?: number;
+}) {
+  return (
+    <div className={depth > 0 ? "border-l-2 border-slate-200 pl-4" : undefined}>
+      <Field label="Type">
+        <select
+          className="w-full max-w-xs px-2.5 py-1.5 text-xs rounded-lg border border-slate-200 bg-white text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          value={value.type}
+          onChange={(e) => onChange(DEFAULTS[e.target.value as ProviderType])}
+        >
+          {(Object.entries(TYPE_LABELS) as [ProviderType, string][]).map(([type, label]) => (
+            <option key={type} value={type}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {UNIMPLEMENTED.has(value.type) && (
+        <p className="text-xs text-amber-600 mt-1.5">
+          Not implemented yet in this release — builds but degrades to a no-op (schema-aware
+          translation falls back to dialect-only). Use &ldquo;Test connection&rdquo; below to
+          confirm.
+        </p>
+      )}
+
+      {value.type === "static" && (
+        <div className="mt-3">
+          <StaticSchemasEditor
+            schemas={value.schemas}
+            onChange={(schemas) => onChange({ ...value, schemas })}
+          />
+        </div>
+      )}
+
+      {value.type === "engineDelegate" && (
+        <div className="mt-3">
+          <TextInput
+            label="Cluster group"
+            value={value.clusterGroup}
+            onChange={(clusterGroup) => onChange({ ...value, clusterGroup })}
+            placeholder="trino-default"
+          />
+        </div>
+      )}
+
+      {value.type === "hiveMetastore" && (
+        <div className="mt-3">
+          <TextInput
+            label="Metastore URI"
+            value={value.uri}
+            onChange={(uri) => onChange({ ...value, uri })}
+            placeholder="thrift://localhost:9083"
+          />
+        </div>
+      )}
+
+      {value.type === "glue" && (
+        <div className="mt-3">
+          <TextInput
+            label="AWS region (optional)"
+            value={value.region ?? ""}
+            onChange={(region) => onChange({ ...value, region: region || null })}
+            placeholder="us-east-1"
+          />
+        </div>
+      )}
+
+      {value.type === "caching" && (
+        <div className="mt-3 space-y-3">
+          <div className="grid grid-cols-2 gap-4 max-w-sm">
+            <TextInput
+              label="TTL (seconds)"
+              type="number"
+              value={String(value.ttlSeconds)}
+              onChange={(v) => onChange({ ...value, ttlSeconds: Number(v) || 0 })}
+            />
+            <TextInput
+              label="Max entries"
+              type="number"
+              value={String(value.maxEntries)}
+              onChange={(v) => onChange({ ...value, maxEntries: Number(v) || 0 })}
+            />
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1.5">
+              Wrapped provider
+            </p>
+            <CatalogProviderConfigEditor
+              value={value.delegate}
+              onChange={(delegate) => onChange({ ...value, delegate })}
+              depth={depth + 1}
+            />
+          </div>
+        </div>
+      )}
+
+      {value.type === "fallback" && (
+        <div className="mt-3 space-y-4">
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1.5">
+              Primary
+            </p>
+            <CatalogProviderConfigEditor
+              value={value.primary}
+              onChange={(primary) => onChange({ ...value, primary })}
+              depth={depth + 1}
+            />
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-widest mb-1.5">
+              Secondary (used when primary errors, or can&rsquo;t find a table)
+            </p>
+            <CatalogProviderConfigEditor
+              value={value.secondary}
+              onChange={(secondary) => onChange({ ...value, secondary })}
+              depth={depth + 1}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function CatalogEditor({ initialConfig }: Props) {
+  const [config, setConfig] = useState<CatalogProviderConfig>(initialConfig ?? { type: "null" });
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<{ text: string; ok: boolean } | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testMsg, setTestMsg] = useState<{ text: string; ok: boolean } | null>(null);
+
+  const save = async () => {
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      await putCatalogProviderConfig(config);
+      setSaveMsg({ text: "Saved. The proxy reloads config automatically.", ok: true });
+    } catch (e) {
+      setSaveMsg({ text: String(e), ok: false });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const test = async () => {
+    setTesting(true);
+    setTestMsg(null);
+    try {
+      const result = await testCatalogProviderConfig(config);
+      setTestMsg({ text: result.message, ok: result.ok });
+    } catch (e) {
+      setTestMsg({ text: String(e), ok: false });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-5xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Catalog</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          Table/column metadata source for schema-aware SQL translation. Defaults to none
+          (dialect-only translation) — configuring a provider here lets sqlglot qualify columns
+          and types instead of just transpiling syntax.
+        </p>
+      </div>
+
+      <section className="bg-white rounded-xl border border-slate-200 shadow-xs overflow-hidden">
+        <SectionHeader icon={<Database size={15} />} title="Catalog provider" />
+        <div className="p-6 space-y-5">
+          <CatalogProviderConfigEditor value={config} onChange={setConfig} />
+
+          <div className="space-y-3 pt-2">
+            <SaveBar saving={saving} message={saveMsg} onSave={save} />
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={test}
+                disabled={testing}
+                className="px-4 py-2 rounded-lg border border-slate-200 text-slate-700 text-xs font-semibold hover:bg-slate-50 disabled:opacity-50 transition-colors"
+              >
+                {testing ? "Testing…" : "Test connection"}
+              </button>
+              {testMsg && (
+                <span
+                  className={`text-xs font-medium ${testMsg.ok ? "text-emerald-600" : "text-red-600"}`}
+                >
+                  {testMsg.text}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/queryflux-studio/app/catalog/page.tsx
+++ b/queryflux-studio/app/catalog/page.tsx
@@ -1,0 +1,10 @@
+import { getCatalogProviderConfig } from "@/lib/api";
+import { CatalogEditor } from "./catalog-editor";
+
+export const revalidate = 0;
+
+export default async function CatalogPage() {
+  const config = await getCatalogProviderConfig().catch(() => null);
+
+  return <CatalogEditor initialConfig={config} />;
+}

--- a/queryflux-studio/app/client-shell.tsx
+++ b/queryflux-studio/app/client-shell.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import {
   Bot,
   BookOpen,
+  Database,
   FileCode,
   LayoutDashboard,
   List,
@@ -30,6 +31,7 @@ const nav = [
   { href: "/guardrails", label: "Guardrails", icon: ShieldCheck },
   { href: "/protocols", label: "Protocols", icon: Radio },
   { href: "/routing", label: "Routing", icon: Route },
+  { href: "/catalog", label: "Catalog", icon: Database },
   { href: "/swagger", label: "API Reference", icon: BookOpen },
 ];
 

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -523,3 +523,52 @@ export interface GuardrailsConfig {
   /** Per-group additional guards. Group name → guard list. */
   groups: Record<string, GuardSpecDto[]>;
 }
+
+// ---------------------------------------------------------------------------
+// Catalog provider config (GET/PUT /admin/config/catalog, POST .../test)
+//
+// Feeds schema-aware SQL translation (queryflux_core::catalog::CatalogProvider).
+// A true discriminated union (not the flat-optional-fields style used above for
+// GuardSpecDto) because `caching`/`fallback` recursively nest another
+// CatalogProviderConfig — TS narrows `.type` correctly through the recursion,
+// which the flat style doesn't support.
+// ---------------------------------------------------------------------------
+
+export interface StaticColumnDefDto {
+  name: string;
+  dataType: string;
+  nullable: boolean;
+}
+
+export interface StaticTableSchemaDto {
+  catalog: string;
+  database: string;
+  table: string;
+  columns: StaticColumnDefDto[];
+}
+
+export type CatalogProviderConfig =
+  | { type: "null" }
+  | { type: "static"; schemas: StaticTableSchemaDto[] }
+  /** Not yet implemented server-side — builds but degrades to a no-op. */
+  | { type: "engineDelegate"; clusterGroup: string }
+  /** Not yet implemented server-side — builds but degrades to a no-op. */
+  | { type: "hiveMetastore"; uri: string }
+  /** Not yet implemented server-side — builds but degrades to a no-op. */
+  | { type: "glue"; region?: string | null }
+  | {
+      type: "caching";
+      ttlSeconds: number;
+      maxEntries: number;
+      delegate: CatalogProviderConfig;
+    }
+  | {
+      type: "fallback";
+      primary: CatalogProviderConfig;
+      secondary: CatalogProviderConfig;
+    };
+
+export interface TestCatalogProviderResponse {
+  ok: boolean;
+  message: string;
+}

--- a/queryflux-studio/lib/api.ts
+++ b/queryflux-studio/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   AgentListParams,
   AgentSummary,
+  CatalogProviderConfig,
   ClusterStateDto,
   ConversationListParams,
   ConversationSummary,
@@ -11,6 +12,7 @@ import type {
   GuardrailsConfig,
   QueryHistoryRecord,
   QueryListParams,
+  TestCatalogProviderResponse,
 } from "./api-types";
 import {
   SESSION_COOKIE_NAME,
@@ -246,6 +248,20 @@ export async function getGuardrailsConfig(): Promise<GuardrailsConfig> {
 
 export async function putGuardrailsConfig(config: GuardrailsConfig): Promise<void> {
   return apiPutNoContent("/admin/config/guardrails", config);
+}
+
+export async function getCatalogProviderConfig(): Promise<CatalogProviderConfig> {
+  return apiFetch<CatalogProviderConfig>("/admin/config/catalog");
+}
+
+export async function putCatalogProviderConfig(config: CatalogProviderConfig): Promise<void> {
+  return apiPutNoContent("/admin/config/catalog", config);
+}
+
+export async function testCatalogProviderConfig(
+  config: CatalogProviderConfig,
+): Promise<TestCatalogProviderResponse> {
+  return apiPost("/admin/config/catalog/test", { config });
 }
 
 export async function getEngineStats(hours = 24): Promise<EngineStatRow[]> {

--- a/website/docs/architecture/catalog-integration.md
+++ b/website/docs/architecture/catalog-integration.md
@@ -1,0 +1,136 @@
+# Catalog Provider
+
+QueryFlux can discover table and column metadata from a pluggable catalog provider, feeding [schema-aware SQL translation](./query-translation) so `sqlglot`'s optimizer can qualify columns and types instead of just transpiling syntax.
+
+## How it works
+
+```
+Client → QueryFlux
+          │
+          ├── extract table refs from SQL (sqlglot, excludes CTE aliases)
+          │
+          ├── catalog.get_schemas_for_query(catalog, database, tables)  ── timeout-guarded
+          │
+          └── SchemaContext (table → column → type) → sqlglot.optimizer.optimize(schema=…)
+```
+
+1. **Table-ref extraction** — before translation, QueryFlux parses the SQL (via the same `sqlglot` binding used for dialect translation) to find every table it references, excluding names that resolve to a CTE defined in the same query.
+2. **Catalog lookup** — those table names are looked up via the configured `CatalogProvider`, timeout-guarded so a slow or unreachable catalog never blocks a query.
+3. **Schema-aware translation** — the result populates a `SchemaContext` that `sqlglot`'s optimizer uses to resolve column references and types, producing more accurate translated SQL than dialect-only transpilation.
+4. **Fails open, always** — a parse failure, catalog error, or timeout at any step degrades to the same dialect-only translation QueryFlux always did before this feature existed. Schema-aware translation can only ever *improve* accuracy, never break a query.
+
+With no `catalogProvider` configured (the default), a `NullCatalogProvider` returns empty results and step 1 is skipped entirely — a query pays no extra cost.
+
+## Configuration
+
+`catalogProvider` is a single top-level YAML key, hot-reloadable via the [admin API](#admin-api) or Studio's **Catalog** page. It's a tagged union (`type:` selects the variant); some variants wrap another `catalogProvider` value recursively.
+
+### `null` (default)
+
+No catalog configured — dialect-only translation, same as omitting `catalogProvider` entirely.
+
+```yaml
+catalogProvider:
+  type: null
+```
+
+### `static`
+
+A literal, hand-declared schema. No network calls — the simplest provider, useful for testing or a small fixed set of tables.
+
+| Field | Description |
+|-------|-------------|
+| `schemas` | List of `{ catalog, database, table, columns: [{ name, dataType, nullable }] }` |
+
+```yaml
+catalogProvider:
+  type: static
+  schemas:
+    - catalog: hive
+      database: analytics
+      table: orders
+      columns:
+        - { name: order_id, dataType: BIGINT, nullable: false }
+        - { name: total, dataType: "DECIMAL(10,2)", nullable: true }
+```
+
+### `caching`
+
+Wraps another provider with a TTL + capacity-bounded cache. Only successful lookups are cached — an error is never pinned for `ttlSeconds`, so a transient catalog outage self-heals on the next call.
+
+| Field | Description |
+|-------|-------------|
+| `ttlSeconds` | How long a cached result stays valid |
+| `maxEntries` | Capacity bound (FIFO eviction beyond this) |
+| `delegate` | The wrapped `catalogProvider` config |
+
+```yaml
+catalogProvider:
+  type: caching
+  ttlSeconds: 300
+  maxEntries: 10000
+  delegate:
+    type: static
+    schemas: []
+```
+
+### `fallback`
+
+Tries `primary` first, falls through to `secondary` on any error, and — for a single table lookup specifically — when `primary` doesn't have that table (an empty `list_tables`/`list_databases` result does **not** trigger fallback, since that's a legitimate answer, not a "try harder" signal).
+
+| Field | Description |
+|-------|-------------|
+| `primary` | Tried first |
+| `secondary` | Used on `primary` error, or a missing single table |
+
+```yaml
+catalogProvider:
+  type: fallback
+  primary:
+    type: static
+    schemas: []
+  secondary:
+    # a bare YAML `null` parses as YAML's null type, not the string tag
+    # this enum's `type` field needs — quote it.
+    type: "null"
+```
+
+### Declared but not yet implemented
+
+These variants parse and build successfully, but currently degrade to a no-op provider (same behavior as `type: null`) with a startup warning — real integrations land in a follow-up release:
+
+| Type | Fields | Notes |
+|------|--------|-------|
+| `engineDelegate` | `clusterGroup` | Delegates to a cluster group's own adapter (Trino, DuckDB, StarRocks, Athena, ClickHouse) |
+| `glue` | `region` | AWS Glue Data Catalog |
+| `hiveMetastore` | `uri` | Hive Metastore (Thrift) |
+
+Use [`/admin/config/catalog/test`](#admin-api) to check whether a given config actually does anything, rather than silently degrading unnoticed.
+
+## Admin API
+
+```bash
+# Read the current config (persisted override, or the startup YAML value)
+curl -u admin:admin http://localhost:9000/admin/config/catalog
+
+# Replace it — structurally validated, then persisted and hot-reloaded
+curl -u admin:admin -X PUT http://localhost:9000/admin/config/catalog \
+  -H 'content-type: application/json' \
+  -d '{"type": "static", "schemas": []}'
+
+# Build a config and smoke-test it (list_catalogs()) without persisting it
+curl -u admin:admin -X POST http://localhost:9000/admin/config/catalog/test \
+  -H 'content-type: application/json' \
+  -d '{"config": {"type": "static", "schemas": []}}'
+```
+
+A `PUT` never fails startup or a running proxy: an invalid `type` is rejected with `400`, but a *structurally valid* config for an unimplemented provider (e.g. `glue`) is accepted — it will simply degrade to a no-op at build time. Use the `/test` endpoint first if you want to know that ahead of saving.
+
+Studio's **Catalog** page (left nav) is a thin UI over these same three endpoints — a `type:` picker per provider, recursive nesting for `caching`/`fallback`, and the same test-connection button.
+
+## Architecture notes
+
+- `CatalogProvider` (`queryflux_core::catalog`) is the one generic trait every integration implements — `list_catalogs`, `list_databases`, `list_tables`, `get_table_schema`, plus a default `get_schemas_for_query` that batches `get_table_schema` calls.
+- The live provider is hot-reloadable: it lives on `LiveConfig` (not a static `AppState` field), carried forward on a reload unless `catalog_config` has a new, successfully-parsed value — a reload must never silently regress to `NullCatalogProvider` and quietly stop discovering schema for already-working translation.
+- Real integrations are deliberately **engine-independent** — catalog discovery must work even when no query engine is configured or healthy. A future `glue`/`hiveMetastore` implementation talks directly to the catalog service; `engineDelegate` (also not yet implemented) is the one intentional exception, an opt-in convenience that delegates to an already-configured cluster group's adapter.
+- See [`architecture/query-translation`](./query-translation) for how `SchemaContext` flows into `sqlglot`'s optimizer, and [`architecture/system-map`](./system-map) for where this fits in the overall request path.

--- a/website/docs/architecture/system-map.md
+++ b/website/docs/architecture/system-map.md
@@ -436,6 +436,6 @@ curl -s -X POST http://localhost:8080/v1/statement \
 | P1 | QueryFlux Studio — management UI | **Done** |
 | P1 | Athena backend | **Done** |
 | P1 | Authentication / authorization (`queryflux-auth`) | **Done** |
-| P2 | Wire `SchemaContext` from catalog into dispatch | Planned |
+| P2 | Wire `SchemaContext` from catalog into dispatch — see [Catalog Provider](./catalog-integration) | **Done** (foundation: `static`/`caching`/`fallback`; `glue`/`hiveMetastore`/`engineDelegate` still planned) |
 | P3 | ClickHouse backend (HTTP, Arrow) | **Done** |
 | P3 | ClickHouse HTTP frontend | Planned |

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -62,9 +62,9 @@ These are the next items actively being worked on or immediately queued.
 
 ### Schema-aware SQL translation
 
-Today's translation is **dialect-only**: `sqlglot.transpile(sql, read=src, write=tgt)`. It handles syntax differences but cannot resolve semantic gaps that require knowing the target schema — e.g. resolving ambiguous column references, pushing down predicates, or rewriting unsupported functions against actual table definitions.
+Translation was **dialect-only** — `sqlglot.transpile(sql, read=src, write=tgt)` — which handles syntax differences but can't resolve semantic gaps that require knowing the target schema (e.g. resolving ambiguous column references against actual table definitions). The foundation for schema-aware translation now exists: a pluggable `CatalogProvider` populates `SchemaContext`, which `sqlglot.optimizer.optimize` uses with a `MappingSchema` — dialect-only remains the automatic fallback whenever no schema is available or optimization fails. See [Catalog Provider](./architecture/catalog-integration) for the full picture.
 
-The plan: wire `SchemaContext` (populated from catalog discovery via `EngineAdapterTrait::list_tables` / `describe_table`) into the dispatch path so the translator can call `sqlglot.optimizer.optimize` with a `MappingSchema`. Dialect-only remains the fallback when the schema is unavailable or optimization fails.
+What's still ahead: real, engine-independent catalog integrations. Today only `static` (a literal, hand-declared schema), `caching`, and `fallback` are implemented — `glue`, `hiveMetastore`, and `engineDelegate` are declared in config but currently degrade to a no-op provider.
 
 ### ClickHouse HTTP frontend
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
         'architecture/motivation-and-goals',
         'architecture/system-map',
         'architecture/query-translation',
+        'architecture/catalog-integration',
         'architecture/routing-and-clusters',
         'architecture/cluster-variants-and-health',
         'architecture/caching',


### PR DESCRIPTION
## Summary

Stacked on #202 (needs that merged/rebased-onto first). Makes the catalog provider from #202 admin-configurable and hot-reloadable instead of fixed at startup, adds a Studio UI page for it, and documents the whole feature.

## Backend

- Moved `catalog: Arc<dyn CatalogProvider>` from a static `AppState` field into `LiveConfig`, following the existing `auth_provider`/`authorization` pattern — it's swappable on reload now, not fixed at process start.
- Wired into both reload paths:
  - Postgres-backed `reload_live_config`: carries forward the previous provider on a missing/invalid `catalog_config` row — same "never silently regress" discipline already used for auth/authz, so a bad write can't quietly stop schema-aware translation from working.
  - YAML-only `reload_guard_chain_from_admin` path: admin-store-only reload; resets to `NullCatalogProvider` on an explicit clear (safe here — unlike auth, "no catalog configured" is never a security regression, just a translation-accuracy one).
- New `GET`/`PUT /admin/config/catalog` — same `ProxySettingsStore` key/value + validate-then-store pattern as `/admin/config/guardrails` (`serde_json::Value` in/out, structurally validated against `CatalogProviderConfig` before persisting).
- New `POST /admin/config/catalog/test` — builds a provider in-memory and smoke-tests it via `list_catalogs()`, **and explicitly flags a provider that silently degraded to a no-op** (e.g. saving `type: glue` today would otherwise report "saved successfully" while doing nothing, since unimplemented providers degrade rather than fail per #202's design).
- `dispatch.rs`'s two `resolve_schema_context` call sites now read `catalog` from the same `live.read().await` snapshot as everything else, instead of a separate field.

## Studio UI

New **Catalog** page (left nav, between Routing and API Reference):
- A recursive `CatalogProviderConfigEditor` — the only place in Studio handling a genuinely self-nesting discriminated union (`caching`/`fallback` wrap another `CatalogProviderConfig`); a true TS union rather than the flat-optional-fields style used for `GuardSpecDto`, since that style doesn't narrow correctly through recursion.
- A static-schema table editor (add/remove tables, `name:TYPE` shorthand for columns).
- Save + "Test connection" actions, the latter calling the new `/test` endpoint.
- `CatalogProviderConfig`/`TestCatalogProviderResponse` hand-added to `api-types.ts` (same as the existing `GuardrailsConfig` — the backend handlers use raw JSON, not a `ToSchema` DTO, so there's nothing to regenerate from `/openapi.json` for this one).

## Docs

- New [`website/docs/architecture/catalog-integration.md`](../../website/docs/architecture/catalog-integration.md) — how it works, one section per config variant (clearly marked implemented vs. declared-but-not-yet), admin API `curl` examples, architecture notes. Registered in `sidebars.ts`.
- Updated `system-map.md`'s roadmap table and `roadmap.md`'s "Schema-aware SQL translation" section, both of which still described this as entirely planned — now point at the new doc and note what's actually implemented (`static`/`caching`/`fallback`) vs. still ahead (`glue`/`hiveMetastore`/`engineDelegate`).

## Testing

- `cargo test --workspace --exclude queryflux-e2e-tests` — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` — clean, matching CI.
- Studio: `tsc --noEmit`, `eslint`, and a full `next build` (route `/catalog` shows up, production build succeeds) — all clean.
- Docs: `docusaurus build` — clean, new page indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)