### PR TITLE
fix: split SessionContext.database into catalog + database

### DIFF
--- a/crates/queryflux-cache/src/lib.rs
+++ b/crates/queryflux-cache/src/lib.rs
@@ -79,6 +79,9 @@ impl CacheKey {
         hasher.update(sql.as_bytes());
         hasher.update(group.as_bytes());
         hasher.update(user.as_bytes());
+        if let Some(catalog) = &session.catalog {
+            hasher.update(catalog.as_bytes());
+        }
         if let Some(db) = &session.database {
             hasher.update(db.as_bytes());
         }
@@ -242,6 +245,25 @@ mod tests {
         };
         let s2 = SessionContext {
             database: Some("db2".to_string()),
+            ..Default::default()
+        };
+        let k1 = CacheKey::new("SELECT 1", "grp", &s1, "alice", &[]);
+        let k2 = CacheKey::new("SELECT 1", "grp", &s2, "alice", &[]);
+        assert_ne!(k1.hex, k2.hex);
+    }
+
+    #[test]
+    fn cache_key_different_catalog_same_database() {
+        // Same schema name under two different catalogs (e.g. Trino's
+        // hive.sales.orders vs. iceberg.sales.orders) must not collide.
+        let s1 = SessionContext {
+            catalog: Some("hive".to_string()),
+            database: Some("sales".to_string()),
+            ..Default::default()
+        };
+        let s2 = SessionContext {
+            catalog: Some("iceberg".to_string()),
+            database: Some("sales".to_string()),
             ..Default::default()
         };
         let k1 = CacheKey::new("SELECT 1", "grp", &s1, "alice", &[]);

--- a/crates/queryflux-core/src/session.rs
+++ b/crates/queryflux-core/src/session.rs
@@ -144,8 +144,17 @@ impl AgentContext {
 pub struct SessionContext {
     /// Resolved user identity (extracted at connection time by the frontend).
     pub user: Option<String>,
-    /// Target database/catalog hint for routing and catalog providers.
+    /// Target database/schema hint for routing and catalog providers. For
+    /// protocols with a real catalog layer (Trino, Snowflake), this is the
+    /// *schema* — the catalog goes in `catalog` below. For protocols without one
+    /// (Postgres, MySQL/StarRocks), this is simply the selected database.
     pub database: Option<String>,
+    /// Target catalog hint, for protocols that have a separate catalog concept
+    /// from database/schema (Trino's `X-Trino-Catalog`, Snowflake's database).
+    /// `None` for protocols with no catalog layer — never assume it falls back
+    /// to `database`, the two are genuinely different things per-protocol.
+    #[serde(default)]
+    pub catalog: Option<String>,
     /// Query tags for routing and metrics.
     pub tags: QueryTags,
     /// Protocol-specific key-value data. Frontends own the key conventions.
@@ -166,9 +175,16 @@ impl SessionContext {
         self.user.as_deref()
     }
 
-    /// Extract the target database/catalog hint.
+    /// Extract the target database/schema hint (see field doc comment for what
+    /// this means per-protocol — it is *not* the catalog for Trino/Snowflake).
     pub fn database(&self) -> Option<&str> {
         self.database.as_deref()
+    }
+
+    /// Extract the target catalog hint. `None` for protocols without a catalog
+    /// layer (Postgres, MySQL/StarRocks) — never falls back to `database`.
+    pub fn catalog(&self) -> Option<&str> {
+        self.catalog.as_deref()
     }
 
     /// Resolve agent identity for this session.
@@ -232,9 +248,31 @@ mod tests {
         let s = SessionContext::default();
         assert_eq!(s.user(), None);
         assert_eq!(s.database(), None);
+        assert_eq!(s.catalog(), None);
         assert!(s.tags().is_empty());
         assert!(s.extra.is_empty());
         assert_eq!(s.client_source(), None);
+    }
+
+    #[test]
+    fn catalog_and_database_are_independent() {
+        let s = SessionContext {
+            catalog: Some("hive".to_string()),
+            database: Some("analytics".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(s.catalog(), Some("hive"));
+        assert_eq!(s.database(), Some("analytics"));
+    }
+
+    #[test]
+    fn deserializes_json_missing_catalog_field() {
+        // Backward compat: rows persisted before `catalog` existed (e.g. queued
+        // queries stored as JSON in Postgres) must still deserialize.
+        let json = r#"{"user":"alice","database":"hive","tags":{},"extra":{}}"#;
+        let s: SessionContext = serde_json::from_str(json).unwrap();
+        assert_eq!(s.database(), Some("hive"));
+        assert_eq!(s.catalog(), None);
     }
 
     #[test]

--- a/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
+++ b/crates/queryflux-engine-adapters/src/clickhouse/mod.rs
@@ -583,7 +583,11 @@ impl crate::SyncAdapter for ClickHouseAdapter {
             _ => sql.to_string(),
         };
         let mut req = self.query_request_with_id(&effective_sql, "ArrowStream", &query_id);
-        if let Some(db) = session.database() {
+        // ClickHouse has no catalog concept of its own — a client's `catalog`
+        // (e.g. Trino's `x-trino-catalog` with no `x-trino-schema`) is the
+        // intended database just as much as an explicit `database` hint, so
+        // fall back to it when no database was set.
+        if let Some(db) = session.database().or(session.catalog()) {
             req = req.query(&[("database", db)]);
         }
         if !tags.is_empty() {

--- a/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
+++ b/crates/queryflux-engine-adapters/src/mysql_native/mod.rs
@@ -251,7 +251,11 @@ async fn stream_on_conn(
     params: &QueryParams,
     chunk_tx: &tokio::sync::mpsc::Sender<Result<NativeResultChunk>>,
 ) -> Result<()> {
-    if let Some(db) = session.database() {
+    // MySQL has no catalog concept of its own — a client's `catalog` (e.g.
+    // Trino's `x-trino-catalog` with no `x-trino-schema`) is the intended
+    // database just as much as an explicit `database` hint, so fall back to
+    // it when no database was set.
+    if let Some(db) = session.database().or(session.catalog()) {
         let use_sql = format!("USE `{}`", db.replace('`', "``"));
         conn.query_drop(&use_sql)
             .await

--- a/crates/queryflux-engine-adapters/src/starrocks/mod.rs
+++ b/crates/queryflux-engine-adapters/src/starrocks/mod.rs
@@ -298,7 +298,11 @@ impl StarRocksAdapter {
         params: &queryflux_core::params::QueryParams,
         batch_tx: &tokio::sync::mpsc::Sender<Result<RecordBatch>>,
     ) -> Result<()> {
-        if let Some(db) = session.database() {
+        // StarRocks has no catalog concept of its own — a client's `catalog`
+        // (e.g. Trino's `x-trino-catalog` with no `x-trino-schema`) is the
+        // intended database just as much as an explicit `database` hint, so
+        // fall back to it when no database was set.
+        if let Some(db) = session.database().or(session.catalog()) {
             let use_sql = format!("USE `{}`", db.replace('`', "``"));
             conn.query_drop(&use_sql)
                 .await

--- a/crates/queryflux-frontend/src/dispatch.rs
+++ b/crates/queryflux-frontend/src/dispatch.rs
@@ -357,7 +357,13 @@ pub async fn dispatch_query(
     let sql = if should_attempt_translation(&session, &protocol) {
         let schema_context = state
             .translation
-            .resolve_schema_context(&sql, &src_dialect, &catalog, None, session.database())
+            .resolve_schema_context(
+                &sql,
+                &src_dialect,
+                &catalog,
+                session.catalog(),
+                session.database(),
+            )
             .await;
         match state
             .translation
@@ -1413,7 +1419,13 @@ async fn setup_sync_query(
     let translated = if should_attempt_translation(&session, &protocol) {
         let schema_context = state
             .translation
-            .resolve_schema_context(&sql, &src_dialect, &catalog, None, session.database())
+            .resolve_schema_context(
+                &sql,
+                &src_dialect,
+                &catalog,
+                session.catalog(),
+                session.database(),
+            )
             .await;
         match state
             .translation

--- a/crates/queryflux-frontend/src/flight_sql/mod.rs
+++ b/crates/queryflux-frontend/src/flight_sql/mod.rs
@@ -121,6 +121,10 @@ impl QueryFluxFlightSql {
         SessionContext {
             user,
             database: None,
+            // Not yet extracted — Flight SQL commands (e.g. CommandGetTables) do
+            // carry catalog/schema filters, but no current-catalog session concept
+            // is wired up here yet.
+            catalog: None,
             tags: queryflux_core::tags::QueryTags::new(),
             extra: headers,
             agent_context: None,

--- a/crates/queryflux-frontend/src/mysql_wire/mod.rs
+++ b/crates/queryflux-frontend/src/mysql_wire/mod.rs
@@ -202,6 +202,8 @@ async fn handle_connection(
     let mut session = SessionContext {
         user: if user.is_empty() { None } else { Some(user) },
         database: schema,
+        // MySQL wire / StarRocks has no catalog concept — just a database/schema.
+        catalog: None,
         extra: HashMap::new(),
         tags: QueryTags::new(),
         agent_context: None,
@@ -1732,6 +1734,7 @@ mod tests {
         let mut session = queryflux_core::session::SessionContext {
             user: None,
             database: None,
+            catalog: None,
             tags: queryflux_core::tags::QueryTags::new(),
             extra: std::collections::HashMap::new(),
             agent_context: None,

--- a/crates/queryflux-frontend/src/postgres_wire/mod.rs
+++ b/crates/queryflux-frontend/src/postgres_wire/mod.rs
@@ -211,6 +211,8 @@ async fn handle_connection(
     let session = SessionContext {
         user: if user.is_empty() { None } else { Some(user) },
         database,
+        // Postgres wire has no catalog concept — just a database.
+        catalog: None,
         tags,
         extra,
         agent_context: None,
@@ -784,6 +786,7 @@ mod tests {
         SessionContext {
             user: None,
             database: None,
+            catalog: None,
             tags: queryflux_core::tags::QueryTags::new(),
             extra,
             agent_context: None,

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/query.rs
@@ -241,6 +241,9 @@ pub async fn query_request(
     let session_ctx = SessionContext {
         user: Some(auth_ctx.user.clone()),
         database: Some(database.clone()),
+        // See the matching comment in snowflake/http/handlers/session.rs — mapped
+        // onto our catalog.database.table model as catalog, not database.
+        catalog: Some(database.clone()),
         tags: QueryTags::default(),
         extra,
         agent_context: None,

--- a/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
+++ b/crates/queryflux-frontend/src/snowflake/http/handlers/session.rs
@@ -99,6 +99,14 @@ pub async fn login_request(
     let session_ctx = SessionContext {
         user: Some(auth_ctx.user.clone()),
         database: database.clone(),
+        // Snowflake's "database" is the top-level namespace, mapping onto our
+        // catalog.database.table model as *catalog*, not database — mirrored here
+        // rather than also renaming `database` (Snowflake's schema, tracked
+        // separately in `extra["snowflake.schema"]` where captured) to avoid
+        // changing what existing `session.database()` consumers see for Snowflake
+        // sessions. TODO: thread `extra["snowflake.schema"]` into a real
+        // `database` value once this session-store path captures it too.
+        catalog: database.clone(),
         tags: QueryTags::default(),
         extra: Default::default(),
         agent_context: None,

--- a/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
+++ b/crates/queryflux-frontend/src/snowflake/sql_api/handlers.rs
@@ -259,7 +259,10 @@ pub async fn submit_statement(
 
     let session_ctx = SessionContext {
         user: Some(auth_ctx.user.clone()),
-        database,
+        database: database.clone(),
+        // See the matching comment in snowflake/http/handlers/session.rs — mapped
+        // onto our catalog.database.table model as catalog, not database.
+        catalog: database,
         tags: QueryTags::default(),
         extra,
         agent_context: None,

--- a/crates/queryflux-frontend/src/state.rs
+++ b/crates/queryflux-frontend/src/state.rs
@@ -255,8 +255,8 @@ impl AppState {
             was_translated: ctx.was_translated,
             translated_sql: ctx.translated_sql.clone(),
             user: ctx.session.user().map(|s| s.to_string()),
-            catalog: ctx.session.database().map(|s| s.to_string()),
-            database: None,
+            catalog: ctx.session.catalog().map(|s| s.to_string()),
+            database: ctx.session.database().map(|s| s.to_string()),
             sql_preview: ctx.sql.chars().take(500).collect(),
             status: outcome.status,
             routing_trace: outcome

--- a/crates/queryflux-frontend/src/trino_http/handlers.rs
+++ b/crates/queryflux-frontend/src/trino_http/handlers.rs
@@ -318,16 +318,47 @@ fn extract_session(headers: &HeaderMap) -> SessionContext {
     }
     let tags = extract_trino_tags(&h);
     let user = h.get("x-trino-user").cloned();
-    let database = h.get("x-trino-catalog").cloned();
+    // `X-Trino-Catalog` / `X-Trino-Schema` map onto our catalog.database.table model
+    // as catalog/database respectively — Trino's own three-part naming, not two
+    // different names for the same thing.
+    let catalog = h.get("x-trino-catalog").cloned();
+    let database = h.get("x-trino-schema").cloned();
     // Agent context is NOT extracted here — it is derived lazily from `extra` in
     // dispatch.rs via `session.resolved_agent_context()`. All HTTP frontends that
     // store headers in `extra` (lowercase) automatically support agent headers.
     SessionContext {
         user,
         database,
+        catalog,
         tags,
         extra: h,
         agent_context: None,
+    }
+}
+
+#[cfg(test)]
+mod extract_session_tests {
+    use super::extract_session;
+    use axum::http::HeaderMap;
+
+    #[test]
+    fn catalog_and_schema_headers_map_to_distinct_fields() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-trino-user", "alice".parse().unwrap());
+        headers.insert("x-trino-catalog", "hive".parse().unwrap());
+        headers.insert("x-trino-schema", "analytics".parse().unwrap());
+
+        let session = extract_session(&headers);
+        assert_eq!(session.catalog(), Some("hive"));
+        assert_eq!(session.database(), Some("analytics"));
+    }
+
+    #[test]
+    fn missing_headers_leave_both_none() {
+        let headers = HeaderMap::new();
+        let session = extract_session(&headers);
+        assert_eq!(session.catalog(), None);
+        assert_eq!(session.database(), None);
     }
 }
 

--- a/crates/queryflux-routing/src/implementations/python_script.rs
+++ b/crates/queryflux-routing/src/implementations/python_script.rs
@@ -119,6 +119,7 @@ fn build_routing_ctx<'py>(
     ctx.set_item("protocol", protocol_camel(protocol))?;
     set_opt_str(&ctx, py, "user", &session.user)?;
     set_opt_str(&ctx, py, "database", &session.database)?;
+    set_opt_str(&ctx, py, "catalog", &session.catalog)?;
     ctx.set_item("extra", str_str_dict(py, &session.extra)?)?;
 
     if let Some(a) = auth {

--- a/website/docs/architecture/frontends/flight-sql.md
+++ b/website/docs/architecture/frontends/flight-sql.md
@@ -76,7 +76,7 @@ SELECT * FROM qf.my_catalog.my_schema.my_table LIMIT 10;
 | `DoAction` / `ListActions` | Not implemented. |
 | Prepared statements (`CreatePreparedStatement`, `ClosePreparedStatement`, `ExecutePreparedStatement`) | Not implemented. |
 | Query tags | Not extracted. `SessionContext.tags` is always empty; the `tags` router type cannot be used with Flight SQL clients. |
-| `database` hint | Not extracted. `SessionContext.database` is always `None`; only `user` and metadata entries in `extra` are available for routing. |
+| `database`/`catalog` hint | Not extracted. `SessionContext.database` and `SessionContext.catalog` are always `None`; only `user` and metadata entries in `extra` are available for routing. |
 | TLS | Not terminated by QueryFlux. Use an external TLS terminator or gRPC plaintext. |
 
 ## Related

--- a/website/docs/architecture/frontends/snowflake.md
+++ b/website/docs/architecture/frontends/snowflake.md
@@ -148,7 +148,7 @@ curl -X POST http://localhost:8443/api/v2/statements \
 | Async query execution (`asyncExec: true`) | Not supported. `query-monitoring-request` returns an empty polling response so the connector stops polling. All queries run synchronously. |
 | Query cancel (`DELETE /queries/v1/{id}`, `DELETE /api/v2/statements/{handle}`) | No-op — synchronous execution cannot be interrupted mid-flight via HTTP. Returns a success response. |
 | SQL REST API v2 polling (`GET /api/v2/statements/{handle}`) | Stub — returns HTTP 404 with "already complete" message. |
-| `database` in SQL REST API v2 | Not extracted. `SessionContext.database` is always `None`; protocolBased routing on database hint is not available for REST v2 clients. |
+| `schema` as a routing hint | The request body's top-level `database` field populates both `SessionContext.database` and `SessionContext.catalog` (Snowflake's database maps onto our `catalog.database.table` model as the catalog) — `schema` is captured into `extra["snowflake.schema"]` but not mapped onto a dedicated field yet, so it isn't available for `protocolBased` routing on its own. |
 | Query tags | Not extracted for either sub-protocol. The `tags` router type cannot be used with Snowflake frontends. |
 | Multiple statements per request | Not supported. Only the first statement in the request body is executed. |
 | Transactions (`BEGIN` / `COMMIT` / `ROLLBACK`) | No transaction state is maintained. These statements are forwarded to the backend as-is. |

--- a/website/docs/architecture/frontends/trino-http.md
+++ b/website/docs/architecture/frontends/trino-http.md
@@ -57,11 +57,12 @@ The Trino HTTP frontend populates `SessionContext` as follows:
 | Field | Source |
 |-------|--------|
 | `user` | `X-Trino-User` header |
-| `database` | `X-Trino-Catalog` header |
+| `catalog` | `X-Trino-Catalog` header |
+| `database` | `X-Trino-Schema` header |
 | `tags` | `X-Trino-Client-Tags` and `X-Trino-Session` headers (extracted at request time) |
 | `extra` | All request headers, lowercased (e.g. `x-trino-user`, `x-trino-catalog`, `x-trino-schema`) |
 
-Routers and the `pythonScript` router can inspect any header via `ctx["extra"]` (e.g. `ctx["extra"].get("x-trino-source")`). The common fields `ctx["user"]` and `ctx["database"]` are preferred for user/catalog routing.
+Routers and the `pythonScript` router can inspect any header via `ctx["extra"]` (e.g. `ctx["extra"].get("x-trino-source")`). The common fields `ctx["user"]`, `ctx["catalog"]`, and `ctx["database"]` are preferred for user/catalog/schema routing — `catalog`/`database` here follow Trino's own three-part `catalog.schema.table` naming, not two names for the same thing.
 
 ## Query tags
 
@@ -94,7 +95,6 @@ curl -X POST http://localhost:8080/v1/statement \
 | Feature | Status |
 |---------|--------|
 | Prepared statements | Not supported. The Trino HTTP protocol does not use a separate prepare/execute flow; all queries arrive as raw SQL. |
-| `X-Trino-Schema` as routing hint | The `X-Trino-Schema` header is stored in `extra` and forwarded to the backend but is not mapped to `SessionContext.database`. Use `X-Trino-Catalog` for the `ctx["database"]` routing field. |
 | TLS termination | Not handled by QueryFlux. Use an external TLS terminator in front of the Trino HTTP listener. |
 
 ## Related


### PR DESCRIPTION
## Summary

Stacked on #203 (itself stacked on #202). Fixes a real gap identified while reviewing that work: [both `resolve_schema_context` call sites](https://github.com/lakeops-org/queryflux/pull/202) always passed `default_catalog: None`, because `SessionContext` had no separate catalog concept to give them one in the first place.

`SessionContext.database` was doing double duty as "database or catalog, whichever this protocol happens to call it" — populated inconsistently per frontend, and for Trino specifically, actively mislabeled: `X-Trino-Catalog` landed in `session.database`, while `X-Trino-Schema` was dropped entirely (one doc even described that as an intentional limitation).

## Changes

- `SessionContext` gets a real `catalog: Option<String>` field alongside `database`, with a matching `catalog()` accessor. `#[serde(default)]` so already-persisted queued-query JSON rows (missing the field) still deserialize.
- Per-frontend fixes — each protocol mapped correctly, not uniformly:
  - **Trino HTTP**: `X-Trino-Catalog` → `catalog`, `X-Trino-Schema` → `database` (previously dropped).
  - **Snowflake** (wire v1 + SQL API v2, all three session-construction sites): the request's `database` value now also populates `catalog` (Snowflake's database is our catalog level). `database` itself is left unchanged to avoid touching existing tested behavior — schema (already captured into `extra["snowflake.schema"]`) isn't wired into a dedicated field yet, flagged with a `TODO` rather than silently left half-done.
  - **Postgres wire / MySQL wire / Flight SQL**: explicit `catalog: None` — none of these protocols have a catalog concept.
- `dispatch.rs`'s two `resolve_schema_context` calls pass `session.catalog()` now, instead of a hardcoded `None`.
- Two other consumers were silently relying on the same mislabeling, both fixed:
  - `QueryContext` → `QueryRecord` population: was `catalog: session.database()`, `database: None` (always null!) — now both populated correctly.
  - Query-result cache key: now hashes catalog and database independently, so `hive.sales.orders` and `iceberg.sales.orders` no longer collide on the same cache key.
- Exposed `ctx["catalog"]` to Python routing scripts alongside the existing `ctx["database"]`, for symmetry.
- Docs (`trino-http.md`, `snowflake.md`, `flight-sql.md`) all had stale or outright wrong descriptions of this exact gap — updated to match the fixed behavior.

## Testing

- New tests: `SessionContext` catalog/database independence + JSON backward-compat (`queryflux-core`), Trino header extraction (`queryflux-frontend`), cache-key catalog-vs-database collision (`queryflux-cache`).
- `cargo test --workspace --exclude queryflux-e2e-tests` — all green (900 tests, 0 failed — same pass count profile as before this change plus the new ones, nothing regressed).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)