### PR TITLE
feat: nudge network-calling catalog providers toward caching

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -105,13 +105,19 @@ catalogProvider:
   # Iceberg, Hive/Parquet, and any other table format Glue tracks). `auth` is
   # optional and follows the same shape as engine cluster `auth`; omit it to
   # use the default AWS credential chain (env vars, ECS task role, EC2
-  # instance profile, etc.).
-  # type: glue
-  # region: us-east-1
-  # auth:
-  #   type: roleArn
-  #   roleArn: arn:aws:iam::123456789012:role/queryflux-glue-readonly
-  #   externalId: ${GLUE_EXTERNAL_ID}
+  # instance profile, etc.). Wrapped in `caching` here since Glue makes a real
+  # network call per uncached lookup and table schemas rarely change — a bare
+  # `type: glue` (no caching ancestor) logs a startup warning recommending this.
+  # type: caching
+  # ttlSeconds: 300
+  # maxEntries: 10000
+  # delegate:
+  #   type: glue
+  #   region: us-east-1
+  #   auth:
+  #     type: roleArn
+  #     roleArn: arn:aws:iam::123456789012:role/queryflux-glue-readonly
+  #     externalId: ${GLUE_EXTERNAL_ID}
   #
   # Wrap any provider with a TTL cache:
   # type: caching

--- a/crates/queryflux-catalog/src/lib.rs
+++ b/crates/queryflux-catalog/src/lib.rs
@@ -38,7 +38,33 @@ pub use static_provider::StaticCatalogProvider;
 pub fn build_catalog_provider(
     cfg: &CatalogProviderConfig,
 ) -> Pin<Box<dyn Future<Output = Arc<dyn CatalogProvider>> + Send + '_>> {
