### PR TITLE
feat: implement real AWS Glue catalog provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-glue"
+version = "1.142.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc77647907307c70ffd751db85653804552e4a3c27f054d3af7a0874ef4dfe22"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-sts"
 version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4085,6 +4109,10 @@ name = "queryflux-catalog"
 version = "0.3.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-glue",
+ "aws-types",
  "queryflux-core",
  "tokio",
  "tracing",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -101,6 +101,18 @@ catalogProvider:
   #       - { name: order_id, dataType: BIGINT, nullable: false }
   #       - { name: total, dataType: "DECIMAL(10,2)", nullable: true }
   #
+  # AWS Glue Data Catalog — direct Glue API access (format-agnostic: sees
+  # Iceberg, Hive/Parquet, and any other table format Glue tracks). `auth` is
+  # optional and follows the same shape as engine cluster `auth`; omit it to
+  # use the default AWS credential chain (env vars, ECS task role, EC2
+  # instance profile, etc.).
+  # type: glue
+  # region: us-east-1
+  # auth:
+  #   type: roleArn
+  #   roleArn: arn:aws:iam::123456789012:role/queryflux-glue-readonly
+  #   externalId: ${GLUE_EXTERNAL_ID}
+  #
   # Wrap any provider with a TTL cache:
   # type: caching
   # ttlSeconds: 300