+    build_catalog_provider_inner(cfg, false)
+}
+
+/// Integrations that make a real network call per lookup — worth flagging when
+/// they're configured without a `Caching` ancestor, since every schema-aware
+/// translation attempt on a table QueryFlux hasn't seen recently will otherwise
+/// pay that round-trip. Grows as more real integrations (Iceberg REST, ...) land.
+fn is_network_calling(cfg: &CatalogProviderConfig) -> bool {
+    matches!(cfg, CatalogProviderConfig::Glue { .. })
+}
+
+/// `cached`: true when this call is already inside a `Caching` ancestor —
+/// threaded down (not part of the public signature, which callers shouldn't
+/// need to know about) so a network-calling leaf can warn when it isn't.
+fn build_catalog_provider_inner(
+    cfg: &CatalogProviderConfig,
+    cached: bool,
+) -> Pin<Box<dyn Future<Output = Arc<dyn CatalogProvider>> + Send + '_>> {
     Box::pin(async move {
+        if is_network_calling(cfg) && !cached {
+            tracing::warn!(
+                "catalogProvider: this provider makes a real network call on every \
+                 uncached lookup — consider wrapping it in `type: caching` \
+                 (schema rarely changes, so a TTL of several minutes or more is \
+                 usually safe) to avoid adding that latency to every query"
+            );
+        }
         match cfg {
             CatalogProviderConfig::Null => {
                 Arc::new(NullCatalogProvider) as Arc<dyn CatalogProvider>
@@ -86,7 +112,7 @@ pub fn build_catalog_provider(
                 max_entries,
                 delegate,
             } => {
-                let inner = build_catalog_provider(delegate).await;
+                let inner = build_catalog_provider_inner(delegate, true).await;
                 Arc::new(CachingCatalogProvider::new(
                     inner,
                     *ttl_seconds,
@@ -95,8 +121,11 @@ pub fn build_catalog_provider(
             }
 
             CatalogProviderConfig::Fallback { primary, secondary } => {
-                let primary = build_catalog_provider(primary).await;
-                let secondary = build_catalog_provider(secondary).await;
+                // `cached` propagates unchanged: wrapping the whole Fallback in
+                // Caching covers both sides, but a bare Fallback over two
+                // network-calling providers should warn for each independently.
+                let primary = build_catalog_provider_inner(primary, cached).await;
+                let secondary = build_catalog_provider_inner(secondary, cached).await;
                 Arc::new(FallbackCatalogProvider::new(primary, secondary))
                     as Arc<dyn CatalogProvider>
             }
@@ -121,6 +150,25 @@ mod tests {
         })
         .await;
         assert!(provider.list_catalogs().await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn is_network_calling_flags_glue_only() {
+        assert!(is_network_calling(&CatalogProviderConfig::Glue {
+            region: None,
+            auth: None,
+        }));
+        assert!(!is_network_calling(&CatalogProviderConfig::Null));
+        assert!(!is_network_calling(&CatalogProviderConfig::Static {
+            schemas: vec![]
+        }));
+        // Caching/Fallback/EngineDelegate/HiveMetastore are checked at their own
+        // leaves during recursion, not flagged as "network-calling" themselves.
+        assert!(!is_network_calling(
+            &CatalogProviderConfig::EngineDelegate {
+                cluster_group: "g".to_string()
+            }
+        ));
     }
 
     #[tokio::test]

--- a/queryflux-studio/app/catalog/catalog-editor.tsx
+++ b/queryflux-studio/app/catalog/catalog-editor.tsx
@@ -17,12 +17,23 @@ interface Props {
 
 type ProviderType = CatalogProviderConfig["type"];
 
+const BARE_GLUE: CatalogProviderConfig = { type: "glue", region: null, auth: null };
+
 const DEFAULTS: Record<ProviderType, CatalogProviderConfig> = {
   null: { type: "null" },
   static: { type: "static", schemas: [] },
   engineDelegate: { type: "engineDelegate", clusterGroup: "" },
   hiveMetastore: { type: "hiveMetastore", uri: "" },
-  glue: { type: "glue", region: null, auth: null },
+  // Glue makes a real network call per uncached lookup — default to
+  // caching-wrapped so picking "AWS Glue" from the type picker doesn't quietly
+  // add that latency to every query. Still fully editable/removable: change the
+  // top-level type back to "glue" (or edit the delegate) to go uncached.
+  glue: {
+    type: "caching",
+    ttlSeconds: 300,
+    maxEntries: 10000,
+    delegate: BARE_GLUE,
+  },
   caching: {
     type: "caching",
     ttlSeconds: 300,
@@ -296,6 +307,14 @@ function CatalogProviderConfigEditor({
 
       {value.type === "caching" && (
         <div className="mt-3 space-y-3">
+          {value.delegate.type === "glue" && (
+            <p className="text-xs text-slate-500">
+              Selecting &ldquo;AWS Glue&rdquo; defaults to wrapping it in a cache — Glue
+              makes a real network call per uncached lookup, and table schemas
+              rarely change. Set the wrapped provider below back to a bare
+              &ldquo;AWS Glue&rdquo; type if you want every lookup to hit Glue directly.
+            </p>
+          )}
           <div className="grid grid-cols-2 gap-4 max-w-sm">
             <TextInput
               label="TTL (seconds)"

--- a/website/docs/architecture/catalog-integration.md
+++ b/website/docs/architecture/catalog-integration.md
@@ -75,9 +75,11 @@ catalogProvider:
 
 Column types come straight from Glue's own type strings (e.g. `bigint`, `struct<a:int>`) rather than a normalized SQL type — `sqlglot`'s optimizer accepts most of them as-is. Partition keys are included alongside regular columns, since they're valid in `WHERE`/`SELECT` on a Hive-style partitioned table. Nullability isn't exposed by Glue's `Column` type, so every column defaults to nullable.
 
+> **Performance:** `glue` makes a real network call per uncached lookup — wrap it in [`caching`](#caching) (below) unless you have a reason not to. A `catalogProvider` config for a network-calling integration with no `caching` ancestor logs a startup warning saying exactly this; Studio's Catalog page defaults the "AWS Glue" picker to a caching-wrapped config for the same reason.
+
 ### `caching`
 
-Wraps another provider with a TTL + capacity-bounded cache. Only successful lookups are cached — an error is never pinned for `ttlSeconds`, so a transient catalog outage self-heals on the next call.
+Wraps another provider with a TTL + capacity-bounded cache. Only successful lookups are cached — an error is never pinned for `ttlSeconds`, so a transient catalog outage self-heals on the next call. Table schemas change far less often than query results, so a longer TTL than you'd use for a [query result cache](./caching) — several minutes to hours — is usually safe.
 
 | Field | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

Stacked on #205 → #204 → #203 → #202. Follow-up from testing `glue` directly and asking whether we should cache table-schema lookups — we already do (`CachingCatalogProvider`, shipped in #202), but it's opt-in, and configuring an external provider uncached had no signal that anything was wrong. Per discussion: keep it opt-in, but nudge — a startup warning plus a Studio default.

## Changes

- `build_catalog_provider` threads a `cached` flag through its recursion (`Caching` sets it, `Fallback` propagates unchanged to both sides) and logs a startup warning for any "network-calling" provider (today: `glue`) built without a `Caching` ancestor.
- Studio: picking **AWS Glue** in the Catalog page now defaults to a caching-wrapped config instead of bare `glue` — still fully editable if you want every lookup to hit Glue directly, with a short explanatory note when a Glue delegate is showing.
- `config.example.yaml` and `catalog-integration.md`'s `glue` example updated to show the caching-wrapped shape, with guidance that schema rarely changes so a multi-minute-to-hour TTL is normally safe (contrasted against the [query result cache](https://queryflux.dev/docs/architecture/caching) doc, which has different TTL expectations).

## Testing

- New test: `is_network_calling` flags only `Glue` (not the wrapper/unimplemented variants).
- `cargo test --workspace --exclude queryflux-e2e-tests`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — all clean.
- Studio: `tsc --noEmit`, `eslint`, `next build` — all clean.
- Verified the new caching-wrapped Glue YAML example parses via the real `serde_yaml::from_str::<CatalogProviderConfig>` path.
- Docs: `docusaurus build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)