--- a/crates/queryflux-catalog/Cargo.toml
+++ b/crates/queryflux-catalog/Cargo.toml
@@ -9,6 +9,13 @@ queryflux-core = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+# Same generation as the Athena adapter's aws-sdk-athena — direct Glue Data
+# Catalog access, format-agnostic (unlike iceberg-catalog-glue, which only sees
+# Iceberg-format tables).
+aws-sdk-glue = "1"
+aws-config = { version = "1", default-features = false, features = ["rustls", "rt-tokio"] }
+aws-credential-types = "1"
+aws-types = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/crates/queryflux-catalog/src/glue.rs
+++ b/crates/queryflux-catalog/src/glue.rs
@@ -1,0 +1,276 @@
+//! AWS Glue Data Catalog integration.
+//!
+//! Talks directly to the Glue API (`aws-sdk-glue`) rather than through Iceberg's
+//! own Glue catalog client — deliberately, so it sees tables of any format Glue
+//! tracks (Iceberg, Hive/Parquet, CSV/JSON, ...), not just Iceberg ones. Mirrors
+//! the Athena adapter's AWS credential / AssumeRole setup
+//! (`crates/queryflux-engine-adapters/src/athena/mod.rs`) so the two behave
+//! consistently for operators already familiar with one.
+
+use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_types::region::Region;
+use queryflux_core::catalog::{CatalogProvider, ColumnDef, TableSchema};
+use queryflux_core::config::ClusterAuth;
+use queryflux_core::error::{QueryFluxError, Result};
+
+/// Glue has no catalog concept of its own — every database/table lives under
+/// the caller's AWS account. This is the single synthetic catalog name
+/// `list_catalogs()` reports, matching the convention the Athena adapter
+/// already uses for its own default-catalog handling.
+const DEFAULT_CATALOG_NAME: &str = "AwsDataCatalog";
+
+#[derive(Debug)]
+pub struct GlueCatalogProvider {
+    client: aws_sdk_glue::Client,
+}
+
+impl GlueCatalogProvider {
+    /// Builds the Glue client. `auth` reuses the same `ClusterAuth` shape as
+    /// engine cluster config; only `AccessKey`/`RoleArn`/absent (default AWS
+    /// credential chain) are meaningful here — `Basic`/`Bearer`/`KeyPair` are
+    /// rejected since they don't apply to AWS.
+    pub async fn new(region: Option<String>, auth: Option<ClusterAuth>) -> Result<Self> {
+        let aws_region = region.map(Region::new);
+
+        let sdk_config = match auth {
+            Some(ClusterAuth::AccessKey {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            }) => {
+                let creds = Credentials::new(
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                    None,
+                    "queryflux-static",
+                );
+                let mut builder =
+                    aws_config::defaults(BehaviorVersion::latest()).credentials_provider(creds);
+                if let Some(r) = aws_region {
+                    builder = builder.region(r);
+                }
+                builder.load().await
+            }
+            Some(ClusterAuth::RoleArn {
+                role_arn,
+                external_id,
+            }) => {
+                // Refreshing AssumeRole provider (not a one-shot AssumeRole call) so
+                // temporary STS credentials renew before they expire — same reasoning
+                // as the Athena adapter's identical setup.
+                let mut base_builder = aws_config::defaults(BehaviorVersion::latest());
+                if let Some(r) = aws_region.clone() {
+                    base_builder = base_builder.region(r);
+                }
+                let base_config = base_builder.load().await;
+                let mut role_builder = aws_config::sts::AssumeRoleProvider::builder(&role_arn)
+                    .session_name("queryflux-catalog")
+                    .configure(&base_config);
+                if let Some(eid) = external_id {
+                    role_builder = role_builder.external_id(eid);
+                }
+                let provider = role_builder.build().await;
+                let mut builder =
+                    aws_config::defaults(BehaviorVersion::latest()).credentials_provider(provider);
+                if let Some(r) = aws_region {
+                    builder = builder.region(r);
+                }
+                builder.load().await
+            }
+            Some(other) => {
+                return Err(QueryFluxError::Config(format!(
+                    "catalogProvider glue: unsupported auth type {other:?} — use \
+                     accessKey or roleArn, or omit auth for the default AWS \
+                     credential chain"
+                )));
+            }
+            None => {
+                let mut builder = aws_config::defaults(BehaviorVersion::latest());
+                if let Some(r) = aws_region {
+                    builder = builder.region(r);
+                }
+                builder.load().await
+            }
+        };
+
+        let mut glue_builder = aws_sdk_glue::config::Builder::from(&sdk_config);
+        if let Ok(endpoint) = std::env::var("AWS_ENDPOINT_URL") {
+            if !endpoint.is_empty() {
+                glue_builder = glue_builder.endpoint_url(endpoint);
+            }
+        }
+        let client = aws_sdk_glue::Client::from_conf(glue_builder.build());
+
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl CatalogProvider for GlueCatalogProvider {
+    async fn list_catalogs(&self) -> Result<Vec<String>> {
+        Ok(vec![DEFAULT_CATALOG_NAME.to_string()])
+    }
+
+    async fn list_databases(&self, _catalog: &str) -> Result<Vec<String>> {
+        let mut names = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let mut req = self.client.get_databases();
+            if let Some(t) = next_token {
+                req = req.next_token(t);
+            }
+            let resp = req.send().await.map_err(|e| {
+                QueryFluxError::Catalog(format!("Glue GetDatabases: {}", aws_err(&e)))
+            })?;
+            names.extend(resp.database_list().iter().map(|d| d.name().to_string()));
+            next_token = resp.next_token().map(|t| t.to_string());
+            if next_token.is_none() {
+                break;
+            }
+        }
+        Ok(names)
+    }
+
+    async fn list_tables(&self, _catalog: &str, database: &str) -> Result<Vec<String>> {
+        let mut names = Vec::new();
+        let mut next_token: Option<String> = None;
+        loop {
+            let mut req = self.client.get_tables().database_name(database);
+            if let Some(t) = next_token {
+                req = req.next_token(t);
+            }
+            let resp = req
+                .send()
+                .await
+                .map_err(|e| QueryFluxError::Catalog(format!("Glue GetTables: {}", aws_err(&e))))?;
+            names.extend(resp.table_list().iter().map(|t| t.name().to_string()));
+            next_token = resp.next_token().map(|t| t.to_string());
+            if next_token.is_none() {
+                break;
+            }
+        }
+        Ok(names)
+    }
+
+    async fn get_table_schema(
+        &self,
+        _catalog: &str,
+        database: &str,
+        table: &str,
+    ) -> Result<Option<TableSchema>> {
+        let resp = match self
+            .client
+            .get_table()
+            .database_name(database)
+            .name(table)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                if e.as_service_error()
+                    .is_some_and(|se| se.is_entity_not_found_exception())
+                {
+                    return Ok(None);
+                }
+                return Err(QueryFluxError::Catalog(format!(
+                    "Glue GetTable: {}",
+                    aws_err(&e)
+                )));
+            }
+        };
+        let Some(tbl) = resp.table() else {
+            return Ok(None);
+        };
+
+        let mut columns: Vec<ColumnDef> = Vec::new();
+        if let Some(sd) = tbl.storage_descriptor() {
+            columns.extend(sd.columns().iter().map(glue_column_to_column_def));
+        }
+        // Partition keys are real, queryable columns on a Hive-style partitioned
+        // table — the Athena adapter's own TableMetadata mapping folds them in
+        // the same way, for the same reason (they're valid in WHERE/SELECT).
+        columns.extend(tbl.partition_keys().iter().map(glue_column_to_column_def));
+
+        Ok(Some(TableSchema {
+            catalog: DEFAULT_CATALOG_NAME.to_string(),
+            database: database.to_string(),
+            table: table.to_string(),
+            columns,
+        }))
+    }
+}
+
+fn glue_column_to_column_def(c: &aws_sdk_glue::types::Column) -> ColumnDef {
+    ColumnDef {
+        name: c.name().to_string(),
+        // Glue/Hive type strings (e.g. "bigint", "struct<a:int>") aren't
+        // normalized to standard SQL here — sqlglot's MappingSchema accepts
+        // most of them as-is. A dedicated type-mapping pass is future work if
+        // this proves insufficient for the optimizer in practice.
+        data_type: c.r#type().unwrap_or("string").to_uppercase(),
+        // Glue's Column type carries no nullability — defaults to true, same
+        // reasoning (and same default) as the Athena adapter's own mapping.
+        nullable: true,
+    }
+}
+
+/// Same error-chain formatter the Athena adapter uses, so Glue errors read the
+/// same way in logs/admin-API responses as Athena's already do.
+fn aws_err(e: &impl std::error::Error) -> String {
+    let mut parts = vec![e.to_string()];
+    let mut src = e.source();
+    while let Some(s) = src {
+        let s_str = s.to_string();
+        if !parts.contains(&s_str) {
+            parts.push(s_str);
+        }
+        src = s.source();
+    }
+    parts.join(": ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_mapping_uppercases_type_and_defaults_nullable_true() {
+        let col = aws_sdk_glue::types::Column::builder()
+            .name("order_id")
+            .r#type("bigint")
+            .build()
+            .unwrap();
+        let mapped = glue_column_to_column_def(&col);
+        assert_eq!(mapped.name, "order_id");
+        assert_eq!(mapped.data_type, "BIGINT");
+        assert!(mapped.nullable);
+    }
+
+    #[test]
+    fn column_mapping_defaults_missing_type_to_string() {
+        let col = aws_sdk_glue::types::Column::builder()
+            .name("mystery")
+            .build()
+            .unwrap();
+        let mapped = glue_column_to_column_def(&col);
+        assert_eq!(mapped.data_type, "STRING");
+    }
+
+    #[tokio::test]
+    async fn unsupported_auth_type_is_rejected_before_any_network_call() {
+        let err = GlueCatalogProvider::new(
+            None,
+            Some(ClusterAuth::Basic {
+                username: "x".to_string(),
+                password: "y".to_string(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("unsupported auth type"), "{err}");
+    }
+}

--- a/crates/queryflux-catalog/src/lib.rs
+++ b/crates/queryflux-catalog/src/lib.rs
@@ -2,16 +2,17 @@
 //! (Glue, Iceberg REST, Snowflake, ...) behind one `CatalogProvider` trait
 //! (`queryflux_core::catalog`), feeding schema-aware SQL translation.
 //!
-//! **Foundation phase** (this crate today): `Static`/`Caching`/`Fallback`, plus the
-//! `build_catalog_provider` factory that turns YAML config into a live provider.
-//! Real external integrations (Glue, Iceberg REST, Snowflake, engine-delegated
-//! discovery) land in a follow-up phase — see `plans/` for the full design. Until
-//! then, every config variant beyond `Null`/`Static`/`Caching`/`Fallback` degrades
-//! to a no-op `NullCatalogProvider` with a startup warning, exactly like an
-//! unreachable external catalog would at runtime — never a hard failure.
+//! Implemented today: `Static`/`Caching`/`Fallback` (no external dependency) and
+//! `Glue` (direct AWS Glue Data Catalog access — format-agnostic, unlike going
+//! through Iceberg's own Glue catalog client). `EngineDelegate`/`HiveMetastore`
+//! remain unimplemented — see `plans/` for the full design. Any unimplemented
+//! variant, or a real integration that fails to build (bad credentials,
+//! unreachable endpoint), degrades to a no-op `NullCatalogProvider` with a
+//! startup warning rather than refusing to boot.
 
 pub mod caching;
 pub mod fallback;
+pub mod glue;
 pub mod static_provider;
 
 use std::future::Future;
@@ -23,6 +24,7 @@ use queryflux_core::config::CatalogProviderConfig;
 
 pub use caching::CachingCatalogProvider;
 pub use fallback::FallbackCatalogProvider;
+pub use glue::GlueCatalogProvider;
 pub use static_provider::StaticCatalogProvider;
 
 /// Builds a live `CatalogProvider` tree from config. Recursive (`Caching`/`Fallback`
@@ -56,13 +58,18 @@ pub fn build_catalog_provider(
                 Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
             }
 
-            CatalogProviderConfig::Glue { .. } => {
-                tracing::warn!(
-                    "catalogProvider: type 'glue' is not implemented yet — using a \
-                     no-op catalog provider (schema-aware translation will fall back \
-                     to dialect-only)"
-                );
-                Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+            CatalogProviderConfig::Glue { region, auth } => {
+                match GlueCatalogProvider::new(region.clone(), auth.clone()).await {
+                    Ok(provider) => Arc::new(provider) as Arc<dyn CatalogProvider>,
+                    Err(e) => {
+                        tracing::warn!(
+                            "catalogProvider: failed to build 'glue' provider ({e}) — \
+                             using a no-op catalog provider (schema-aware translation \
+                             will fall back to dialect-only)"
+                        );
+                        Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
+                    }
+                }
             }
 
             CatalogProviderConfig::HiveMetastore { .. } => {

--- a/crates/queryflux-core/src/config.rs
+++ b/crates/queryflux-core/src/config.rs
@@ -1908,6 +1908,12 @@ pub enum CatalogProviderConfig {
     },
     Glue {
         region: Option<String>,
+        /// AWS credentials — reuses the same `ClusterAuth` shape as engine cluster
+        /// config (`accessKey`/`roleArn`; `basic`/`bearer`/`keyPair` don't apply
+        /// here). Omitted: the default AWS credential chain (env vars, ECS task
+        /// role, EC2 instance profile, etc.).
+        #[serde(default)]
+        auth: Option<ClusterAuth>,
     },
     Caching {
         #[serde(rename = "ttlSeconds")]
@@ -3298,7 +3304,7 @@ auth:
 /// These tests exist so both classes of bug can't silently reappear.
 #[cfg(test)]
 mod catalog_provider_config_tests {
-    use super::CatalogProviderConfig;
+    use super::{CatalogProviderConfig, ClusterAuth};
 
     #[test]
     fn null_is_the_default_and_parses_from_yaml() {
@@ -3398,12 +3404,44 @@ secondary:
         assert!(matches!(
             glue,
             CatalogProviderConfig::Glue {
-                region: Some(ref r)
+                region: Some(ref r),
+                auth: None,
             } if r == "us-east-1"
         ));
 
         let hms: CatalogProviderConfig =
             serde_yaml::from_str("type: hiveMetastore\nuri: thrift://localhost:9083\n").unwrap();
         assert!(matches!(hms, CatalogProviderConfig::HiveMetastore { .. }));
+    }
+
+    #[test]
+    fn glue_role_arn_auth_parses() {
+        let yaml = r#"
+type: glue
+region: us-east-1
+auth:
+  type: roleArn
+  roleArn: arn:aws:iam::123456789012:role/queryflux-glue-readonly
+  externalId: queryflux-ext-id
+"#;
+        let glue: CatalogProviderConfig = serde_yaml::from_str(yaml).unwrap();
+        match glue {
+            CatalogProviderConfig::Glue {
+                region: Some(region),
+                auth:
+                    Some(ClusterAuth::RoleArn {
+                        role_arn,
+                        external_id,
+                    }),
+            } => {
+                assert_eq!(region, "us-east-1");
+                assert_eq!(
+                    role_arn,
+                    "arn:aws:iam::123456789012:role/queryflux-glue-readonly"
+                );
+                assert_eq!(external_id.as_deref(), Some("queryflux-ext-id"));
+            }
+            other => panic!("expected Glue with RoleArn auth, got {other:?}"),
+        }
     }
 }

--- a/queryflux-studio/app/catalog/catalog-editor.tsx
+++ b/queryflux-studio/app/catalog/catalog-editor.tsx
@@ -2,7 +2,12 @@
 
 import React, { useState } from "react";
 import { putCatalogProviderConfig, testCatalogProviderConfig } from "@/lib/api";
-import type { CatalogProviderConfig, StaticColumnDefDto, StaticTableSchemaDto } from "@/lib/api-types";
+import type {
+  CatalogProviderConfig,
+  GlueAuthConfig,
+  StaticColumnDefDto,
+  StaticTableSchemaDto,
+} from "@/lib/api-types";
 import { Field, SectionHeader, TextInput, SaveBar } from "@/components/studio-settings";
 import { Database, Plus, Trash2 } from "lucide-react";
 
@@ -17,7 +22,7 @@ const DEFAULTS: Record<ProviderType, CatalogProviderConfig> = {
   static: { type: "static", schemas: [] },
   engineDelegate: { type: "engineDelegate", clusterGroup: "" },
   hiveMetastore: { type: "hiveMetastore", uri: "" },
-  glue: { type: "glue", region: null },
+  glue: { type: "glue", region: null, auth: null },
   caching: {
     type: "caching",
     ttlSeconds: 300,
@@ -44,7 +49,78 @@ const TYPE_LABELS: Record<ProviderType, string> = {
 // Declared in config, but the backend doesn't have a real implementation for
 // these yet — they build successfully and degrade to a no-op provider rather
 // than failing, per queryflux_catalog::build_catalog_provider.
-const UNIMPLEMENTED = new Set<ProviderType>(["engineDelegate", "hiveMetastore", "glue"]);
+const UNIMPLEMENTED = new Set<ProviderType>(["engineDelegate", "hiveMetastore"]);
+
+const GLUE_AUTH_LABELS: Record<"none" | GlueAuthConfig["type"], string> = {
+  none: "Default AWS credential chain",
+  accessKey: "Static access key",
+  roleArn: "Assume IAM role",
+};
+
+function GlueAuthEditor({
+  auth,
+  onChange,
+}: {
+  auth: GlueAuthConfig | null | undefined;
+  onChange: (v: GlueAuthConfig | null) => void;
+}) {
+  const kind = auth?.type ?? "none";
+  return (
+    <div className="space-y-3">
+      <Field label="Credentials">
+        <select
+          className="w-full max-w-xs px-2.5 py-1.5 text-xs rounded-lg border border-slate-200 bg-white text-slate-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          value={kind}
+          onChange={(e) => {
+            const next = e.target.value as "none" | GlueAuthConfig["type"];
+            if (next === "none") onChange(null);
+            else if (next === "accessKey")
+              onChange({ type: "accessKey", accessKeyId: "", secretAccessKey: "" });
+            else onChange({ type: "roleArn", roleArn: "" });
+          }}
+        >
+          {(Object.entries(GLUE_AUTH_LABELS) as [string, string][]).map(([k, label]) => (
+            <option key={k} value={k}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {auth?.type === "accessKey" && (
+        <div className="grid grid-cols-2 gap-4">
+          <TextInput
+            label="Access key ID"
+            value={auth.accessKeyId}
+            onChange={(v) => onChange({ ...auth, accessKeyId: v })}
+          />
+          <TextInput
+            label="Secret access key"
+            type="password"
+            value={auth.secretAccessKey}
+            onChange={(v) => onChange({ ...auth, secretAccessKey: v })}
+          />
+        </div>
+      )}
+
+      {auth?.type === "roleArn" && (
+        <div className="grid grid-cols-2 gap-4">
+          <TextInput
+            label="Role ARN"
+            value={auth.roleArn}
+            onChange={(v) => onChange({ ...auth, roleArn: v })}
+            placeholder="arn:aws:iam::123456789012:role/queryflux-glue-readonly"
+          />
+          <TextInput
+            label="External ID (optional)"
+            value={auth.externalId ?? ""}
+            onChange={(v) => onChange({ ...auth, externalId: v || null })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Static schema editor — one row per table, columns as a "name:TYPE" shorthand
@@ -204,12 +280,16 @@ function CatalogProviderConfigEditor({
       )}
 
       {value.type === "glue" && (
-        <div className="mt-3">
+        <div className="mt-3 space-y-4">
           <TextInput
             label="AWS region (optional)"
             value={value.region ?? ""}
             onChange={(region) => onChange({ ...value, region: region || null })}
             placeholder="us-east-1"
+          />
+          <GlueAuthEditor
+            auth={value.auth}
+            onChange={(auth) => onChange({ ...value, auth })}
           />
         </div>
       )}

--- a/queryflux-studio/lib/api-types.ts
+++ b/queryflux-studio/lib/api-types.ts
@@ -547,6 +547,15 @@ export interface StaticTableSchemaDto {
   columns: StaticColumnDefDto[];
 }
 
+/**
+ * AWS credentials for the `glue` provider — same shape as engine cluster
+ * config's `ClusterAuth` (only `accessKey`/`roleArn` apply to AWS; omitted
+ * means the default AWS credential chain).
+ */
+export type GlueAuthConfig =
+  | { type: "accessKey"; accessKeyId: string; secretAccessKey: string; sessionToken?: string | null }
+  | { type: "roleArn"; roleArn: string; externalId?: string | null };
+
 export type CatalogProviderConfig =
   | { type: "null" }
   | { type: "static"; schemas: StaticTableSchemaDto[] }
@@ -554,8 +563,7 @@ export type CatalogProviderConfig =
   | { type: "engineDelegate"; clusterGroup: string }
   /** Not yet implemented server-side — builds but degrades to a no-op. */
   | { type: "hiveMetastore"; uri: string }
-  /** Not yet implemented server-side — builds but degrades to a no-op. */
-  | { type: "glue"; region?: string | null }
+  | { type: "glue"; region?: string | null; auth?: GlueAuthConfig | null }
   | {
       type: "caching";
       ttlSeconds: number;

--- a/website/docs/architecture/catalog-integration.md
+++ b/website/docs/architecture/catalog-integration.md
@@ -54,6 +54,27 @@ catalogProvider:
         - { name: total, dataType: "DECIMAL(10,2)", nullable: true }
 ```
 
+### `glue`
+
+Talks directly to the [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/components-overview.html#data-catalog-intro) API — format-agnostic, so it sees Hive/Parquet, CSV/JSON, and Iceberg tables alike (unlike going through Iceberg's own Glue catalog client, which would only see Iceberg-format tables). Glue has no catalog concept of its own — every database/table lives under the caller's AWS account, so `list_catalogs()` always reports the single synthetic name `AwsDataCatalog`, matching the convention the Athena backend adapter already uses.
+
+| Field | Description |
+|-------|-------------|
+| `region` | AWS region (optional — falls back to the default region resolution) |
+| `auth` | Optional, same shape as engine cluster `auth` (`accessKey` or `roleArn`; `basic`/`bearer`/`keyPair` don't apply to AWS). Omitted: the default AWS credential chain (env vars, ECS task role, EC2 instance profile, ...). |
+
+```yaml
+catalogProvider:
+  type: glue
+  region: us-east-1
+  auth:
+    type: roleArn
+    roleArn: arn:aws:iam::123456789012:role/queryflux-glue-readonly
+    externalId: ${GLUE_EXTERNAL_ID}
+```
+
+Column types come straight from Glue's own type strings (e.g. `bigint`, `struct<a:int>`) rather than a normalized SQL type — `sqlglot`'s optimizer accepts most of them as-is. Partition keys are included alongside regular columns, since they're valid in `WHERE`/`SELECT` on a Hive-style partitioned table. Nullability isn't exposed by Glue's `Column` type, so every column defaults to nullable.
+
 ### `caching`
 
 Wraps another provider with a TTL + capacity-bounded cache. Only successful lookups are cached — an error is never pinned for `ttlSeconds`, so a transient catalog outage self-heals on the next call.
@@ -102,7 +123,6 @@ These variants parse and build successfully, but currently degrade to a no-op pr
 | Type | Fields | Notes |
 |------|--------|-------|
 | `engineDelegate` | `clusterGroup` | Delegates to a cluster group's own adapter (Trino, DuckDB, StarRocks, Athena, ClickHouse) |
-| `glue` | `region` | AWS Glue Data Catalog |
 | `hiveMetastore` | `uri` | Hive Metastore (Thrift) |
 
 Use [`/admin/config/catalog/test`](#admin-api) to check whether a given config actually does anything, rather than silently degrading unnoticed.
@@ -124,7 +144,7 @@ curl -u admin:admin -X POST http://localhost:9000/admin/config/catalog/test \
   -d '{"config": {"type": "static", "schemas": []}}'
 ```
 
-A `PUT` never fails startup or a running proxy: an invalid `type` is rejected with `400`, but a *structurally valid* config for an unimplemented provider (e.g. `glue`) is accepted — it will simply degrade to a no-op at build time. Use the `/test` endpoint first if you want to know that ahead of saving.
+A `PUT` never fails startup or a running proxy: an invalid `type` is rejected with `400`, but a *structurally valid* config for an unimplemented provider (e.g. `hiveMetastore`) is accepted — it will simply degrade to a no-op at build time. A `glue` config that's structurally valid but fails to actually build (unreachable AWS, bad credentials) degrades the same way. Use the `/test` endpoint first if you want to know that ahead of saving.
 
 Studio's **Catalog** page (left nav) is a thin UI over these same three endpoints — a `type:` picker per provider, recursive nesting for `caching`/`fallback`, and the same test-connection button.
 
@@ -132,5 +152,5 @@ Studio's **Catalog** page (left nav) is a thin UI over these same three endpoint
 
 - `CatalogProvider` (`queryflux_core::catalog`) is the one generic trait every integration implements — `list_catalogs`, `list_databases`, `list_tables`, `get_table_schema`, plus a default `get_schemas_for_query` that batches `get_table_schema` calls.
 - The live provider is hot-reloadable: it lives on `LiveConfig` (not a static `AppState` field), carried forward on a reload unless `catalog_config` has a new, successfully-parsed value — a reload must never silently regress to `NullCatalogProvider` and quietly stop discovering schema for already-working translation.
-- Real integrations are deliberately **engine-independent** — catalog discovery must work even when no query engine is configured or healthy. A future `glue`/`hiveMetastore` implementation talks directly to the catalog service; `engineDelegate` (also not yet implemented) is the one intentional exception, an opt-in convenience that delegates to an already-configured cluster group's adapter.
+- Real integrations are deliberately **engine-independent** — catalog discovery must work even when no query engine is configured or healthy. `glue` (and a future `hiveMetastore`) talk directly to the catalog service; `engineDelegate` (not yet implemented) is the one intentional exception, an opt-in convenience that delegates to an already-configured cluster group's adapter.
 - See [`architecture/query-translation`](./query-translation) for how `SchemaContext` flows into `sqlglot`'s optimizer, and [`architecture/system-map`](./system-map) for where this fits in the overall request path.

--- a/website/docs/architecture/system-map.md
+++ b/website/docs/architecture/system-map.md
@@ -436,6 +436,6 @@ curl -s -X POST http://localhost:8080/v1/statement \
 | P1 | QueryFlux Studio — management UI | **Done** |
 | P1 | Athena backend | **Done** |
 | P1 | Authentication / authorization (`queryflux-auth`) | **Done** |
-| P2 | Wire `SchemaContext` from catalog into dispatch — see [Catalog Provider](./catalog-integration) | **Done** (foundation: `static`/`caching`/`fallback`; `glue`/`hiveMetastore`/`engineDelegate` still planned) |
+| P2 | Wire `SchemaContext` from catalog into dispatch — see [Catalog Provider](./catalog-integration) | **Done** (`static`/`caching`/`fallback`/`glue`; `hiveMetastore`/`engineDelegate` still planned) |
 | P3 | ClickHouse backend (HTTP, Arrow) | **Done** |
 | P3 | ClickHouse HTTP frontend | Planned |

--- a/website/docs/roadmap.md
+++ b/website/docs/roadmap.md
@@ -64,7 +64,7 @@ These are the next items actively being worked on or immediately queued.
 
 Translation was **dialect-only** — `sqlglot.transpile(sql, read=src, write=tgt)` — which handles syntax differences but can't resolve semantic gaps that require knowing the target schema (e.g. resolving ambiguous column references against actual table definitions). The foundation for schema-aware translation now exists: a pluggable `CatalogProvider` populates `SchemaContext`, which `sqlglot.optimizer.optimize` uses with a `MappingSchema` — dialect-only remains the automatic fallback whenever no schema is available or optimization fails. See [Catalog Provider](./architecture/catalog-integration) for the full picture.
 
-What's still ahead: real, engine-independent catalog integrations. Today only `static` (a literal, hand-declared schema), `caching`, and `fallback` are implemented — `glue`, `hiveMetastore`, and `engineDelegate` are declared in config but currently degrade to a no-op provider.
+What's still ahead: `hiveMetastore` and `engineDelegate` are declared in config but currently degrade to a no-op provider. `static`, `caching`, `fallback`, and `glue` (direct AWS Glue Data Catalog access) are implemented.
 
 ### ClickHouse HTTP frontend
 


### PR DESCRIPTION
## Summary

Stacked on #204 → #203 → #202. Implements the first real Phase 2 catalog integration — replaces the `glue` stub (builds successfully, always degrades to a no-op) with an actual `GlueCatalogProvider`.

This is what the reported "Not implemented yet in this release" message was correctly telling you about — it was the `/test` endpoint doing its job.

## What's in this PR

- **`GlueCatalogProvider`** (`crates/queryflux-catalog/src/glue.rs`) — talks directly to the Glue API (`aws-sdk-glue`), not through Iceberg's own Glue catalog client, so it sees Iceberg *and* Hive/Parquet/CSV/JSON tables alike. Mirrors the Athena adapter's AWS credential + refreshing-AssumeRole setup (`crates/queryflux-engine-adapters/src/athena/mod.rs`) for consistency. `list_catalogs()` always reports the single synthetic `AwsDataCatalog` name (Glue has no catalog concept of its own — same convention Athena already uses). Partition keys are folded into a table's columns since they're valid in `WHERE`/`SELECT`; nullability defaults to `true` (Glue's `Column` type doesn't expose it).
- **Config**: `CatalogProviderConfig::Glue` gets a new `auth: Option<ClusterAuth>` field — reuses the existing `ClusterAuth` enum (`accessKey`/`roleArn`) rather than inventing a parallel type, matching how engine cluster config already does `auth`. Omitted `auth` uses the default AWS credential chain.
- **Factory**: construction failure (bad credentials, unreachable Glue endpoint) still degrades to `NullCatalogProvider` with a warning — same "never fails startup" contract every other provider here has.
- **Studio**: the Catalog page's Glue form now has a real credentials picker (default chain / access key / assume role), and `glue` is removed from the "not implemented yet" warning set — so it'll no longer show that message once this lands.
- **Docs + `config.example.yaml`**: `glue` moved from "declared but not implemented" to a proper documented section with a worked example.

## Testing

- New tests: Glue column→`ColumnDef` type mapping (`queryflux-catalog`), unsupported-auth-type rejected before any network call, `ClusterAuth::RoleArn` parsing nested inside the `Glue` config variant (`queryflux-core`).
- **Not covered**: `list_databases`/`list_tables`/`get_table_schema` against a real or mocked Glue endpoint — there's no AWS-mocking infrastructure in this repo yet (checked; the Athena adapter's own tests have the same gap, covering only pure logic, not network-calling paths). Worth a follow-up if that infra gets added.
- `cargo test --workspace --exclude queryflux-e2e-tests`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — all clean.
- Studio: `tsc --noEmit`, `eslint`, `next build` — all clean.
- Docs: `docusaurus build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)